### PR TITLE
refactor: cache lowercased search value

### DIFF
--- a/src/components/ClientsTab.jsx
+++ b/src/components/ClientsTab.jsx
@@ -59,12 +59,14 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
   const [editing, setEditing] = useState<Client | null>(null);
   const [selected, setSelected] = useState<Client | null>(null);
 
+  const search = ui.search.toLowerCase();
+
   const list = useMemo(() => {
     return db.clients.filter(c =>
       (area === "all" || c.area === area) &&
       (group === "all" || c.group === group) &&
       (pay === "all" || c.payStatus === pay) &&
-      (!ui.search || `${c.firstName} ${c.lastName ?? ""} ${c.phone ?? ""}`.toLowerCase().includes(ui.search.toLowerCase()))
+      (!ui.search || `${c.firstName} ${c.lastName ?? ""} ${c.phone ?? ""}`.toLowerCase().includes(search))
     );
   }, [db.clients, area, group, pay, ui.search]);
 


### PR DESCRIPTION
## Summary
- cache lowercase UI search string in `ClientsTab`
- use cached search string when filtering clients

## Testing
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c678522748832bb60bdefa67d95990