### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -148,6 +148,7 @@ export interface UIState {
   breadcrumbs: string[];
   currency: Currency;
   search: string;
+  theme: "light" | "dark";
 }
 
 export type TabKey =
@@ -373,6 +374,7 @@ const defaultUI: UIState = {
   breadcrumbs: ["Дашборд"],
   currency: "EUR",
   search: "",
+  theme: "light",
 };
 
 // Ролевая проверка
@@ -394,6 +396,16 @@ export default function App() {
   const roles: Role[] = ["Администратор", "Менеджер", "Тренер"];
   const { toasts, push } = useToasts();
   const [quickOpen, setQuickOpen] = useState(false);
+
+  // Apply theme to root element
+  useEffect(() => {
+    const root = document.documentElement;
+    if (ui.theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  }, [ui.theme]);
 
   const onQuickAdd = () => setQuickOpen(true);
   const addQuickClient = () => {
@@ -463,7 +475,7 @@ export default function App() {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-white to-sky-50 text-slate-900">
+    <div className="min-h-screen bg-gradient-to-b from-white to-sky-50 text-slate-900 dark:from-slate-900 dark:to-slate-950 dark:text-slate-100">
       <Topbar ui={ui} setUI={setUI} roleList={roles} onQuickAdd={onQuickAdd} />
       <Tabs role={ui.role} />
 

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -3,10 +3,10 @@ import React from "react";
 
 export default function Topbar({ ui, setUI, roleList, onQuickAdd }) {
   return (
-    <div className="w-full flex flex-wrap items-center justify-between gap-2 p-3 bg-white/70 backdrop-blur border-b border-slate-200 sticky top-0 z-30">
+    <div className="w-full flex flex-wrap items-center justify-between gap-2 p-3 bg-white/70 dark:bg-slate-800/70 backdrop-blur border-b border-slate-200 dark:border-slate-700 sticky top-0 z-30">
       <div className="flex items-center gap-3">
-        <div className="font-semibold text-slate-800 text-lg">Judo CRM</div>
-        <div className="hidden sm:block text-xs text-slate-500">спокойные синие/голубые — KPI зелёные</div>
+        <div className="font-semibold text-slate-800 dark:text-slate-100 text-lg">Judo CRM</div>
+        <div className="hidden sm:block text-xs text-slate-500 dark:text-slate-400">спокойные синие/голубые — KPI зелёные</div>
       </div>
       <div className="flex items-center gap-2">
         <input
@@ -24,6 +24,13 @@ export default function Topbar({ ui, setUI, roleList, onQuickAdd }) {
           <option value="TRY">TRY</option>
           <option value="RUB">RUB</option>
         </select>
+        <button
+          onClick={() => { const u = { ...ui, theme: ui.theme === "light" ? "dark" : "light" }; setUI(u); }}
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm"
+          title="Переключить тему"
+        >
+          {ui.theme === "light" ? "🌙" : "☀️"}
+        </button>
         <button onClick={onQuickAdd} className="px-3 py-2 rounded-lg bg-sky-600 text-white text-sm hover:bg-sky-700">+ Быстро добавить</button>
         <select
           className="px-2 py-2 rounded-md border border-slate-300 text-sm"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: "class",
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
   ],


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode using class strategy
- add theme selection with light/dark toggle in Topbar
- apply dark theme class to document root and update styles

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68c5dba7c364832bb0ccccd40a555b12