### PR TITLE
feat: unify modal dialogs with reusable component

### DIFF
--- a/src/components/ClientsTab.jsx
+++ b/src/components/ClientsTab.jsx
@@ -5,6 +5,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import Breadcrumbs from "./Breadcrumbs";
 import TableWrap from "./TableWrap";
+import Modal from "./Modal";
 import { uid, todayISO, parseDateInput, fmtMoney, calcAgeYears, calcExperience, saveDB } from "../App";
 import type { DB, UIState, Client, Area, Group, PaymentStatus } from "../App";
 
@@ -181,44 +182,41 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
       </TableWrap>
 
       {selected && (
-        <div className="fixed inset-0 z-40 bg-black/30 flex items-center justify-center p-4">
-          <div className="w-full max-w-md rounded-2xl bg-white p-4 space-y-3">
-            <div className="font-semibold text-slate-800">
-              {selected.firstName} {selected.lastName}
-            </div>
-            <div className="grid gap-1 text-sm">
-              <div><span className="text-slate-500">Телефон:</span> {selected.phone || "—"}</div>
-              <div><span className="text-slate-500">Канал:</span> {selected.channel}</div>
-              <div><span className="text-slate-500">Родитель:</span> {selected.parentName || "—"}</div>
-              <div><span className="text-slate-500">Дата рождения:</span> {selected.birthDate?.slice(0,10)}</div>
-              <div><span className="text-slate-500">Возраст:</span> {selected.birthDate ? `${calcAgeYears(selected.birthDate)} лет` : "—"}</div>
-              <div><span className="text-slate-500">Район:</span> {selected.area}</div>
-              <div><span className="text-slate-500">Группа:</span> {selected.group}</div>
-              <div><span className="text-slate-500">Опыт:</span> {calcExperience(selected.startDate)}</div>
-              <div><span className="text-slate-500">Статус оплаты:</span> {selected.payStatus}</div>
-              <div><span className="text-slate-500">Дата оплаты:</span> {selected.payDate?.slice(0,10) || "—"}</div>
-              <div><span className="text-slate-500">Сумма оплаты:</span> {selected.payAmount != null ? fmtMoney(selected.payAmount, ui.currency) : "—"}</div>
-            </div>
-            <div className="flex justify-end gap-2">
-              <button onClick={() => startEdit(selected)} className="px-3 py-2 rounded-md border border-slate-300">Редактировать</button>
-              <button onClick={() => { removeClient(selected.id); setSelected(null); }} className="px-3 py-2 rounded-md border border-rose-200 text-rose-600">Удалить</button>
-              <button onClick={() => setSelected(null)} className="px-3 py-2 rounded-md border border-slate-300">Закрыть</button>
-            </div>
+        <Modal size="md" onClose={() => setSelected(null)}>
+          <div className="font-semibold text-slate-800">
+            {selected.firstName} {selected.lastName}
           </div>
-        </div>
+          <div className="grid gap-1 text-sm">
+            <div><span className="text-slate-500">Телефон:</span> {selected.phone || "—"}</div>
+            <div><span className="text-slate-500">Канал:</span> {selected.channel}</div>
+            <div><span className="text-slate-500">Родитель:</span> {selected.parentName || "—"}</div>
+            <div><span className="text-slate-500">Дата рождения:</span> {selected.birthDate?.slice(0,10)}</div>
+            <div><span className="text-slate-500">Возраст:</span> {selected.birthDate ? `${calcAgeYears(selected.birthDate)} лет` : "—"}</div>
+            <div><span className="text-slate-500">Район:</span> {selected.area}</div>
+            <div><span className="text-slate-500">Группа:</span> {selected.group}</div>
+            <div><span className="text-slate-500">Опыт:</span> {calcExperience(selected.startDate)}</div>
+            <div><span className="text-slate-500">Статус оплаты:</span> {selected.payStatus}</div>
+            <div><span className="text-slate-500">Дата оплаты:</span> {selected.payDate?.slice(0,10) || "—"}</div>
+            <div><span className="text-slate-500">Сумма оплаты:</span> {selected.payAmount != null ? fmtMoney(selected.payAmount, ui.currency) : "—"}</div>
+          </div>
+          <div className="flex justify-end gap-2">
+            <button onClick={() => startEdit(selected)} className="px-3 py-2 rounded-md border border-slate-300">Редактировать</button>
+            <button onClick={() => { removeClient(selected.id); setSelected(null); }} className="px-3 py-2 rounded-md border border-rose-200 text-rose-600">Удалить</button>
+            <button onClick={() => setSelected(null)} className="px-3 py-2 rounded-md border border-slate-300">Закрыть</button>
+          </div>
+        </Modal>
       )}
 
       {modalOpen && (
-        <div className="fixed inset-0 z-40 bg-black/30 flex items-center justify-center p-4">
-          <div className="w-full max-w-xl rounded-2xl bg-white p-4 space-y-3">
-            <div className="font-semibold text-slate-800">{editing ? "Редактирование клиента" : "Новый клиент"}</div>
-            <form onSubmit={handleSubmit(saveClient)} className="space-y-3">
-              <div className="grid sm:grid-cols-2 gap-2">
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-slate-500">Имя</label>
-                  <input className="px-3 py-2 rounded-md border border-slate-300" {...register("firstName")} />
-                  {errors.firstName && <span className="text-xs text-rose-600">{errors.firstName.message}</span>}
-                </div>
+        <Modal size="xl" onClose={() => { setModalOpen(false); setEditing(null); }}>
+          <div className="font-semibold text-slate-800">{editing ? "Редактирование клиента" : "Новый клиент"}</div>
+          <form onSubmit={handleSubmit(saveClient)} className="space-y-3">
+            <div className="grid sm:grid-cols-2 gap-2">
+              <div className="flex flex-col gap-1">
+                <label className="text-xs text-slate-500">Имя</label>
+                <input className="px-3 py-2 rounded-md border border-slate-300" {...register("firstName")} />
+                {errors.firstName && <span className="text-xs text-rose-600">{errors.firstName.message}</span>}
+              </div>
                 <div className="flex flex-col gap-1">
                   <label className="text-xs text-slate-500">Фамилия</label>
                   <input className="px-3 py-2 rounded-md border border-slate-300" {...register("lastName")} />
@@ -275,13 +273,12 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
                   </select>
                 </div>
               </div>
-              <div className="flex justify-end gap-2">
-                <button type="button" onClick={() => { setModalOpen(false); setEditing(null); }} className="px-3 py-2 rounded-md border border-slate-300">Отмена</button>
-                <button type="submit" disabled={!isValid} className="px-3 py-2 rounded-md bg-sky-600 text-white disabled:bg-slate-400">Сохранить</button>
-              </div>
-            </form>
-          </div>
-        </div>
+            <div className="flex justify-end gap-2">
+              <button type="button" onClick={() => { setModalOpen(false); setEditing(null); }} className="px-3 py-2 rounded-md border border-slate-300">Отмена</button>
+              <button type="submit" disabled={!isValid} className="px-3 py-2 rounded-md bg-sky-600 text-white disabled:bg-slate-400">Сохранить</button>
+            </div>
+          </form>
+        </Modal>
       )}
     </div>
   );

--- a/src/components/LeadsTab.jsx
+++ b/src/components/LeadsTab.jsx
@@ -4,6 +4,7 @@ import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import Breadcrumbs from "./Breadcrumbs";
+import Modal from "./Modal";
 import { todayISO, saveDB, uid, fmtDate } from "../App";
 import type { DB, Lead, LeadStage, StaffMember } from "../App";
 
@@ -104,39 +105,37 @@ function LeadModal(
   };
 
   return (
-    <div className="fixed inset-0 z-40 bg-black/30 flex items-center justify-center p-4">
-      <div className="w-full max-w-lg rounded-2xl bg-white p-4 space-y-3">
-        <div className="font-semibold text-slate-800">{lead.name}</div>
-        <div className="grid gap-1 text-sm">
-          <div><span className="text-slate-500">Родитель:</span> {lead.parentName || "—"}</div>
-          <div><span className="text-slate-500">Имя ребёнка:</span> {lead.firstName}</div>
-          <div><span className="text-slate-500">Фамилия:</span> {lead.lastName}</div>
-          <div><span className="text-slate-500">Дата рождения:</span> {fmtDate(lead.birthDate)}</div>
-          <div><span className="text-slate-500">Старт:</span> {fmtDate(lead.startDate)}</div>
-          <div><span className="text-slate-500">Источник:</span> {lead.source}</div>
-          <div><span className="text-slate-500">Контакт:</span> {lead.contact || "—"}</div>
-          <div><span className="text-slate-500">Создан:</span> {fmtDate(lead.createdAt)}</div>
-          <div><span className="text-slate-500">Обновлён:</span> {fmtDate(lead.updatedAt)}</div>
-        </div>
-        <div className="flex justify-end gap-2">
-          {!edit && <button onClick={() => setEdit(true)} className="px-3 py-2 rounded-md border border-slate-300">Редактировать</button>}
-          <button onClick={remove} className="px-3 py-2 rounded-md border border-rose-200 text-rose-600">Удалить</button>
-          <button onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300">Закрыть</button>
-        </div>
-        {edit && (
-          <form onSubmit={handleSubmit(save)} className="space-y-2 pt-2 border-t border-slate-200">
-            <input className="w-full px-3 py-2 rounded-md border border-slate-300" {...register("name")} placeholder="Имя" />
-            {errors.name && <span className="text-xs text-rose-600">{errors.name.message}</span>}
-            <input className="w-full px-3 py-2 rounded-md border border-slate-300" {...register("parentName")} placeholder="Родитель" />
-            <input className="w-full px-3 py-2 rounded-md border border-slate-300" {...register("contact")} placeholder="Контакт" />
-            {errors.contact && <span className="text-xs text-rose-600">{errors.contact.message}</span>}
-            <div className="flex justify-end gap-2">
-              <button type="submit" disabled={!isValid} className="px-3 py-2 rounded-md bg-sky-600 text-white disabled:bg-slate-400">Сохранить</button>
-              <button type="button" onClick={() => setEdit(false)} className="px-3 py-2 rounded-md border border-slate-300">Отмена</button>
-            </div>
-          </form>
-        )}
+    <Modal size="lg" onClose={onClose}>
+      <div className="font-semibold text-slate-800">{lead.name}</div>
+      <div className="grid gap-1 text-sm">
+        <div><span className="text-slate-500">Родитель:</span> {lead.parentName || "—"}</div>
+        <div><span className="text-slate-500">Имя ребёнка:</span> {lead.firstName}</div>
+        <div><span className="text-slate-500">Фамилия:</span> {lead.lastName}</div>
+        <div><span className="text-slate-500">Дата рождения:</span> {fmtDate(lead.birthDate)}</div>
+        <div><span className="text-slate-500">Старт:</span> {fmtDate(lead.startDate)}</div>
+        <div><span className="text-slate-500">Источник:</span> {lead.source}</div>
+        <div><span className="text-slate-500">Контакт:</span> {lead.contact || "—"}</div>
+        <div><span className="text-slate-500">Создан:</span> {fmtDate(lead.createdAt)}</div>
+        <div><span className="text-slate-500">Обновлён:</span> {fmtDate(lead.updatedAt)}</div>
       </div>
-    </div>
+      <div className="flex justify-end gap-2">
+        {!edit && <button onClick={() => setEdit(true)} className="px-3 py-2 rounded-md border border-slate-300">Редактировать</button>}
+        <button onClick={remove} className="px-3 py-2 rounded-md border border-rose-200 text-rose-600">Удалить</button>
+        <button onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300">Закрыть</button>
+      </div>
+      {edit && (
+        <form onSubmit={handleSubmit(save)} className="space-y-2 pt-2 border-t border-slate-200">
+          <input className="w-full px-3 py-2 rounded-md border border-slate-300" {...register("name")} placeholder="Имя" />
+          {errors.name && <span className="text-xs text-rose-600">{errors.name.message}</span>}
+          <input className="w-full px-3 py-2 rounded-md border border-slate-300" {...register("parentName")} placeholder="Родитель" />
+          <input className="w-full px-3 py-2 rounded-md border border-slate-300" {...register("contact")} placeholder="Контакт" />
+          {errors.contact && <span className="text-xs text-rose-600">{errors.contact.message}</span>}
+          <div className="flex justify-end gap-2">
+            <button type="submit" disabled={!isValid} className="px-3 py-2 rounded-md bg-sky-600 text-white disabled:bg-slate-400">Сохранить</button>
+            <button type="button" onClick={() => setEdit(false)} className="px-3 py-2 rounded-md border border-slate-300">Отмена</button>
+          </div>
+        </form>
+      )}
+    </Modal>
   );
 }

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,0 +1,28 @@
+// @flow
+import React from "react";
+
+type Props = {
+  children: React.ReactNode,
+  onClose?: () => void,
+  size?: "sm" | "md" | "lg" | "xl",
+  className?: string,
+};
+
+export default function Modal({ children, onClose, size = "md", className = "" }: Props) {
+  const sizeClass = {
+    sm: "max-w-sm",
+    md: "max-w-md",
+    lg: "max-w-lg",
+    xl: "max-w-xl",
+  }[size];
+  return (
+    <div className="fixed inset-0 z-40 bg-black/30 flex items-center justify-center p-4" onClick={onClose}>
+      <div
+        onClick={e => e.stopPropagation()}
+        className={`w-full ${sizeClass} rounded-2xl bg-white p-4 space-y-3 ${className}`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/QuickAddModal.jsx
+++ b/src/components/QuickAddModal.jsx
@@ -1,21 +1,20 @@
 // @flow
 import React from "react";
+import Modal from "./Modal";
 
 export default function QuickAddModal({ open, onClose, onAddClient, onAddLead, onAddTask }: { open: boolean; onClose: () => void; onAddClient: () => void; onAddLead: () => void; onAddTask: () => void }) {
   if (!open) return null;
   return (
-    <div className="fixed inset-0 z-40 bg-black/30 flex items-center justify-center p-4">
-      <div className="w-full max-w-md rounded-2xl bg-white p-4 space-y-3">
-        <div className="font-semibold">Быстро добавить</div>
-        <div className="grid gap-2">
-          <button onClick={onAddClient} className="px-3 py-2 rounded-lg bg-sky-600 text-white hover:bg-sky-700">+ Клиента</button>
-          <button onClick={onAddLead} className="px-3 py-2 rounded-lg border border-slate-300 hover:bg-slate-50">+ Лида</button>
-          <button onClick={onAddTask} className="px-3 py-2 rounded-lg border border-slate-300 hover:bg-slate-50">+ Задачу</button>
-        </div>
-        <div className="flex justify-end">
-          <button onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300">Закрыть</button>
-        </div>
+    <Modal size="md" onClose={onClose}>
+      <div className="font-semibold">Быстро добавить</div>
+      <div className="grid gap-2">
+        <button onClick={onAddClient} className="px-3 py-2 rounded-lg bg-sky-600 text-white hover:bg-sky-700">+ Клиента</button>
+        <button onClick={onAddLead} className="px-3 py-2 rounded-lg border border-slate-300 hover:bg-slate-50">+ Лида</button>
+        <button onClick={onAddTask} className="px-3 py-2 rounded-lg border border-slate-300 hover:bg-slate-50">+ Задачу</button>
       </div>
-    </div>
+      <div className="flex justify-end">
+        <button onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300">Закрыть</button>
+      </div>
+    </Modal>
   );
 }

--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -1,6 +1,7 @@
 // @flow
 import React, { useState } from "react";
 import Breadcrumbs from "./Breadcrumbs";
+import Modal from "./Modal";
 import { fmtDate, uid, saveDB, todayISO } from "../App";
 import type { DB, TaskItem } from "../App";
 
@@ -45,17 +46,15 @@ export default function TasksTab({ db, setDB }: { db: DB; setDB: (db: DB) => voi
         ))}
       </ul>
       {edit && (
-        <div className="fixed inset-0 z-40 bg-black/30 flex items-center justify-center p-4">
-          <div className="w-full max-w-md rounded-2xl bg-white p-4 space-y-3">
-            <div className="font-semibold text-slate-800">Редактирование задачи</div>
-            <input className="w-full px-3 py-2 rounded-md border border-slate-300" value={edit.title} onChange={e => setEdit({ ...edit, title: e.target.value })} />
-            <input type="date" className="w-full px-3 py-2 rounded-md border border-slate-300" value={edit.due.slice(0,10)} onChange={e => setEdit({ ...edit, due: e.target.value })} />
-            <div className="flex justify-end gap-2">
-              <button onClick={() => setEdit(null)} className="px-3 py-2 rounded-md border border-slate-300">Отмена</button>
-              <button onClick={save} className="px-3 py-2 rounded-md bg-sky-600 text-white">Сохранить</button>
-            </div>
+        <Modal size="md" onClose={() => setEdit(null)}>
+          <div className="font-semibold text-slate-800">Редактирование задачи</div>
+          <input className="w-full px-3 py-2 rounded-md border border-slate-300" value={edit.title} onChange={e => setEdit({ ...edit, title: e.target.value })} />
+          <input type="date" className="w-full px-3 py-2 rounded-md border border-slate-300" value={edit.due.slice(0,10)} onChange={e => setEdit({ ...edit, due: e.target.value })} />
+          <div className="flex justify-end gap-2">
+            <button onClick={() => setEdit(null)} className="px-3 py-2 rounded-md border border-slate-300">Отмена</button>
+            <button onClick={save} className="px-3 py-2 rounded-md bg-sky-600 text-white">Сохранить</button>
           </div>
-        </div>
+        </Modal>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add reusable Modal component
- refactor client, lead, task and quick add dialogs to use Modal

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d7985f78832bad3d9f15f58bc053