### PR TITLE
Remove coach info from schedule view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -752,7 +752,7 @@ function ScheduleTab({ db }: { db: DB }) {
             <ul className="space-y-1 text-sm">
               {list.sort((a,b)=> a.weekday - b.weekday || a.time.localeCompare(b.time)).map(s => (
                 <li key={s.id} className="flex items-center justify-between gap-2">
-                  <span className="truncate">{["Пн","Вт","Ср","Чт","Пт","Сб","Вс"][s.weekday-1]} {s.time} · {s.group} · тренер {db.staff.find(st => st.id===s.coachId)?.name || "—"}</span>
+                  <span className="truncate">{["Пн","Вт","Ср","Чт","Пт","Сб","Вс"][s.weekday-1]} {s.time} · {s.group}</span>
                   <span className="text-slate-500">{s.location}</span>
                 </li>
               ))}


### PR DESCRIPTION
## Summary
- Hide coach name in schedule listing

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c59647b054832b9c85eef71bd4786b