### PR TITLE
Add error boundary around app routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import SettingsTab from "./components/SettingsTab";
 import QuickAddModal from "./components/QuickAddModal";
 import Toasts, { useToasts } from "./components/Toasts";
 import usePersistentState from "./hooks/usePersistentState";
+import ErrorBoundary from "./components/ErrorBoundary";
 
 // === ЛЁГКИЙ КАРКАС CRM (SPA в одном файле) ===
 // Эта версия: вкладки, роли, seed-данные в LocalStorage, минимальные таблицы, поиск/фильтры,
@@ -468,71 +469,73 @@ export default function App() {
       <Tabs role={ui.role} />
 
       <main className="max-w-7xl mx-auto p-3 space-y-3">
-        <Routes>
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<Dashboard db={db} ui={ui} />} />
-          <Route
-            path="/clients"
-            element={
-              can(ui.role, "manage_clients") ? (
-                <ClientsTab db={db} setDB={setDB} ui={ui} />
-              ) : (
-                <Navigate to="/dashboard" replace />
-              )
-            }
-          />
-          <Route
-            path="/attendance"
-            element={
-              can(ui.role, "attendance") ? (
-                <AttendanceTab db={db} setDB={setDB} />
-              ) : (
-                <Navigate to="/dashboard" replace />
-              )
-            }
-          />
-          <Route
-            path="/schedule"
-            element={
-              can(ui.role, "schedule") ? (
-                <ScheduleTab db={db} setDB={setDB} />
-              ) : (
-                <Navigate to="/dashboard" replace />
-              )
-            }
-          />
-          <Route
-            path="/leads"
-            element={
-              can(ui.role, "leads") ? (
-                <LeadsTab db={db} setDB={setDB} />
-              ) : (
-                <Navigate to="/dashboard" replace />
-              )
-            }
-          />
-          <Route
-            path="/tasks"
-            element={
-              can(ui.role, "tasks") ? (
-                <TasksTab db={db} setDB={setDB} />
-              ) : (
-                <Navigate to="/dashboard" replace />
-              )
-            }
-          />
-          <Route
-            path="/settings"
-            element={
-              can(ui.role, "settings") ? (
-                <SettingsTab db={db} setDB={setDB} />
-              ) : (
-                <Navigate to="/dashboard" replace />
-              )
-            }
-          />
-          <Route path="*" element={<Navigate to="/dashboard" replace />} />
-        </Routes>
+        <ErrorBoundary>
+          <Routes>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<Dashboard db={db} ui={ui} />} />
+            <Route
+              path="/clients"
+              element={
+                can(ui.role, "manage_clients") ? (
+                  <ClientsTab db={db} setDB={setDB} ui={ui} />
+                ) : (
+                  <Navigate to="/dashboard" replace />
+                )
+              }
+            />
+            <Route
+              path="/attendance"
+              element={
+                can(ui.role, "attendance") ? (
+                  <AttendanceTab db={db} setDB={setDB} />
+                ) : (
+                  <Navigate to="/dashboard" replace />
+                )
+              }
+            />
+            <Route
+              path="/schedule"
+              element={
+                can(ui.role, "schedule") ? (
+                  <ScheduleTab db={db} setDB={setDB} />
+                ) : (
+                  <Navigate to="/dashboard" replace />
+                )
+              }
+            />
+            <Route
+              path="/leads"
+              element={
+                can(ui.role, "leads") ? (
+                  <LeadsTab db={db} setDB={setDB} />
+                ) : (
+                  <Navigate to="/dashboard" replace />
+                )
+              }
+            />
+            <Route
+              path="/tasks"
+              element={
+                can(ui.role, "tasks") ? (
+                  <TasksTab db={db} setDB={setDB} />
+                ) : (
+                  <Navigate to="/dashboard" replace />
+                )
+              }
+            />
+            <Route
+              path="/settings"
+              element={
+                can(ui.role, "settings") ? (
+                  <SettingsTab db={db} setDB={setDB} />
+                ) : (
+                  <Navigate to="/dashboard" replace />
+                )
+              }
+            />
+            <Route path="*" element={<Navigate to="/dashboard" replace />} />
+          </Routes>
+        </ErrorBoundary>
       </main>
 
       <QuickAddModal open={quickOpen} onClose={() => setQuickOpen(false)} onAddClient={addQuickClient} onAddLead={addQuickLead} onAddTask={addQuickTask} />

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,41 @@
+// @flow
+import React from "react";
+
+type Props = {
+  children: React.Node,
+};
+
+type State = {
+  hasError: boolean,
+};
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: { componentStack: string }) {
+    // Log error to console or send to a server
+    console.error("ErrorBoundary caught an error", error, info);
+    // Example: send to server (replace with real endpoint)
+    // fetch("/log-error", {
+    //   method: "POST",
+    //   headers: { "Content-Type": "application/json" },
+    //   body: JSON.stringify({ error: error.toString(), info }),
+    // });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 text-center text-red-700">
+          <h1 className="text-lg font-semibold">Что-то пошло не так.</h1>
+          <p>Пожалуйста, перезагрузите страницу или попробуйте позже.</p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `ErrorBoundary` component with `componentDidCatch`
- wrap `<Routes>` in `App.jsx` with the new error boundary
- log uncaught errors to the console and show a fallback UI

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c5db8cf670832bb46a0c928c29f811