### PR TITLE
feat: improve dark theme support

### DIFF
--- a/src/components/AttendanceTab.jsx
+++ b/src/components/AttendanceTab.jsx
@@ -34,11 +34,11 @@ export default function AttendanceTab({ db, setDB }: { db: DB; setDB: (db: DB) =
     <div className="space-y-3">
       <Breadcrumbs items={["Посещаемость"]} />
       <div className="flex flex-wrap items-center gap-2">
-        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm" value={area} onChange={e => setArea(e.target.value)}>
+        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200" value={area} onChange={e => setArea(e.target.value)}>
           <option value="all">Все районы</option>
           {db.settings.areas.map(a => <option key={a}>{a}</option>)}
         </select>
-        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm" value={group} onChange={e => setGroup(e.target.value)}>
+        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200" value={group} onChange={e => setGroup(e.target.value)}>
           <option value="all">Все группы</option>
           {db.settings.groups.map(g => <option key={g}>{g}</option>)}
         </select>
@@ -46,7 +46,7 @@ export default function AttendanceTab({ db, setDB }: { db: DB; setDB: (db: DB) =
       </div>
 
       <TableWrap>
-        <thead className="bg-slate-50 text-slate-600">
+        <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
           <tr>
             <th className="text-left p-2">Ученик</th>
             <th className="text-left p-2">Район</th>
@@ -58,12 +58,12 @@ export default function AttendanceTab({ db, setDB }: { db: DB; setDB: (db: DB) =
           {list.map(c => {
             const m = getMark(c.id);
             return (
-              <tr key={c.id} className="border-t border-slate-100">
+              <tr key={c.id} className="border-t border-slate-100 dark:border-slate-700">
                 <td className="p-2">{c.firstName} {c.lastName}</td>
                 <td className="p-2">{c.area}</td>
                 <td className="p-2">{c.group}</td>
                 <td className="p-2">
-                  <button onClick={() => toggle(c.id)} className={`px-3 py-1 rounded-md text-xs border ${m?.came ? "bg-emerald-100 text-emerald-700 border-emerald-200" : "bg-slate-50 text-slate-700 border-slate-200"}`}>
+                  <button onClick={() => toggle(c.id)} className={`px-3 py-1 rounded-md text-xs border ${m?.came ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700" : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"}`}>
                     {m?.came ? "пришёл" : "не отмечен"}
                   </button>
                 </td>

--- a/src/components/ClientsTab.jsx
+++ b/src/components/ClientsTab.jsx
@@ -11,7 +11,7 @@ import type { DB, UIState, Client, Area, Group, PaymentStatus } from "../App";
 
 function Chip({ active, onClick, children }: { active?: boolean; onClick?: () => void; children: React.ReactNode }) {
   return (
-    <button onClick={onClick} className={`px-3 py-1 rounded-full border text-xs ${active ? "bg-sky-600 text-white border-sky-600" : "bg-white text-slate-700 border-slate-300 hover:bg-slate-50"}`}>{children}</button>
+    <button onClick={onClick} className={`px-3 py-1 rounded-full border text-xs ${active ? "bg-sky-600 text-white border-sky-600" : "bg-white text-slate-700 border-slate-300 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-700"}`}>{children}</button>
   );
 }
 
@@ -136,11 +136,11 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
       </div>
 
       <div className="flex flex-wrap gap-2 items-center">
-        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm" value={group} onChange={e => setGroup(e.target.value)}>
+        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200" value={group} onChange={e => setGroup(e.target.value)}>
           <option value="all">Все группы</option>
           {db.settings.groups.map(g => <option key={g} value={g}>{g}</option>)}
         </select>
-        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm" value={pay} onChange={e => setPay(e.target.value)}>
+        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200" value={pay} onChange={e => setPay(e.target.value)}>
           <option value="all">Все статусы оплаты</option>
           <option value="ожидание">ожидание</option>
           <option value="действует">действует</option>
@@ -150,7 +150,7 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
       </div>
 
       <TableWrap>
-        <thead className="bg-slate-50 text-slate-600">
+        <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
           <tr>
             <th className="text-left p-2">Имя</th>
             <th className="text-left p-2">Телефон</th>
@@ -163,7 +163,7 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
         </thead>
         <tbody>
           {list.map(c => (
-            <tr key={c.id} className="border-t border-slate-100">
+            <tr key={c.id} className="border-t border-slate-100 dark:border-slate-700">
               <td className="p-2 cursor-pointer" onClick={() => setSelected(c)}>{c.firstName} {c.lastName}</td>
               <td className="p-2">{c.phone}</td>
               <td className="p-2">{c.area}</td>
@@ -173,8 +173,8 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
               </td>
               <td className="p-2">{c.payAmount != null ? fmtMoney(c.payAmount, ui.currency) : "—"}</td>
               <td className="p-2 text-right">
-                <button onClick={() => startEdit(c)} className="px-2 py-1 text-xs rounded-md border border-slate-300 mr-1">Редактировать</button>
-                <button onClick={() => removeClient(c.id)} className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50">Удалить</button>
+                <button onClick={() => startEdit(c)} className="px-2 py-1 text-xs rounded-md border border-slate-300 mr-1 dark:border-slate-700 dark:bg-slate-800">Редактировать</button>
+                <button onClick={() => removeClient(c.id)} className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30">Удалить</button>
               </td>
             </tr>
           ))}

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -5,7 +5,7 @@ import { fmtMoney, fmtDate } from "../App";
 
 function OfflineTip() {
   return (
-    <div className="m-3 p-3 rounded-xl bg-blue-50 border border-blue-200 text-slate-700">
+    <div className="m-3 p-3 rounded-xl bg-blue-50 border border-blue-200 text-slate-700 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-300">
       <div className="font-medium mb-1">Как сохранить и работать офлайн</div>
       <ul className="list-disc pl-5 text-sm space-y-1">
         <li>В браузере откройте эту страницу, оставьте её открытой один раз (кешируется автоматически).</li>
@@ -17,7 +17,11 @@ function OfflineTip() {
 }
 
 function MetricCard({ title, value, accent }) {
-  const cls = accent === "green" ? "bg-emerald-50 border-emerald-200" : accent === "sky" ? "bg-sky-50 border-sky-200" : "bg-slate-50 border-slate-200";
+  const cls = accent === "green"
+    ? "bg-emerald-50 border-emerald-200 dark:bg-emerald-900/30 dark:border-emerald-700"
+    : accent === "sky"
+      ? "bg-sky-50 border-sky-200 dark:bg-sky-900/30 dark:border-sky-700"
+      : "bg-slate-50 border-slate-200 dark:bg-slate-800 dark:border-slate-700";
   return (
     <div className={`p-4 rounded-2xl border ${cls} min-w-[180px]`}>
       <div className="text-xs text-slate-500">{title}</div>
@@ -50,18 +54,18 @@ export default function Dashboard({ db, ui }) {
         <MetricCard title="Заполняемость" value={`${fillPct}%`} accent={fillPct >= 80 ? "green" : "slate"} />
       </div>
       <div className="grid lg:grid-cols-2 gap-3">
-        <div className="p-4 rounded-2xl border border-slate-200 bg-white">
+        <div className="p-4 rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
           <div className="font-semibold mb-2">Лиды по этапам</div>
           <div className="flex flex-wrap gap-2">
             {["Очередь", "Задержка", "Пробное", "Ожидание оплаты", "Оплаченный абонемент", "Отмена"].map(s => (
-              <div key={s} className="px-3 py-2 rounded-xl bg-slate-50 border border-slate-200 text-xs">
+              <div key={s} className="px-3 py-2 rounded-xl bg-slate-50 border border-slate-200 text-xs dark:bg-slate-800 dark:border-slate-700">
                 <div className="text-slate-500">{s}</div>
                 <div className="text-lg font-semibold text-slate-800">{db.leads.filter(l => l.stage === s).length}</div>
               </div>
             ))}
           </div>
         </div>
-        <div className="p-4 rounded-2xl border border-slate-200 bg-white">
+        <div className="p-4 rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
           <div className="font-semibold mb-2">Предстоящие задачи</div>
           <ul className="space-y-2">
             {db.tasks

--- a/src/components/LeadsTab.jsx
+++ b/src/components/LeadsTab.jsx
@@ -23,16 +23,16 @@ export default function LeadsTab({ db, setDB }: { db: DB; setDB: (db: DB) => voi
       <Breadcrumbs items={["Лиды"]} />
       <div className="grid md:grid-cols-3 lg:grid-cols-6 gap-3">
         {stages.map(s => (
-          <div key={s} className="p-3 rounded-2xl border border-slate-200 bg-white">
+          <div key={s} className="p-3 rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
             <div className="text-xs text-slate-500 mb-2">{s}</div>
             <div className="space-y-2">
               {db.leads.filter(l => l.stage === s).map(l => (
-                <div key={l.id} className="p-2 rounded-xl border border-slate-200 bg-slate-50">
+                <div key={l.id} className="p-2 rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800">
                   <button onClick={() => setOpen(l)} className="text-sm font-medium text-left hover:underline w-full">{l.name}</button>
                   <div className="text-xs text-slate-500">{l.source}{l.contact ? " · " + l.contact : ""}</div>
                   <div className="flex gap-1 mt-2">
-                    <button onClick={() => move(l.id, -1)} className="px-2 py-1 text-xs rounded-md border border-slate-300">◀</button>
-                    <button onClick={() => move(l.id, +1)} className="px-2 py-1 text-xs rounded-md border border-slate-300">▶</button>
+                    <button onClick={() => move(l.id, -1)} className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">◀</button>
+                    <button onClick={() => move(l.id, +1)} className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">▶</button>
                   </div>
                 </div>
               ))}
@@ -119,20 +119,20 @@ function LeadModal(
         <div><span className="text-slate-500">Обновлён:</span> {fmtDate(lead.updatedAt)}</div>
       </div>
       <div className="flex justify-end gap-2">
-        {!edit && <button onClick={() => setEdit(true)} className="px-3 py-2 rounded-md border border-slate-300">Редактировать</button>}
-        <button onClick={remove} className="px-3 py-2 rounded-md border border-rose-200 text-rose-600">Удалить</button>
-        <button onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300">Закрыть</button>
+        {!edit && <button onClick={() => setEdit(true)} className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">Редактировать</button>}
+        <button onClick={remove} className="px-3 py-2 rounded-md border border-rose-200 text-rose-600 dark:border-rose-700 dark:bg-rose-900/20">Удалить</button>
+        <button onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">Закрыть</button>
       </div>
       {edit && (
-        <form onSubmit={handleSubmit(save)} className="space-y-2 pt-2 border-t border-slate-200">
-          <input className="w-full px-3 py-2 rounded-md border border-slate-300" {...register("name")} placeholder="Имя" />
+        <form onSubmit={handleSubmit(save)} className="space-y-2 pt-2 border-t border-slate-200 dark:border-slate-700">
+          <input className="w-full px-3 py-2 rounded-md border border-slate-300 bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100" {...register("name")} placeholder="Имя" />
           {errors.name && <span className="text-xs text-rose-600">{errors.name.message}</span>}
-          <input className="w-full px-3 py-2 rounded-md border border-slate-300" {...register("parentName")} placeholder="Родитель" />
-          <input className="w-full px-3 py-2 rounded-md border border-slate-300" {...register("contact")} placeholder="Контакт" />
+          <input className="w-full px-3 py-2 rounded-md border border-slate-300 bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100" {...register("parentName")} placeholder="Родитель" />
+          <input className="w-full px-3 py-2 rounded-md border border-slate-300 bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100" {...register("contact")} placeholder="Контакт" />
           {errors.contact && <span className="text-xs text-rose-600">{errors.contact.message}</span>}
           <div className="flex justify-end gap-2">
             <button type="submit" disabled={!isValid} className="px-3 py-2 rounded-md bg-sky-600 text-white disabled:bg-slate-400">Сохранить</button>
-            <button type="button" onClick={() => setEdit(false)} className="px-3 py-2 rounded-md border border-slate-300">Отмена</button>
+            <button type="button" onClick={() => setEdit(false)} className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">Отмена</button>
           </div>
         </form>
       )}

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -19,7 +19,7 @@ export default function Modal({ children, onClose, size = "md", className = "" }
     <div className="fixed inset-0 z-40 bg-black/30 flex items-center justify-center p-4" onClick={onClose}>
       <div
         onClick={e => e.stopPropagation()}
-        className={`w-full ${sizeClass} rounded-2xl bg-white p-4 space-y-3 ${className}`}
+        className={`w-full ${sizeClass} rounded-2xl bg-white dark:bg-slate-800 p-4 space-y-3 ${className}`}
       >
         {children}
       </div>

--- a/src/components/QuickAddModal.jsx
+++ b/src/components/QuickAddModal.jsx
@@ -9,11 +9,11 @@ export default function QuickAddModal({ open, onClose, onAddClient, onAddLead, o
       <div className="font-semibold">Быстро добавить</div>
       <div className="grid gap-2">
         <button onClick={onAddClient} className="px-3 py-2 rounded-lg bg-sky-600 text-white hover:bg-sky-700">+ Клиента</button>
-        <button onClick={onAddLead} className="px-3 py-2 rounded-lg border border-slate-300 hover:bg-slate-50">+ Лида</button>
-        <button onClick={onAddTask} className="px-3 py-2 rounded-lg border border-slate-300 hover:bg-slate-50">+ Задачу</button>
+        <button onClick={onAddLead} className="px-3 py-2 rounded-lg border border-slate-300 hover:bg-slate-50 bg-white dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700">+ Лида</button>
+        <button onClick={onAddTask} className="px-3 py-2 rounded-lg border border-slate-300 hover:bg-slate-50 bg-white dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700">+ Задачу</button>
       </div>
       <div className="flex justify-end">
-        <button onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300">Закрыть</button>
+        <button onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">Закрыть</button>
       </div>
     </Modal>
   );

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -94,7 +94,7 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
       </div>
       <div className="grid lg:grid-cols-3 gap-3">
         {Object.entries(byArea).map(([area, list]) => (
-          <div key={area} className="p-4 rounded-2xl border border-slate-200 bg-white space-y-2">
+          <div key={area} className="p-4 rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 space-y-2">
             <div className="flex justify-between items-center font-semibold">
               <span>{area}</span>
               <span className="flex gap-1 text-xs">

--- a/src/components/SettingsTab.jsx
+++ b/src/components/SettingsTab.jsx
@@ -50,14 +50,14 @@ export default function SettingsTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
   return (
     <div className="space-y-3">
       <Breadcrumbs items={["Настройки"]} />
-      <div className="p-4 rounded-2xl border border-slate-200 bg-white space-y-3">
+      <div className="p-4 rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 space-y-3">
         <div className="font-semibold">Курсы валют</div>
         <div className="grid sm:grid-cols-3 gap-2">
           <label className="text-sm">EUR → TRY
             <input
               type="number"
               readOnly
-              className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300 bg-slate-100"
+              className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300 bg-slate-100 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
               value={rates.eurTry ? rates.eurTry.toFixed(2) : ""}
             />
           </label>
@@ -65,7 +65,7 @@ export default function SettingsTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
             <input
               type="number"
               readOnly
-              className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300 bg-slate-100"
+              className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300 bg-slate-100 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
               value={rates.eurRub ? rates.eurRub.toFixed(2) : ""}
             />
           </label>
@@ -73,14 +73,14 @@ export default function SettingsTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
             <input
               type="number"
               readOnly
-              className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300 bg-slate-100"
+              className="mt-1 w-full px-3 py-2 rounded-md border border-slate-300 bg-slate-100 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
               value={rates.tryRub ? rates.tryRub.toFixed(2) : ""}
             />
           </label>
         </div>
       </div>
 
-      <div className="p-4 rounded-2xl border border-slate-200 bg-white space-y-3">
+      <div className="p-4 rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 space-y-3">
         <div className="font-semibold">Лимиты мест</div>
         <div className="grid md:grid-cols-3 gap-4">
           {["Центр", "Джикджилли", "Махмутлар"].map(area => (
@@ -89,12 +89,12 @@ export default function SettingsTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
               {db.settings.groups.map(group => {
                 const key = `${area}|${group}`;
                 return (
-                  <div key={key} className="text-sm flex items-center justify-between gap-2 border border-slate-200 rounded-xl p-2">
+                  <div key={key} className="text-sm flex items-center justify-between gap-2 border border-slate-200 rounded-xl p-2 dark:border-slate-700 dark:bg-slate-800">
                     <div className="truncate">{group}</div>
                     <input
                       type="number"
                       min={0}
-                      className="w-24 px-2 py-1 rounded-md border border-slate-300"
+                      className="w-24 px-2 py-1 rounded-md border border-slate-300 bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
                       value={db.settings.limits[key]}
                       onChange={e => {
                         const next = { ...db, settings: { ...db.settings, limits: { ...db.settings.limits, [key]: Number(e.target.value) } } };

--- a/src/components/TableWrap.jsx
+++ b/src/components/TableWrap.jsx
@@ -3,7 +3,7 @@ import React from "react";
 
 export default function TableWrap({ children }: { children: React.ReactNode }) {
   return (
-    <div className="w-full overflow-auto rounded-xl border border-slate-200 bg-white">
+    <div className="w-full overflow-auto rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
       <table className="w-full text-sm">
         {children}
       </table>

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -18,7 +18,7 @@ export const TAB_TITLES = TABS.reduce((acc, t) => ({ ...acc, [t.key]: t.title })
 export default function Tabs({ role }) {
   const visible = TABS.filter(t => !t.need || t.need(role));
   return (
-    <div className="w-full overflow-x-auto border-b border-slate-200 bg-gradient-to-r from-sky-50 to-blue-50">
+    <div className="w-full overflow-x-auto border-b border-slate-200 bg-gradient-to-r from-sky-50 to-blue-50 dark:border-slate-700 dark:from-slate-800 dark:to-slate-900">
       <div className="flex gap-1 p-2">
         {visible.map(t => (
           <NavLink
@@ -26,7 +26,9 @@ export default function Tabs({ role }) {
             to={`/${t.key}`}
             className={({ isActive }) =>
               `px-3 py-2 rounded-md text-sm ${
-                isActive ? "bg-white text-sky-700 border border-sky-200" : "text-slate-700 hover:bg-white/80"
+                isActive
+                  ? "bg-white text-sky-700 border border-sky-200 dark:bg-slate-800 dark:text-sky-400 dark:border-slate-700"
+                  : "text-slate-700 hover:bg-white/80 dark:text-slate-300 dark:hover:bg-slate-800/80"
               }`}
           >
             {t.title}

--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -32,15 +32,15 @@ export default function TasksTab({ db, setDB }: { db: DB; setDB: (db: DB) => voi
       <button onClick={add} className="px-3 py-2 rounded-lg bg-sky-600 text-white text-sm hover:bg-sky-700">+ задача</button>
       <ul className="space-y-2">
         {db.tasks.map(t => (
-          <li key={t.id} className="p-3 rounded-xl border border-slate-200 bg-white flex items-center justify-between gap-2">
+          <li key={t.id} className="p-3 rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <input type="checkbox" checked={t.status === "done"} onChange={() => toggle(t.id)} />
               <span className={`text-sm ${t.status === "done" ? "line-through text-slate-500" : ""}`}>{t.title}</span>
             </div>
             <div className="flex items-center gap-2 text-xs">
               <span className="text-slate-500">{fmtDate(t.due)}</span>
-              <button onClick={() => setEdit(t)} className="px-2 py-1 rounded-md border border-slate-300">✎</button>
-              <button onClick={() => remove(t.id)} className="px-2 py-1 rounded-md border border-slate-300">✕</button>
+              <button onClick={() => setEdit(t)} className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">✎</button>
+              <button onClick={() => remove(t.id)} className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">✕</button>
             </div>
           </li>
         ))}
@@ -48,10 +48,10 @@ export default function TasksTab({ db, setDB }: { db: DB; setDB: (db: DB) => voi
       {edit && (
         <Modal size="md" onClose={() => setEdit(null)}>
           <div className="font-semibold text-slate-800">Редактирование задачи</div>
-          <input className="w-full px-3 py-2 rounded-md border border-slate-300" value={edit.title} onChange={e => setEdit({ ...edit, title: e.target.value })} />
-          <input type="date" className="w-full px-3 py-2 rounded-md border border-slate-300" value={edit.due.slice(0,10)} onChange={e => setEdit({ ...edit, due: e.target.value })} />
+          <input className="w-full px-3 py-2 rounded-md border border-slate-300 bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100" value={edit.title} onChange={e => setEdit({ ...edit, title: e.target.value })} />
+          <input type="date" className="w-full px-3 py-2 rounded-md border border-slate-300 bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100" value={edit.due.slice(0,10)} onChange={e => setEdit({ ...edit, due: e.target.value })} />
           <div className="flex justify-end gap-2">
-            <button onClick={() => setEdit(null)} className="px-3 py-2 rounded-md border border-slate-300">Отмена</button>
+            <button onClick={() => setEdit(null)} className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">Отмена</button>
             <button onClick={save} className="px-3 py-2 rounded-md bg-sky-600 text-white">Сохранить</button>
           </div>
         </Modal>

--- a/src/components/Toasts.jsx
+++ b/src/components/Toasts.jsx
@@ -18,7 +18,12 @@ export default function Toasts({ toasts }: { toasts: Toast[] }) {
   return (
     <div className="fixed bottom-4 right-4 z-50 space-y-2">
       {toasts.map(t => (
-        <div key={t.id} className={`px-4 py-3 rounded-xl shadow border text-sm ${t.type === "success" ? "bg-emerald-50 border-emerald-200 text-emerald-800" : t.type === "error" ? "bg-rose-50 border-rose-200 text-rose-800" : "bg-slate-50 border-slate-200 text-slate-800"}`}>{t.text}</div>
+        <div key={t.id} className={`px-4 py-3 rounded-xl shadow border text-sm ${t.type === "success"
+          ? "bg-emerald-50 border-emerald-200 text-emerald-800 dark:bg-emerald-900/30 dark:border-emerald-700 dark:text-emerald-300"
+          : t.type === "error"
+            ? "bg-rose-50 border-rose-200 text-rose-800 dark:bg-rose-900/30 dark:border-rose-700 dark:text-rose-300"
+            : "bg-slate-50 border-slate-200 text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+        }`}>{t.text}</div>
       ))}
     </div>
   );

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -11,12 +11,12 @@ export default function Topbar({ ui, setUI, roleList, onQuickAdd }) {
       <div className="flex items-center gap-2">
         <input
           placeholder="Поиск…"
-          className="px-3 py-2 rounded-md border border-slate-300 text-sm focus:outline-none focus:ring focus:ring-sky-200"
+          className="px-3 py-2 rounded-md border border-slate-300 text-sm focus:outline-none focus:ring focus:ring-sky-200 bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
           value={ui.search}
           onChange={e => { const u = { ...ui, search: e.target.value }; setUI(u); }}
         />
         <select
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
           value={ui.currency}
           onChange={e => { const u = { ...ui, currency: e.target.value }; setUI(u); }}
         >
@@ -26,14 +26,14 @@ export default function Topbar({ ui, setUI, roleList, onQuickAdd }) {
         </select>
         <button
           onClick={() => { const u = { ...ui, theme: ui.theme === "light" ? "dark" : "light" }; setUI(u); }}
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
           title="Переключить тему"
         >
           {ui.theme === "light" ? "🌙" : "☀️"}
         </button>
         <button onClick={onQuickAdd} className="px-3 py-2 rounded-lg bg-sky-600 text-white text-sm hover:bg-sky-700">+ Быстро добавить</button>
         <select
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
           value={ui.role}
           onChange={e => { const u = { ...ui, role: e.target.value }; setUI(u); }}
           title="Войти как"


### PR DESCRIPTION
## Summary
- refine schedule cards to honor dark theme
- add dark styling to top bar controls and navigation tabs
- ensure lists and forms adapt to dark mode

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c5dd94c8c8832ba5da879d0a2b2d9b