### PR TITLE
Introduce global DB and UI context providers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState, useContext } from "react";
 import Topbar from "./components/Topbar";
 import Tabs from "./components/Tabs";
 import Dashboard from "./components/Dashboard";
@@ -11,6 +11,8 @@ import TasksTab from "./components/TasksTab";
 import SettingsTab from "./components/SettingsTab";
 import QuickAddModal from "./components/QuickAddModal";
 import Toasts, { useToasts } from "./components/Toasts";
+import { DBContext } from "./context/DBContext";
+import { UIContext } from "./context/UIContext";
 
 // === ЛЁГКИЙ КАРКАС CRM (SPA в одном файле) ===
 // Эта версия: вкладки, роли, seed-данные в LocalStorage, минимальные таблицы, поиск/фильтры,
@@ -397,8 +399,8 @@ export function can(role: Role, feature: "all" | "manage_clients" | "attendance"
 
 export default function App() {
 
-  const [db, setDB] = useState<DB>(() => loadDB());
-  const [ui, setUI] = useState<UIState>(() => loadUI());
+  const { db, setDB } = useContext(DBContext);
+  const { ui, setUI } = useContext(UIContext);
   const roles: Role[] = ["Администратор", "Менеджер", "Тренер"];
   const { toasts, push } = useToasts();
   const [quickOpen, setQuickOpen] = useState(false);
@@ -475,17 +477,17 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-white to-sky-50 text-slate-900">
-      <Topbar ui={ui} setUI={setUI} roleList={roles} onQuickAdd={onQuickAdd} />
-      <Tabs ui={ui} setUI={setUI} role={ui.role} />
+      <Topbar roleList={roles} onQuickAdd={onQuickAdd} />
+      <Tabs />
 
       <main className="max-w-7xl mx-auto p-3 space-y-3">
-        {activeTab === "dashboard" && <Dashboard db={db} ui={ui} />}
-        {activeTab === "clients" && can(ui.role, "manage_clients") && <ClientsTab db={db} setDB={setDB} ui={ui} />}
-        {activeTab === "attendance" && can(ui.role, "attendance") && <AttendanceTab db={db} setDB={setDB} />}
-        {activeTab === "schedule" && can(ui.role, "schedule") && <ScheduleTab db={db} setDB={setDB} />}
-        {activeTab === "leads" && can(ui.role, "leads") && <LeadsTab db={db} setDB={setDB} />}
-        {activeTab === "tasks" && can(ui.role, "tasks") && <TasksTab db={db} setDB={setDB} />}
-        {activeTab === "settings" && can(ui.role, "settings") && <SettingsTab db={db} setDB={setDB} />}
+        {activeTab === "dashboard" && <Dashboard />}
+        {activeTab === "clients" && can(ui.role, "manage_clients") && <ClientsTab />}
+        {activeTab === "attendance" && can(ui.role, "attendance") && <AttendanceTab />}
+        {activeTab === "schedule" && can(ui.role, "schedule") && <ScheduleTab />}
+        {activeTab === "leads" && can(ui.role, "leads") && <LeadsTab />}
+        {activeTab === "tasks" && can(ui.role, "tasks") && <TasksTab />}
+        {activeTab === "settings" && can(ui.role, "settings") && <SettingsTab />}
       </main>
 
       <QuickAddModal open={quickOpen} onClose={() => setQuickOpen(false)} onAddClient={addQuickClient} onAddLead={addQuickLead} onAddTask={addQuickTask} />

--- a/src/components/AttendanceTab.jsx
+++ b/src/components/AttendanceTab.jsx
@@ -1,11 +1,13 @@
 // @flow
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useContext } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import TableWrap from "./TableWrap";
 import { fmtDate, uid, saveDB } from "../App";
-import type { DB, Area, Group, AttendanceEntry } from "../App";
+import type { Area, Group, AttendanceEntry } from "../App";
+import { DBContext } from "../context/DBContext";
 
-export default function AttendanceTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
+export default function AttendanceTab() {
+  const { db, setDB } = useContext(DBContext);
   const [area, setArea] = useState<Area | "all">("all");
   const [group, setGroup] = useState<Group | "all">("all");
   const today = new Date();

--- a/src/components/ClientsTab.jsx
+++ b/src/components/ClientsTab.jsx
@@ -1,9 +1,11 @@
 // @flow
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useContext } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import TableWrap from "./TableWrap";
 import { uid, todayISO, parseDateInput, fmtMoney, calcAgeYears, calcExperience, saveDB } from "../App";
-import type { DB, UIState, Client, Area, Group, PaymentStatus } from "../App";
+import type { Client, Area, Group, PaymentStatus } from "../App";
+import { DBContext } from "../context/DBContext";
+import { UIContext } from "../context/UIContext";
 
 function Chip({ active, onClick, children }: { active?: boolean; onClick?: () => void; children: React.ReactNode }) {
   return (
@@ -11,7 +13,9 @@ function Chip({ active, onClick, children }: { active?: boolean; onClick?: () =>
   );
 }
 
-export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) => void; ui: UIState }) {
+export default function ClientsTab() {
+  const { db, setDB } = useContext(DBContext);
+  const { ui } = useContext(UIContext);
   const [area, setArea] = useState<Area | "all">("all");
   const [group, setGroup] = useState<Group | "all">("all");
   const [pay, setPay] = useState<PaymentStatus | "all">("all");

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,7 +1,9 @@
 // @flow
-import React from "react";
+import React, { useContext } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import { fmtMoney, fmtDate } from "../App";
+import { DBContext } from "../context/DBContext";
+import { UIContext } from "../context/UIContext";
 
 function OfflineTip() {
   return (
@@ -26,7 +28,9 @@ function MetricCard({ title, value, accent }) {
   );
 }
 
-export default function Dashboard({ db, ui }) {
+export default function Dashboard() {
+  const { db } = useContext(DBContext);
+  const { ui } = useContext(UIContext);
   const currency = ui.currency;
   const totalClients = db.clients.length;
   const activeClients = db.clients.filter(c => c.payStatus === "действует").length;

--- a/src/components/LeadsTab.jsx
+++ b/src/components/LeadsTab.jsx
@@ -1,10 +1,12 @@
 // @flow
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import { todayISO, saveDB, uid, fmtDate } from "../App";
-import type { DB, Lead, LeadStage, StaffMember } from "../App";
+import type { Lead, LeadStage, StaffMember } from "../App";
+import { DBContext } from "../context/DBContext";
 
-export default function LeadsTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
+export default function LeadsTab() {
+  const { db, setDB } = useContext(DBContext);
   const stages: LeadStage[] = ["Очередь", "Задержка", "Пробное", "Ожидание оплаты", "Оплаченный абонемент", "Отмена"];
   const [open, setOpen] = useState<Lead | null>(null);
   const move = (id: string, dir: 1 | -1) => {
@@ -41,8 +43,6 @@ export default function LeadsTab({ db, setDB }: { db: DB; setDB: (db: DB) => voi
           lead={open}
           onClose={() => setOpen(null)}
           staff={db.staff}
-          db={db}
-          setDB={setDB}
         />
       )}
     </div>
@@ -54,16 +54,13 @@ function LeadModal(
     lead,
     onClose,
     staff,
-    db,
-    setDB,
   }: {
     lead: Lead;
     onClose: () => void;
     staff: StaffMember[];
-    db: DB;
-    setDB: (db: DB) => void;
   },
 ) {
+  const { db, setDB } = useContext(DBContext);
   const [edit, setEdit] = useState(false);
   const [form, setForm] = useState<Partial<Lead>>(lead);
   useEffect(() => setForm(lead), [lead]);

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -1,10 +1,12 @@
 // @flow
-import React, { useMemo } from "react";
+import React, { useMemo, useContext } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import { uid, saveDB } from "../App";
-import type { DB, ScheduleSlot } from "../App";
+import type { ScheduleSlot } from "../App";
+import { DBContext } from "../context/DBContext";
 
-export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
+export default function ScheduleTab() {
+  const { db, setDB } = useContext(DBContext);
   const byArea = useMemo(() => {
     const m: Record<string, ScheduleSlot[]> = {};
     for (const a of db.settings.areas) m[a] = [];

--- a/src/components/SettingsTab.jsx
+++ b/src/components/SettingsTab.jsx
@@ -1,10 +1,11 @@
 // @flow
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import { saveDB } from "../App";
-import type { DB } from "../App";
+import { DBContext } from "../context/DBContext";
 
-export default function SettingsTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
+export default function SettingsTab() {
+  const { db, setDB } = useContext(DBContext);
   const [rates, setRates] = useState({
     eurTry: db.settings.currencyRates.TRY,
     eurRub: db.settings.currencyRates.RUB,

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -1,6 +1,7 @@
 // @flow
-import React from "react";
+import React, { useContext } from "react";
 import { saveUI, can } from "../App";
+import { UIContext } from "../context/UIContext";
 
 const TABS = [
   { key: "dashboard", title: "Дашборд" },
@@ -12,7 +13,9 @@ const TABS = [
   { key: "settings", title: "Настройки", need: r => can(r, "settings") },
 ];
 
-export default function Tabs({ ui, setUI, role }) {
+export default function Tabs() {
+  const { ui, setUI } = useContext(UIContext);
+  const role = ui.role;
   const visible = TABS.filter(t => !t.need || t.need(role));
   return (
     <div className="w-full overflow-x-auto border-b border-slate-200 bg-gradient-to-r from-sky-50 to-blue-50">

--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -1,10 +1,12 @@
 // @flow
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import { fmtDate, uid, saveDB, todayISO } from "../App";
-import type { DB, TaskItem } from "../App";
+import type { TaskItem } from "../App";
+import { DBContext } from "../context/DBContext";
 
-export default function TasksTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
+export default function TasksTab() {
+  const { db, setDB } = useContext(DBContext);
   const [edit, setEdit] = useState<TaskItem | null>(null);
   const toggle = (id: string) => {
     const next = { ...db, tasks: db.tasks.map(t => t.id === id ? { ...t, status: t.status === "open" ? "done" : "open" } : t) };

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -1,8 +1,10 @@
 // @flow
-import React from "react";
+import React, { useContext } from "react";
 import { saveUI } from "../App";
+import { UIContext } from "../context/UIContext";
 
-export default function Topbar({ ui, setUI, roleList, onQuickAdd }) {
+export default function Topbar({ roleList, onQuickAdd }) {
+  const { ui, setUI } = useContext(UIContext);
   return (
     <div className="w-full flex flex-wrap items-center justify-between gap-2 p-3 bg-white/70 backdrop-blur border-b border-slate-200 sticky top-0 z-30">
       <div className="flex items-center gap-3">

--- a/src/context/DBContext.jsx
+++ b/src/context/DBContext.jsx
@@ -1,0 +1,17 @@
+import React, { createContext, useState } from "react";
+import { loadDB } from "../App";
+import type { DB } from "../App";
+
+export const DBContext = createContext<{ db: DB, setDB: (DB) => void }>({
+  db: (loadDB(): any),
+  setDB: () => {},
+});
+
+export function DBProvider({ children }: { children: React.ReactNode }) {
+  const [db, setDB] = useState<DB>(() => loadDB());
+  return (
+    <DBContext.Provider value={{ db, setDB }}>
+      {children}
+    </DBContext.Provider>
+  );
+}

--- a/src/context/UIContext.jsx
+++ b/src/context/UIContext.jsx
@@ -1,0 +1,17 @@
+import React, { createContext, useState } from "react";
+import { loadUI } from "../App";
+import type { UIState } from "../App";
+
+export const UIContext = createContext<{ ui: UIState, setUI: (UIState) => void }>({
+  ui: (loadUI(): any),
+  setUI: () => {},
+});
+
+export function UIProvider({ children }: { children: React.ReactNode }) {
+  const [ui, setUI] = useState<UIState>(() => loadUI());
+  return (
+    <UIContext.Provider value={{ ui, setUI }}>
+      {children}
+    </UIContext.Provider>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { DBProvider } from './context/DBContext';
+import { UIProvider } from './context/UIContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <DBProvider>
+      <UIProvider>
+        <App />
+      </UIProvider>
+    </DBProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- Add DBContext and UIContext to centralize database and UI state
- Wrap the application with these providers in `index.js`
- Refactor tabs and UI components to consume state via `useContext`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c5d50df1ac832bbd4076f035bfdea6