### PR TITLE
fix: use react-window v1 for FixedSizeList

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "react-hook-form": "^7.62.0",
         "react-router-dom": "^7.9.1",
         "react-scripts": "5.0.1",
-        "react-window": "^2.1.0",
+        "react-window": "1.8.11",
         "web-vitals": "^2.1.4",
         "yup": "^1.7.0"
       },
@@ -11333,6 +11333,12 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -14089,13 +14095,20 @@
       }
     },
     "node_modules/react-window": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-2.1.0.tgz",
-      "integrity": "sha512-STMrsd6t3pN/XFa5cblpwTLpsEDtrtdeNY+71QsEaY0m7Fhbn9R4XXYzYAyKDpeYbjmBpAflqHBdDDKW928m3Q==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
       "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.9.1",
     "react-scripts": "5.0.1",
-    "react-window": "^2.1.0",
+    "react-window": "1.8.11",
     "web-vitals": "^2.1.4",
     "yup": "^1.7.0"
   },


### PR DESCRIPTION
## Summary
- pin react-window to v1.8.11 to provide FixedSizeList export used by Leads and VirtualizedTable components

## Testing
- `npm run build`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c67ae1700c832b87b4b62689c67b52