### PR TITLE
Add react-window virtualization to tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-hook-form": "^7.62.0",
         "react-router-dom": "^7.9.1",
         "react-scripts": "5.0.1",
+        "react-window": "^2.1.0",
         "web-vitals": "^2.1.4",
         "yup": "^1.7.0"
       },
@@ -14085,6 +14086,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-window": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-2.1.0.tgz",
+      "integrity": "sha512-STMrsd6t3pN/XFa5cblpwTLpsEDtrtdeNY+71QsEaY0m7Fhbn9R4XXYzYAyKDpeYbjmBpAflqHBdDDKW928m3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.9.1",
     "react-scripts": "5.0.1",
+    "react-window": "^2.1.0",
     "web-vitals": "^2.1.4",
     "yup": "^1.7.0"
   },

--- a/src/components/AttendanceTab.jsx
+++ b/src/components/AttendanceTab.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React, { useState, useMemo } from "react";
 import Breadcrumbs from "./Breadcrumbs";
-import TableWrap from "./TableWrap";
+import VirtualizedTable from "./VirtualizedTable";
 import { fmtDate, uid, saveDB } from "../App";
 import type { DB, Area, Group, AttendanceEntry } from "../App";
 
@@ -53,33 +53,35 @@ export default function AttendanceTab({ db, setDB }: { db: DB; setDB: (db: DB) =
         <div className="text-xs text-slate-500">Сегодня: {fmtDate(today.toISOString())}</div>
       </div>
 
-      <TableWrap>
-        <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-          <tr>
-            <th className="text-left p-2">Ученик</th>
-            <th className="text-left p-2">Район</th>
-            <th className="text-left p-2">Группа</th>
-            <th className="text-left p-2">Отметка</th>
-          </tr>
-        </thead>
-        <tbody>
-          {list.map(c => {
-            const m = todayMarks.get(c.id);
-            return (
-              <tr key={c.id} className="border-t border-slate-100 dark:border-slate-700">
-                <td className="p-2">{c.firstName} {c.lastName}</td>
-                <td className="p-2">{c.area}</td>
-                <td className="p-2">{c.group}</td>
-                <td className="p-2">
-                  <button onClick={() => toggle(c.id)} className={`px-3 py-1 rounded-md text-xs border ${m?.came ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700" : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"}`}>
-                    {m?.came ? "пришёл" : "не отмечен"}
-                  </button>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </TableWrap>
+      <VirtualizedTable
+        header={(
+          <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+            <tr>
+              <th className="text-left p-2">Ученик</th>
+              <th className="text-left p-2">Район</th>
+              <th className="text-left p-2">Группа</th>
+              <th className="text-left p-2">Отметка</th>
+            </tr>
+          </thead>
+        )}
+        items={list}
+        rowHeight={44}
+        renderRow={(c, style) => {
+          const m = todayMarks.get(c.id);
+          return (
+            <tr key={c.id} style={style} className="border-t border-slate-100 dark:border-slate-700">
+              <td className="p-2">{c.firstName} {c.lastName}</td>
+              <td className="p-2">{c.area}</td>
+              <td className="p-2">{c.group}</td>
+              <td className="p-2">
+                <button onClick={() => toggle(c.id)} className={`px-3 py-1 rounded-md text-xs border ${m?.came ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700" : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"}`}>
+                  {m?.came ? "пришёл" : "не отмечен"}
+                </button>
+              </td>
+            </tr>
+          );
+        }}
+      />
     </div>
   );
 }

--- a/src/components/ClientsTab.jsx
+++ b/src/components/ClientsTab.jsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import Breadcrumbs from "./Breadcrumbs";
-import TableWrap from "./TableWrap";
+import VirtualizedTable from "./VirtualizedTable";
 import Modal from "./Modal";
 import { uid, todayISO, parseDateInput, fmtMoney, calcAgeYears, calcExperience, saveDB } from "../App";
 import type { DB, UIState, Client, Area, Group, PaymentStatus } from "../App";
@@ -149,37 +149,39 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
         <div className="text-xs text-slate-500">Найдено: {list.length}</div>
       </div>
 
-      <TableWrap>
-        <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-          <tr>
-            <th className="text-left p-2">Имя</th>
-            <th className="text-left p-2">Телефон</th>
-            <th className="text-left p-2">Район</th>
-            <th className="text-left p-2">Группа</th>
-            <th className="text-left p-2">Статус оплаты</th>
-            <th className="text-left p-2">Сумма оплаты</th>
-            <th className="text-right p-2">Действия</th>
-          </tr>
-        </thead>
-        <tbody>
-          {list.map(c => (
-            <tr key={c.id} className="border-t border-slate-100 dark:border-slate-700">
-              <td className="p-2 cursor-pointer" onClick={() => setSelected(c)}>{c.firstName} {c.lastName}</td>
-              <td className="p-2">{c.phone}</td>
-              <td className="p-2">{c.area}</td>
-              <td className="p-2">{c.group}</td>
-              <td className="p-2">
-                <span className={`px-2 py-1 rounded-full text-xs ${c.payStatus === "действует" ? "bg-emerald-100 text-emerald-700" : c.payStatus === "задолженность" ? "bg-rose-100 text-rose-700" : "bg-amber-100 text-amber-700"}`}>{c.payStatus}</span>
-              </td>
-              <td className="p-2">{c.payAmount != null ? fmtMoney(c.payAmount, ui.currency) : "—"}</td>
-              <td className="p-2 text-right">
-                <button onClick={() => startEdit(c)} className="px-2 py-1 text-xs rounded-md border border-slate-300 mr-1 dark:border-slate-700 dark:bg-slate-800">Редактировать</button>
-                <button onClick={() => removeClient(c.id)} className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30">Удалить</button>
-              </td>
+      <VirtualizedTable
+        header={(
+          <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+            <tr>
+              <th className="text-left p-2">Имя</th>
+              <th className="text-left p-2">Телефон</th>
+              <th className="text-left p-2">Район</th>
+              <th className="text-left p-2">Группа</th>
+              <th className="text-left p-2">Статус оплаты</th>
+              <th className="text-left p-2">Сумма оплаты</th>
+              <th className="text-right p-2">Действия</th>
             </tr>
-          ))}
-        </tbody>
-      </TableWrap>
+          </thead>
+        )}
+        items={list}
+        rowHeight={48}
+        renderRow={(c, style) => (
+          <tr key={c.id} style={style} className="border-t border-slate-100 dark:border-slate-700">
+            <td className="p-2 cursor-pointer" onClick={() => setSelected(c)}>{c.firstName} {c.lastName}</td>
+            <td className="p-2">{c.phone}</td>
+            <td className="p-2">{c.area}</td>
+            <td className="p-2">{c.group}</td>
+            <td className="p-2">
+              <span className={`px-2 py-1 rounded-full text-xs ${c.payStatus === "действует" ? "bg-emerald-100 text-emerald-700" : c.payStatus === "задолженность" ? "bg-rose-100 text-rose-700" : "bg-amber-100 text-amber-700"}`}>{c.payStatus}</span>
+            </td>
+            <td className="p-2">{c.payAmount != null ? fmtMoney(c.payAmount, ui.currency) : "—"}</td>
+            <td className="p-2 text-right">
+              <button onClick={() => startEdit(c)} className="px-2 py-1 text-xs rounded-md border border-slate-300 mr-1 dark:border-slate-700 dark:bg-slate-800">Редактировать</button>
+              <button onClick={() => removeClient(c.id)} className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30">Удалить</button>
+            </td>
+          </tr>
+        )}
+      />
 
       {selected && (
         <Modal size="md" onClose={() => setSelected(null)}>

--- a/src/components/LeadsTab.jsx
+++ b/src/components/LeadsTab.jsx
@@ -5,6 +5,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import Breadcrumbs from "./Breadcrumbs";
 import Modal from "./Modal";
+import { FixedSizeList } from "react-window";
 import { todayISO, saveDB, uid, fmtDate } from "../App";
 import type { DB, Lead, LeadStage, StaffMember } from "../App";
 
@@ -27,23 +28,34 @@ export default function LeadsTab({ db, setDB }: { db: DB; setDB: (db: DB) => voi
     <div className="space-y-3">
       <Breadcrumbs items={["Лиды"]} />
       <div className="grid md:grid-cols-3 lg:grid-cols-6 gap-3">
-        {stages.map(s => (
-          <div key={s} className="p-3 rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
-            <div className="text-xs text-slate-500 mb-2">{s}</div>
-            <div className="space-y-2">
-              {(groupedLeads[s] || []).map(l => (
-                <div key={l.id} className="p-2 rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800">
-                  <button onClick={() => setOpen(l)} className="text-sm font-medium text-left hover:underline w-full">{l.name}</button>
-                  <div className="text-xs text-slate-500">{l.source}{l.contact ? " · " + l.contact : ""}</div>
-                  <div className="flex gap-1 mt-2">
-                    <button onClick={() => move(l.id, -1)} className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">◀</button>
-                    <button onClick={() => move(l.id, +1)} className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">▶</button>
-                  </div>
-                </div>
-              ))}
+        {stages.map(s => {
+          const leads = groupedLeads[s] || [];
+          return (
+            <div key={s} className="p-3 rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
+              <div className="text-xs text-slate-500 mb-2">{s}</div>
+              <FixedSizeList
+                height={200}
+                itemCount={leads.length}
+                itemSize={90}
+                width="100%"
+              >
+                {({ index, style }) => {
+                  const l = leads[index];
+                  return (
+                    <div key={l.id} style={style} className="p-2 rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800">
+                      <button onClick={() => setOpen(l)} className="text-sm font-medium text-left hover:underline w-full">{l.name}</button>
+                      <div className="text-xs text-slate-500">{l.source}{l.contact ? " · " + l.contact : ""}</div>
+                      <div className="flex gap-1 mt-2">
+                        <button onClick={() => move(l.id, -1)} className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">◀</button>
+                        <button onClick={() => move(l.id, +1)} className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">▶</button>
+                      </div>
+                    </div>
+                  );
+                }}
+              </FixedSizeList>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
       {open && (
         <LeadModal

--- a/src/components/VirtualizedTable.jsx
+++ b/src/components/VirtualizedTable.jsx
@@ -1,0 +1,52 @@
+// @flow
+import React, { useMemo, forwardRef } from "react";
+import { FixedSizeList } from "react-window";
+
+const TBody = forwardRef<HTMLTableSectionElement, any>((props, ref) => (
+  <tbody ref={ref} {...props} />
+));
+
+export default function VirtualizedTable({
+  header,
+  items,
+  rowHeight,
+  height = 400,
+  renderRow,
+}: {
+  header: React.Node,
+  items: any[],
+  rowHeight: number,
+  height?: number,
+  renderRow: (item: any, style: any) => React.Node,
+}) {
+  const Outer = useMemo(
+    () =>
+      forwardRef<HTMLTableElement, any>(({ style, children, ...rest }, ref) => (
+        <table
+          {...rest}
+          ref={ref}
+          style={style}
+          className="w-full text-sm"
+        >
+          {header}
+          {children}
+        </table>
+      )),
+    [header]
+  );
+
+  return (
+    <div className="w-full overflow-auto rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
+      <FixedSizeList
+        height={height}
+        itemCount={items.length}
+        itemSize={rowHeight}
+        width="100%"
+        outerElementType={Outer}
+        innerElementType={TBody}
+      >
+        {({ index, style }) => renderRow(items[index], style)}
+      </FixedSizeList>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add VirtualizedTable component for fixed-size row rendering
- virtualize Clients, Leads, and Attendance tabs using react-window
- install react-window dependency

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c678558ee4832b8cb458fffc0466b4