### PR TITLE
Fix overlapping client and attendance table layout

### DIFF
--- a/src/components/VirtualizedTable.jsx
+++ b/src/components/VirtualizedTable.jsx
@@ -1,10 +1,5 @@
 // @flow
-import React, { useMemo, forwardRef } from "react";
-import { FixedSizeList } from "react-window";
-
-const TBody = forwardRef<HTMLTableSectionElement, any>((props, ref) => (
-  <tbody ref={ref} {...props} />
-));
+import React from "react";
 
 export default function VirtualizedTable({
   header,
@@ -19,34 +14,18 @@ export default function VirtualizedTable({
   height?: number,
   renderRow: (item: any, style: any) => React.Node,
 }) {
-  const Outer = useMemo(
-    () =>
-      forwardRef<HTMLTableElement, any>(({ style, children, ...rest }, ref) => (
-        <table
-          {...rest}
-          ref={ref}
-          style={style}
-          className="w-full text-sm"
-        >
-          {header}
-          {children}
-        </table>
-      )),
-    [header]
-  );
-
+  // Render a simple scrollable table. Virtualization was causing rows to
+  // overlap which resulted in unreadable data. For the current dataset size a
+  // basic table is sufficient and keeps the markup correct, preventing rows
+  // from stacking on top of each other.
   return (
     <div className="w-full overflow-auto rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
-      <FixedSizeList
-        height={height}
-        itemCount={items.length}
-        itemSize={rowHeight}
-        width="100%"
-        outerElementType={Outer}
-        innerElementType={TBody}
-      >
-        {({ index, style }) => renderRow(items[index], style)}
-      </FixedSizeList>
+      <table className="w-full text-sm" style={{ maxHeight: height }}>
+        {header}
+        <tbody>
+          {items.map(item => renderRow(item, {}))}
+        </tbody>
+      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace virtualized table implementation with simple scrollable table to avoid overlapping rows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c69c8d0208832b909339e023fde299