### PR TITLE
Group seat limits by area

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -832,42 +832,105 @@ function TasksTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
 
 // Вкладка: Настройки (минимум: курсы валют, лимиты)
 function SettingsTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
-  const [rates, setRates] = useState(db.settings.currencyRates);
-  const saveRates = () => {
-    const next = { ...db, settings: { ...db.settings, currencyRates: { ...rates } } };
-    setDB(next); saveDB(next);
-  };
+  const [rates, setRates] = useState({
+    eurTry: db.settings.currencyRates.TRY,
+    eurRub: db.settings.currencyRates.RUB,
+    tryRub: db.settings.currencyRates.RUB / db.settings.currencyRates.TRY,
+  });
+
+  useEffect(() => {
+    async function fetchRates() {
+      try {
+        const fetchRate = async (pair: string) => {
+          const res = await fetch(`https://cors.isomorphic-git.org/https://www.google.com/finance/quote/${pair}?hl=en`);
+          const html = await res.text();
+          const m = html.match(/class="YMlKec fxKbKc">([0-9.,]+)/);
+          return m ? Number(m[1].replace(',', '')) : undefined;
+        };
+        const [eurTry, eurRub, tryRub] = await Promise.all([
+          fetchRate('EUR-TRY'),
+          fetchRate('EUR-RUB'),
+          fetchRate('TRY-RUB'),
+        ]);
+        const nextRates = {
+          eurTry: eurTry ?? rates.eurTry,
+          eurRub: eurRub ?? rates.eurRub,
+          tryRub: tryRub ?? rates.tryRub,
+        };
+        setRates(nextRates);
+        const nextDB = {
+          ...db,
+          settings: {
+            ...db.settings,
+            currencyRates: { EUR: 1, TRY: nextRates.eurTry, RUB: nextRates.eurRub },
+          },
+        };
+        setDB(nextDB);
+        saveDB(nextDB);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    fetchRates();
+  }, []);
+
   return (
     <div className="space-y-3">
       <Breadcrumbs items={["Настройки"]} />
       <div className="p-4 rounded-2xl border border-slate-200 bg-white space-y-3">
         <div className="font-semibold">Курсы валют</div>
         <div className="grid sm:grid-cols-3 gap-2">
-          <label className="text-sm">EUR к EUR
-            <input type="number" step="0.01" className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300" value={rates.EUR} onChange={e => setRates({ ...rates, EUR: Number(e.target.value) })} />
+          <label className="text-sm">EUR → TRY
+            <input
+              type="number"
+              readOnly
+              className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300 bg-slate-100"
+              value={rates.eurTry ? rates.eurTry.toFixed(2) : ""}
+            />
           </label>
-          <label className="text-sm">TRY к EUR
-            <input type="number" step="0.01" className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300" value={rates.TRY} onChange={e => setRates({ ...rates, TRY: Number(e.target.value) })} />
+          <label className="text-sm">EUR → RUB
+            <input
+              type="number"
+              readOnly
+              className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300 bg-slate-100"
+              value={rates.eurRub ? rates.eurRub.toFixed(2) : ""}
+            />
           </label>
-          <label className="text-sm">RUB к EUR
-            <input type="number" step="0.01" className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300" value={rates.RUB} onChange={e => setRates({ ...rates, RUB: Number(e.target.value) })} />
+          <label className="text-sm">TRY → RUB
+            <input
+              type="number"
+              readOnly
+              className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300 bg-slate-100"
+              value={rates.tryRub ? rates.tryRub.toFixed(2) : ""}
+            />
           </label>
-        </div>
-        <div className="flex justify-end">
-          <button onClick={saveRates} className="px-3 py-2 rounded-md bg-sky-600 text-white">Сохранить</button>
         </div>
       </div>
 
       <div className="p-4 rounded-2xl border border-slate-200 bg-white space-y-3">
         <div className="font-semibold">Лимиты мест</div>
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-2">
-          {Object.keys(db.settings.limits).map(k => (
-            <div key={k} className="text-sm flex items-center justify-between gap-2 border border-slate-200 rounded-xl p-2">
-              <div className="truncate">{k}</div>
-              <input type="number" min={0} className="w-24 px-2 py-1 rounded-md border border-slate-300" value={db.settings.limits[k]} onChange={e => {
-                const next = { ...db, settings: { ...db.settings, limits: { ...db.settings.limits, [k]: Number(e.target.value) } } };
-                setDB(next); saveDB(next);
-              }} />
+        <div className="grid md:grid-cols-3 gap-4">
+          {["Центр", "Джикджилли", "Махмутлар"].map(area => (
+            <div key={area} className="space-y-2">
+              <div className="font-medium">{area}</div>
+              {db.settings.groups.map(group => {
+                const key = `${area}|${group}`;
+                return (
+                  <div key={key} className="text-sm flex items-center justify-between gap-2 border border-slate-200 rounded-xl p-2">
+                    <div className="truncate">{group}</div>
+                    <input
+                      type="number"
+                      min={0}
+                      className="w-24 px-2 py-1 rounded-md border border-slate-300"
+                      value={db.settings.limits[key]}
+                      onChange={e => {
+                        const next = { ...db, settings: { ...db.settings, limits: { ...db.settings.limits, [key]: Number(e.target.value) } } };
+                        setDB(next); saveDB(next);
+                      }}
+                    />
+                  </div>
+                );
+              })}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- group seat limit inputs by area
- fetch EUR→TRY, EUR→RUB and TRY→RUB rates from Google Finance and display them automatically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c596279b9c832bb0da4e9f59151d44