### PR TITLE
Remove coach and location info from schedule view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,14 @@ type Role = "Администратор" | "Менеджер" | "Тренер";
 
 type Area = "Махмутлар" | "Центр" | "Джикджилли";
 
-type Group = "4–6" | "6–9" | "9–14" | "взрослые" | "индивидуальные" | "доп. группа";
+type Group =
+  | "4–6"
+  | "6–9"
+  | "7–14"
+  | "9–14"
+  | "взрослые"
+  | "индивидуальные"
+  | "доп. группа";
 
 type Gender = "м" | "ж";
 
@@ -148,13 +155,13 @@ const parseDateInput = (value: string) => {
 // Seed-данные
 function makeSeedDB(): DB {
   const areas: Area[] = ["Махмутлар", "Центр", "Джикджилли"];
-  const groups: Group[] = ["4–6", "6–9", "9–14", "взрослые", "индивидуальные", "доп. группа"];
+  const groups: Group[] = ["4–6", "6–9", "7–14", "9–14", "взрослые", "индивидуальные", "доп. группа"];
   const staff: StaffMember[] = [
     { id: uid(), role: "Администратор", name: "Админ", areas, groups },
     { id: uid(), role: "Менеджер", name: "Марина", areas, groups },
     { id: uid(), role: "Менеджер", name: "Илья", areas, groups },
     { id: uid(), role: "Тренер", name: "Алексей", areas: ["Центр", "Джикджилли"], groups: ["4–6", "6–9", "9–14", "взрослые"] },
-    { id: uid(), role: "Тренер", name: "Сергей", areas: ["Махмутлар"], groups: ["4–6", "6–9", "9–14"] },
+    { id: uid(), role: "Тренер", name: "Сергей", areas: ["Махмутлар"], groups: ["4–6", "6–9", "7–14", "9–14"] },
   ];
   const coachIds = staff.filter(s => s.role === "Тренер").map(s => s.id);
 
@@ -195,21 +202,38 @@ function makeSeedDB(): DB {
     };
   });
 
-  const schedule: ScheduleSlot[] = [];
-  for (const area of areas) {
-    const slots = rnd(3, 5);
-    for (let i = 0; i < slots; i++) {
-      schedule.push({
-        id: uid(),
-        area,
-        group: groups[rnd(0, groups.length - 1)],
-        coachId: coachIds[rnd(0, coachIds.length - 1)],
-        weekday: rnd(1, 7),
-        time: `${String(rnd(16, 21)).padStart(2, "0")}:${Math.random() < 0.5 ? "00" : "30"}`,
-        location: `${area} Dojo #${rnd(1, 3)}`,
-      });
-    }
-  }
+  const coachAlexey = staff.find(s => s.name === "Алексей")?.id || "";
+  const coachSergey = staff.find(s => s.name === "Сергей")?.id || "";
+
+  const schedule: ScheduleSlot[] = [
+    // Центр — вторник и четверг
+    { id: uid(), area: "Центр", group: "6–9", coachId: coachAlexey, weekday: 2, time: "17:30", location: "" },
+    { id: uid(), area: "Центр", group: "4–6", coachId: coachAlexey, weekday: 2, time: "18:30", location: "" },
+    { id: uid(), area: "Центр", group: "9–14", coachId: coachAlexey, weekday: 2, time: "19:30", location: "" },
+    { id: uid(), area: "Центр", group: "6–9", coachId: coachAlexey, weekday: 4, time: "17:30", location: "" },
+    { id: uid(), area: "Центр", group: "4–6", coachId: coachAlexey, weekday: 4, time: "18:30", location: "" },
+    { id: uid(), area: "Центр", group: "9–14", coachId: coachAlexey, weekday: 4, time: "19:30", location: "" },
+
+    // Джикджилли — понедельник и пятница
+    { id: uid(), area: "Джикджилли", group: "взрослые", coachId: coachAlexey, weekday: 1, time: "09:30", location: "" },
+    { id: uid(), area: "Джикджилли", group: "доп. группа", coachId: coachAlexey, weekday: 1, time: "16:00", location: "" },
+    { id: uid(), area: "Джикджилли", group: "6–9", coachId: coachAlexey, weekday: 1, time: "17:00", location: "" },
+    { id: uid(), area: "Джикджилли", group: "4–6", coachId: coachAlexey, weekday: 1, time: "18:00", location: "" },
+    { id: uid(), area: "Джикджилли", group: "9–14", coachId: coachAlexey, weekday: 1, time: "19:00", location: "" },
+    { id: uid(), area: "Джикджилли", group: "доп. группа", coachId: coachAlexey, weekday: 1, time: "20:00", location: "" },
+    { id: uid(), area: "Джикджилли", group: "взрослые", coachId: coachAlexey, weekday: 5, time: "09:30", location: "" },
+    { id: uid(), area: "Джикджилли", group: "доп. группа", coachId: coachAlexey, weekday: 5, time: "16:00", location: "" },
+    { id: uid(), area: "Джикджилли", group: "6–9", coachId: coachAlexey, weekday: 5, time: "17:00", location: "" },
+    { id: uid(), area: "Джикджилли", group: "4–6", coachId: coachAlexey, weekday: 5, time: "18:00", location: "" },
+    { id: uid(), area: "Джикджилли", group: "9–14", coachId: coachAlexey, weekday: 5, time: "19:00", location: "" },
+    { id: uid(), area: "Джикджилли", group: "доп. группа", coachId: coachAlexey, weekday: 5, time: "20:00", location: "" },
+
+    // Махмутлар — среда и суббота
+    { id: uid(), area: "Махмутлар", group: "7–14", coachId: coachSergey, weekday: 3, time: "17:00", location: "" },
+    { id: uid(), area: "Махмутлар", group: "4–6", coachId: coachSergey, weekday: 3, time: "18:00", location: "" },
+    { id: uid(), area: "Махмутлар", group: "4–6", coachId: coachSergey, weekday: 6, time: "11:00", location: "" },
+    { id: uid(), area: "Махмутлар", group: "7–14", coachId: coachSergey, weekday: 6, time: "12:00", location: "" },
+  ];
 
   const leadsSources: ContactChannel[] = ["Instagram", "WhatsApp", "Telegram"];
   const leadStages: LeadStage[] = ["Очередь", "Задержка", "Пробное", "Ожидание оплаты", "Оплаченный абонемент", "Отмена"];
@@ -750,12 +774,13 @@ function ScheduleTab({ db }: { db: DB }) {
           <div key={area} className="p-4 rounded-2xl border border-slate-200 bg-white space-y-2">
             <div className="font-semibold">{area}</div>
             <ul className="space-y-1 text-sm">
-              {list.sort((a,b)=> a.weekday - b.weekday || a.time.localeCompare(b.time)).map(s => (
-                <li key={s.id} className="flex items-center justify-between gap-2">
-                  <span className="truncate">{["Пн","Вт","Ср","Чт","Пт","Сб","Вс"][s.weekday-1]} {s.time} · {s.group} · тренер {db.staff.find(st => st.id===s.coachId)?.name || "—"}</span>
-                  <span className="text-slate-500">{s.location}</span>
-                </li>
-              ))}
+              {list
+                .sort((a, b) => a.weekday - b.weekday || a.time.localeCompare(b.time))
+                .map(s => (
+                  <li key={s.id} className="truncate">
+                    {["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"][s.weekday - 1]} {s.time} · {s.group}
+                  </li>
+                ))}
             </ul>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- Hide coach and location data in schedule listing so only day, time, and group remain
- Seed schedule with provided timetable for Центр, Джикджилли, и Махмутлар
- Add 7–14 age group and include it for Махмутлар coach

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c59647b054832b9c85eef71bd4786b