### PR TITLE
feat: add lead detail modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -767,6 +767,7 @@ function ScheduleTab({ db }: { db: DB }) {
 // Вкладка: Лиды (простая воронка без drag&drop на каркасе)
 function LeadsTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
   const stages: LeadStage[] = ["Очередь", "Задержка", "Пробное", "Ожидание оплаты", "Оплаченный абонемент", "Отмена"];
+  const [open, setOpen] = useState<Lead | null>(null);
   const move = (id: string, dir: 1 | -1) => {
     const l = db.leads.find(x => x.id === id); if (!l) return;
     const idx = stages.indexOf(l.stage);
@@ -784,7 +785,7 @@ function LeadsTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
             <div className="space-y-2">
               {db.leads.filter(l => l.stage === s).map(l => (
                 <div key={l.id} className="p-2 rounded-xl border border-slate-200 bg-slate-50">
-                  <div className="text-sm font-medium">{l.name}</div>
+                  <button onClick={() => setOpen(l)} className="text-sm font-medium text-left hover:underline w-full">{l.name}</button>
                   <div className="text-xs text-slate-500">{l.source}{l.contact ? " · " + l.contact : ""}</div>
                   <div className="flex gap-1 mt-2">
                     <button onClick={() => move(l.id, -1)} className="px-2 py-1 text-xs rounded-md border border-slate-300">◀</button>
@@ -795,6 +796,29 @@ function LeadsTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
             </div>
           </div>
         ))}
+      </div>
+      {open && <LeadModal lead={open} onClose={() => setOpen(null)} staff={db.staff} />}
+    </div>
+  );
+}
+
+function LeadModal({ lead, onClose, staff }: { lead: Lead; onClose: () => void; staff: StaffMember[] }) {
+  return (
+    <div className="fixed inset-0 z-40 bg-black/30 flex items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-4 space-y-3">
+        <div className="font-semibold text-lg">{lead.name}</div>
+        <div className="text-sm space-y-1">
+          <div><span className="text-slate-500">Источник:</span> {lead.source}</div>
+          {lead.contact && <div><span className="text-slate-500">Контакт:</span> {lead.contact}</div>}
+          {lead.notes && <div><span className="text-slate-500">Заметки:</span> {lead.notes}</div>}
+          <div><span className="text-slate-500">Ответственный:</span> {staff.find(s => s.id===lead.managerId)?.name || "—"}</div>
+          <div><span className="text-slate-500">Этап:</span> {lead.stage}</div>
+          <div><span className="text-slate-500">Создан:</span> {fmtDate(lead.createdAt)}</div>
+          <div><span className="text-slate-500">Обновлён:</span> {fmtDate(lead.updatedAt)}</div>
+        </div>
+        <div className="flex justify-end">
+          <button onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300">Закрыть</button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- make lead names clickable in the leads funnel
- show full lead information in a modal

## Testing
- `CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c595c5e870832bb3ff01574fdf34ad