### PR TITLE
refactor clients tab into subcomponents

### DIFF
--- a/src/components/ClientsTab.jsx
+++ b/src/components/ClientsTab.jsx
@@ -1,63 +1,18 @@
 // @flow
 import React, { useState, useMemo } from "react";
-import { useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
-import * as yup from "yup";
 import Breadcrumbs from "./Breadcrumbs";
-import VirtualizedTable from "./VirtualizedTable";
-import Modal from "./Modal";
-import { uid, todayISO, parseDateInput, fmtMoney, calcAgeYears, calcExperience, saveDB } from "../App";
+import ClientFilters from "./clients/ClientFilters";
+import ClientTable from "./clients/ClientTable";
+import ClientForm from "./clients/ClientForm";
+import { uid, todayISO, parseDateInput, saveDB } from "../App";
 import type { DB, UIState, Client, Area, Group, PaymentStatus } from "../App";
-
-function Chip({ active, onClick, children }: { active?: boolean; onClick?: () => void; children: React.ReactNode }) {
-  return (
-    <button onClick={onClick} className={`px-3 py-1 rounded-full border text-xs ${active ? "bg-sky-600 text-white border-sky-600" : "bg-white text-slate-700 border-slate-300 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-700"}`}>{children}</button>
-  );
-}
 
 export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) => void; ui: UIState }) {
   const [area, setArea] = useState<Area | "all">("all");
   const [group, setGroup] = useState<Group | "all">("all");
   const [pay, setPay] = useState<PaymentStatus | "all">("all");
   const [modalOpen, setModalOpen] = useState(false);
-
-  const blankForm = () => ({
-    firstName: "",
-    lastName: "",
-    phone: "",
-    gender: "м",
-    area: db.settings.areas[0],
-    group: db.settings.groups[0],
-    channel: "Telegram",
-    startDate: todayISO().slice(0, 10),
-    payMethod: "перевод",
-    payStatus: "ожидание",
-    birthDate: "2017-01-01",
-    payDate: todayISO().slice(0, 10),
-    parentName: "",
-  });
-
-  const schema = yup.object({
-    firstName: yup.string().required("Имя обязательно"),
-    phone: yup.string().required("Телефон обязателен"),
-    birthDate: yup
-      .string()
-      .required("Дата рождения обязательна")
-      .matches(/\d{4}-\d{2}-\d{2}/, "Неверный формат даты"),
-    startDate: yup
-      .string()
-      .required("Дата начала обязательна")
-      .matches(/\d{4}-\d{2}-\d{2}/, "Неверный формат даты"),
-  });
-
-  const { register, handleSubmit, reset, formState: { errors, isValid } } = useForm({
-    resolver: yupResolver(schema),
-    mode: "onChange",
-    defaultValues: blankForm(),
-  });
-
   const [editing, setEditing] = useState<Client | null>(null);
-  const [selected, setSelected] = useState<Client | null>(null);
 
   const search = ui.search.toLowerCase();
 
@@ -72,19 +27,11 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
 
   const openAddModal = () => {
     setEditing(null);
-    reset(blankForm());
     setModalOpen(true);
   };
 
   const startEdit = (c: Client) => {
     setEditing(c);
-    reset({
-      ...c,
-      birthDate: c.birthDate?.slice(0, 10),
-      startDate: c.startDate?.slice(0, 10),
-      payDate: c.payDate?.slice(0, 10),
-    });
-    setSelected(null);
     setModalOpen(true);
   };
 
@@ -123,167 +70,43 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
 
   const removeClient = (id: string) => {
     if (!confirm("Удалить клиента?")) return;
-    const next = { ...db, clients: db.clients.filter(c => c.id !== id), changelog: [...db.changelog, { id: uid(), who: "UI", what: `Удалён клиент ${id}`, when: todayISO() }] };
+    const next = {
+      ...db,
+      clients: db.clients.filter(c => c.id !== id),
+      changelog: [...db.changelog, { id: uid(), who: "UI", what: `Удалён клиент ${id}`, when: todayISO() }],
+    };
     setDB(next); saveDB(next);
   };
 
   return (
     <div className="space-y-3">
       <Breadcrumbs items={["Клиенты"]} />
-      <div className="flex flex-wrap gap-2 items-center">
-        <Chip active={area === "all"} onClick={() => setArea("all")}>Все районы</Chip>
-        {db.settings.areas.map(a => <Chip key={a} active={area === a} onClick={() => setArea(a)}>{a}</Chip>)}
-        <div className="flex-1" />
-        <button onClick={openAddModal} className="px-3 py-2 rounded-lg bg-sky-600 text-white text-sm hover:bg-sky-700">+ Добавить клиента</button>
-      </div>
-
-      <div className="flex flex-wrap gap-2 items-center">
-        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200" value={group} onChange={e => setGroup(e.target.value)}>
-          <option value="all">Все группы</option>
-          {db.settings.groups.map(g => <option key={g} value={g}>{g}</option>)}
-        </select>
-        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200" value={pay} onChange={e => setPay(e.target.value)}>
-          <option value="all">Все статусы оплаты</option>
-          <option value="ожидание">ожидание</option>
-          <option value="действует">действует</option>
-          <option value="задолженность">задолженность</option>
-        </select>
-        <div className="text-xs text-slate-500">Найдено: {list.length}</div>
-      </div>
-
-      <VirtualizedTable
-        header={(
-          <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-            <tr>
-              <th className="text-left p-2">Имя</th>
-              <th className="text-left p-2">Телефон</th>
-              <th className="text-left p-2">Район</th>
-              <th className="text-left p-2">Группа</th>
-              <th className="text-left p-2">Статус оплаты</th>
-              <th className="text-left p-2">Сумма оплаты</th>
-              <th className="text-right p-2">Действия</th>
-            </tr>
-          </thead>
-        )}
-        items={list}
-        rowHeight={48}
-        renderRow={(c, style) => (
-          <tr key={c.id} style={style} className="border-t border-slate-100 dark:border-slate-700">
-            <td className="p-2 cursor-pointer" onClick={() => setSelected(c)}>{c.firstName} {c.lastName}</td>
-            <td className="p-2">{c.phone}</td>
-            <td className="p-2">{c.area}</td>
-            <td className="p-2">{c.group}</td>
-            <td className="p-2">
-              <span className={`px-2 py-1 rounded-full text-xs ${c.payStatus === "действует" ? "bg-emerald-100 text-emerald-700" : c.payStatus === "задолженность" ? "bg-rose-100 text-rose-700" : "bg-amber-100 text-amber-700"}`}>{c.payStatus}</span>
-            </td>
-            <td className="p-2">{c.payAmount != null ? fmtMoney(c.payAmount, ui.currency) : "—"}</td>
-            <td className="p-2 text-right">
-              <button onClick={() => startEdit(c)} className="px-2 py-1 text-xs rounded-md border border-slate-300 mr-1 dark:border-slate-700 dark:bg-slate-800">Редактировать</button>
-              <button onClick={() => removeClient(c.id)} className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30">Удалить</button>
-            </td>
-          </tr>
-        )}
+      <ClientFilters
+        db={db}
+        area={area}
+        setArea={setArea}
+        group={group}
+        setGroup={setGroup}
+        pay={pay}
+        setPay={setPay}
+        listLength={list.length}
+        onAddClient={openAddModal}
       />
-
-      {selected && (
-        <Modal size="md" onClose={() => setSelected(null)}>
-          <div className="font-semibold text-slate-800">
-            {selected.firstName} {selected.lastName}
-          </div>
-          <div className="grid gap-1 text-sm">
-            <div><span className="text-slate-500">Телефон:</span> {selected.phone || "—"}</div>
-            <div><span className="text-slate-500">Канал:</span> {selected.channel}</div>
-            <div><span className="text-slate-500">Родитель:</span> {selected.parentName || "—"}</div>
-            <div><span className="text-slate-500">Дата рождения:</span> {selected.birthDate?.slice(0,10)}</div>
-            <div><span className="text-slate-500">Возраст:</span> {selected.birthDate ? `${calcAgeYears(selected.birthDate)} лет` : "—"}</div>
-            <div><span className="text-slate-500">Район:</span> {selected.area}</div>
-            <div><span className="text-slate-500">Группа:</span> {selected.group}</div>
-            <div><span className="text-slate-500">Опыт:</span> {calcExperience(selected.startDate)}</div>
-            <div><span className="text-slate-500">Статус оплаты:</span> {selected.payStatus}</div>
-            <div><span className="text-slate-500">Дата оплаты:</span> {selected.payDate?.slice(0,10) || "—"}</div>
-            <div><span className="text-slate-500">Сумма оплаты:</span> {selected.payAmount != null ? fmtMoney(selected.payAmount, ui.currency) : "—"}</div>
-          </div>
-          <div className="flex justify-end gap-2">
-            <button onClick={() => startEdit(selected)} className="px-3 py-2 rounded-md border border-slate-300">Редактировать</button>
-            <button onClick={() => { removeClient(selected.id); setSelected(null); }} className="px-3 py-2 rounded-md border border-rose-200 text-rose-600">Удалить</button>
-            <button onClick={() => setSelected(null)} className="px-3 py-2 rounded-md border border-slate-300">Закрыть</button>
-          </div>
-        </Modal>
-      )}
-
+      <ClientTable
+        list={list}
+        ui={ui}
+        onEdit={startEdit}
+        onRemove={removeClient}
+      />
       {modalOpen && (
-        <Modal size="xl" onClose={() => { setModalOpen(false); setEditing(null); }}>
-          <div className="font-semibold text-slate-800">{editing ? "Редактирование клиента" : "Новый клиент"}</div>
-          <form onSubmit={handleSubmit(saveClient)} className="space-y-3">
-            <div className="grid sm:grid-cols-2 gap-2">
-              <div className="flex flex-col gap-1">
-                <label className="text-xs text-slate-500">Имя</label>
-                <input className="px-3 py-2 rounded-md border border-slate-300" {...register("firstName")} />
-                {errors.firstName && <span className="text-xs text-rose-600">{errors.firstName.message}</span>}
-              </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-slate-500">Фамилия</label>
-                  <input className="px-3 py-2 rounded-md border border-slate-300" {...register("lastName")} />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-slate-500">Телефон</label>
-                  <input className="px-3 py-2 rounded-md border border-slate-300" {...register("phone")} />
-                  {errors.phone && <span className="text-xs text-rose-600">{errors.phone.message}</span>}
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-slate-500">Канал</label>
-                  <select className="px-3 py-2 rounded-md border border-slate-300" {...register("channel")}>
-                    <option>Telegram</option><option>WhatsApp</option><option>Instagram</option>
-                  </select>
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-slate-500">Пол</label>
-                  <select className="px-3 py-2 rounded-md border border-slate-300" {...register("gender")}>
-                    <option value="м">м</option><option value="ж">ж</option>
-                  </select>
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-slate-500">Район</label>
-                  <select className="px-3 py-2 rounded-md border border-slate-300" {...register("area")}>
-                    {db.settings.areas.map(a => <option key={a}>{a}</option>)}
-                  </select>
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-slate-500">Группа</label>
-                  <select className="px-3 py-2 rounded-md border border-slate-300" {...register("group")}>
-                    {db.settings.groups.map(g => <option key={g}>{g}</option>)}
-                  </select>
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-slate-500">Дата рождения</label>
-                  <input type="date" className="px-3 py-2 rounded-md border border-slate-300" {...register("birthDate")} />
-                  {errors.birthDate && <span className="text-xs text-rose-600">{errors.birthDate.message}</span>}
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-slate-500">Дата начала</label>
-                  <input type="date" className="px-3 py-2 rounded-md border border-slate-300" {...register("startDate")} />
-                  {errors.startDate && <span className="text-xs text-rose-600">{errors.startDate.message}</span>}
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-slate-500">Способ оплаты</label>
-                  <select className="px-3 py-2 rounded-md border border-slate-300" {...register("payMethod")}>
-                    <option>перевод</option><option>наличные</option>
-                  </select>
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-xs text-slate-500">Статус оплаты</label>
-                  <select className="px-3 py-2 rounded-md border border-slate-300" {...register("payStatus")}>
-                    <option>ожидание</option><option>действует</option><option>задолженность</option>
-                  </select>
-                </div>
-              </div>
-            <div className="flex justify-end gap-2">
-              <button type="button" onClick={() => { setModalOpen(false); setEditing(null); }} className="px-3 py-2 rounded-md border border-slate-300">Отмена</button>
-              <button type="submit" disabled={!isValid} className="px-3 py-2 rounded-md bg-sky-600 text-white disabled:bg-slate-400">Сохранить</button>
-            </div>
-          </form>
-        </Modal>
+        <ClientForm
+          db={db}
+          editing={editing}
+          onSave={saveClient}
+          onClose={() => { setModalOpen(false); setEditing(null); }}
+        />
       )}
     </div>
   );
 }
+

--- a/src/components/clients/ClientFilters.jsx
+++ b/src/components/clients/ClientFilters.jsx
@@ -1,0 +1,85 @@
+// @flow
+import React from "react";
+import type { DB, Area, Group, PaymentStatus } from "../../App";
+
+type Props = {
+  db: DB,
+  area: Area | "all",
+  setArea: (a: Area | "all") => void,
+  group: Group | "all",
+  setGroup: (g: Group | "all") => void,
+  pay: PaymentStatus | "all",
+  setPay: (p: PaymentStatus | "all") => void,
+  listLength: number,
+  onAddClient: () => void,
+};
+
+function Chip({ active, onClick, children }: { active?: boolean; onClick?: () => void; children: React.Node }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3 py-1 rounded-full border text-xs ${
+        active
+          ? "bg-sky-600 text-white border-sky-600"
+          : "bg-white text-slate-700 border-slate-300 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-700"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default function ClientFilters({
+  db,
+  area,
+  setArea,
+  group,
+  setGroup,
+  pay,
+  setPay,
+  listLength,
+  onAddClient,
+}: Props) {
+  return (
+    <>
+      <div className="flex flex-wrap gap-2 items-center">
+        <Chip active={area === "all"} onClick={() => setArea("all")}>Все районы</Chip>
+        {db.settings.areas.map(a => (
+          <Chip key={a} active={area === a} onClick={() => setArea(a)}>{a}</Chip>
+        ))}
+        <div className="flex-1" />
+        <button
+          onClick={onAddClient}
+          className="px-3 py-2 rounded-lg bg-sky-600 text-white text-sm hover:bg-sky-700"
+        >
+          + Добавить клиента
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-2 items-center">
+        <select
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={group}
+          onChange={e => setGroup(e.target.value)}
+        >
+          <option value="all">Все группы</option>
+          {db.settings.groups.map(g => (
+            <option key={g} value={g}>{g}</option>
+          ))}
+        </select>
+        <select
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={pay}
+          onChange={e => setPay(e.target.value)}
+        >
+          <option value="all">Все статусы оплаты</option>
+          <option value="ожидание">ожидание</option>
+          <option value="действует">действует</option>
+          <option value="задолженность">задолженность</option>
+        </select>
+        <div className="text-xs text-slate-500">Найдено: {listLength}</div>
+      </div>
+    </>
+  );
+}
+

--- a/src/components/clients/ClientForm.jsx
+++ b/src/components/clients/ClientForm.jsx
@@ -1,0 +1,158 @@
+// @flow
+import React, { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import Modal from "../Modal";
+import { todayISO } from "../../App";
+import type { DB, Client } from "../../App";
+
+type Props = {
+  db: DB,
+  editing: Client | null,
+  onSave: (data: any) => void,
+  onClose: () => void,
+};
+
+export default function ClientForm({ db, editing, onSave, onClose }: Props) {
+  const blankForm = () => ({
+    firstName: "",
+    lastName: "",
+    phone: "",
+    gender: "м",
+    area: db.settings.areas[0],
+    group: db.settings.groups[0],
+    channel: "Telegram",
+    startDate: todayISO().slice(0, 10),
+    payMethod: "перевод",
+    payStatus: "ожидание",
+    birthDate: "2017-01-01",
+    payDate: todayISO().slice(0, 10),
+    parentName: "",
+  });
+
+  const schema = yup.object({
+    firstName: yup.string().required("Имя обязательно"),
+    phone: yup.string().required("Телефон обязателен"),
+    birthDate: yup
+      .string()
+      .required("Дата рождения обязательна")
+      .matches(/\d{4}-\d{2}-\d{2}/, "Неверный формат даты"),
+    startDate: yup
+      .string()
+      .required("Дата начала обязательна")
+      .matches(/\d{4}-\d{2}-\d{2}/, "Неверный формат даты"),
+  });
+
+  const { register, handleSubmit, reset, formState: { errors, isValid } } = useForm({
+    resolver: yupResolver(schema),
+    mode: "onChange",
+    defaultValues: blankForm(),
+  });
+
+  useEffect(() => {
+    if (editing) {
+      reset({
+        ...editing,
+        birthDate: editing.birthDate?.slice(0, 10),
+        startDate: editing.startDate?.slice(0, 10),
+        payDate: editing.payDate?.slice(0, 10),
+      });
+    } else {
+      reset(blankForm());
+    }
+  }, [editing, reset, db.settings.areas, db.settings.groups]);
+
+  return (
+    <Modal size="xl" onClose={onClose}>
+      <div className="font-semibold text-slate-800">{editing ? "Редактирование клиента" : "Новый клиент"}</div>
+      <form onSubmit={handleSubmit(onSave)} className="space-y-3">
+        <div className="grid sm:grid-cols-2 gap-2">
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Имя</label>
+            <input className="px-3 py-2 rounded-md border border-slate-300" {...register("firstName")} />
+            {errors.firstName && <span className="text-xs text-rose-600">{errors.firstName.message}</span>}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Фамилия</label>
+            <input className="px-3 py-2 rounded-md border border-slate-300" {...register("lastName")} />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Телефон</label>
+            <input className="px-3 py-2 rounded-md border border-slate-300" {...register("phone")} />
+            {errors.phone && <span className="text-xs text-rose-600">{errors.phone.message}</span>}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Канал</label>
+            <select className="px-3 py-2 rounded-md border border-slate-300" {...register("channel")}>
+              <option>Telegram</option>
+              <option>WhatsApp</option>
+              <option>Instagram</option>
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Пол</label>
+            <select className="px-3 py-2 rounded-md border border-slate-300" {...register("gender")}>
+              <option value="м">м</option>
+              <option value="ж">ж</option>
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Район</label>
+            <select className="px-3 py-2 rounded-md border border-slate-300" {...register("area")}>
+              {db.settings.areas.map(a => (
+                <option key={a}>{a}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Группа</label>
+            <select className="px-3 py-2 rounded-md border border-slate-300" {...register("group")}>
+              {db.settings.groups.map(g => (
+                <option key={g}>{g}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Дата рождения</label>
+            <input type="date" className="px-3 py-2 rounded-md border border-slate-300" {...register("birthDate")} />
+            {errors.birthDate && <span className="text-xs text-rose-600">{errors.birthDate.message}</span>}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Дата начала</label>
+            <input type="date" className="px-3 py-2 rounded-md border border-slate-300" {...register("startDate")} />
+            {errors.startDate && <span className="text-xs text-rose-600">{errors.startDate.message}</span>}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Способ оплаты</label>
+            <select className="px-3 py-2 rounded-md border border-slate-300" {...register("payMethod")}>
+              <option>перевод</option>
+              <option>наличные</option>
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Статус оплаты</label>
+            <select className="px-3 py-2 rounded-md border border-slate-300" {...register("payStatus")}>
+              <option>ожидание</option>
+              <option>действует</option>
+              <option>задолженность</option>
+            </select>
+          </div>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300">
+            Отмена
+          </button>
+          <button
+            type="submit"
+            disabled={!isValid}
+            className="px-3 py-2 rounded-md bg-sky-600 text-white disabled:bg-slate-400"
+          >
+            Сохранить
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+

--- a/src/components/clients/ClientTable.jsx
+++ b/src/components/clients/ClientTable.jsx
@@ -1,0 +1,144 @@
+// @flow
+import React, { useState } from "react";
+import VirtualizedTable from "../VirtualizedTable";
+import Modal from "../Modal";
+import { fmtMoney, calcAgeYears, calcExperience } from "../../App";
+import type { Client, UIState } from "../../App";
+
+type Props = {
+  list: Client[],
+  ui: UIState,
+  onEdit: (c: Client) => void,
+  onRemove: (id: string) => void,
+};
+
+export default function ClientTable({ list, ui, onEdit, onRemove }: Props) {
+  const [selected, setSelected] = useState<Client | null>(null);
+
+  return (
+    <>
+      <VirtualizedTable
+        header={(
+          <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+            <tr>
+              <th className="text-left p-2">Имя</th>
+              <th className="text-left p-2">Телефон</th>
+              <th className="text-left p-2">Район</th>
+              <th className="text-left p-2">Группа</th>
+              <th className="text-left p-2">Статус оплаты</th>
+              <th className="text-left p-2">Сумма оплаты</th>
+              <th className="text-right p-2">Действия</th>
+            </tr>
+          </thead>
+        )}
+        items={list}
+        rowHeight={48}
+        renderRow={(c, style) => (
+          <tr key={c.id} style={style} className="border-t border-slate-100 dark:border-slate-700">
+            <td className="p-2 cursor-pointer" onClick={() => setSelected(c)}>
+              {c.firstName} {c.lastName}
+            </td>
+            <td className="p-2">{c.phone}</td>
+            <td className="p-2">{c.area}</td>
+            <td className="p-2">{c.group}</td>
+            <td className="p-2">
+              <span
+                className={`px-2 py-1 rounded-full text-xs ${
+                  c.payStatus === "действует"
+                    ? "bg-emerald-100 text-emerald-700"
+                    : c.payStatus === "задолженность"
+                    ? "bg-rose-100 text-rose-700"
+                    : "bg-amber-100 text-amber-700"
+                }`}
+              >
+                {c.payStatus}
+              </span>
+            </td>
+            <td className="p-2">{c.payAmount != null ? fmtMoney(c.payAmount, ui.currency) : "—"}</td>
+            <td className="p-2 text-right">
+              <button
+                onClick={() => onEdit(c)}
+                className="px-2 py-1 text-xs rounded-md border border-slate-300 mr-1 dark:border-slate-700 dark:bg-slate-800"
+              >
+                Редактировать
+              </button>
+              <button
+                onClick={() => onRemove(c.id)}
+                className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30"
+              >
+                Удалить
+              </button>
+            </td>
+          </tr>
+        )}
+      />
+
+      {selected && (
+        <Modal size="md" onClose={() => setSelected(null)}>
+          <div className="font-semibold text-slate-800">
+            {selected.firstName} {selected.lastName}
+          </div>
+          <div className="grid gap-1 text-sm">
+            <div>
+              <span className="text-slate-500">Телефон:</span> {selected.phone || "—"}
+            </div>
+            <div>
+              <span className="text-slate-500">Канал:</span> {selected.channel}
+            </div>
+            <div>
+              <span className="text-slate-500">Родитель:</span> {selected.parentName || "—"}
+            </div>
+            <div>
+              <span className="text-slate-500">Дата рождения:</span> {selected.birthDate?.slice(0, 10)}
+            </div>
+            <div>
+              <span className="text-slate-500">Возраст:</span> {selected.birthDate ? `${calcAgeYears(selected.birthDate)} лет` : "—"}
+            </div>
+            <div>
+              <span className="text-slate-500">Район:</span> {selected.area}
+            </div>
+            <div>
+              <span className="text-slate-500">Группа:</span> {selected.group}
+            </div>
+            <div>
+              <span className="text-slate-500">Опыт:</span> {selected.startDate ? calcExperience(selected.startDate) : "—"}
+            </div>
+            <div>
+              <span className="text-slate-500">Статус оплаты:</span> {selected.payStatus}
+            </div>
+            <div>
+              <span className="text-slate-500">Дата оплаты:</span> {selected.payDate?.slice(0, 10) || "—"}
+            </div>
+            <div>
+              <span className="text-slate-500">Сумма оплаты:</span> {selected.payAmount != null ? fmtMoney(selected.payAmount, ui.currency) : "—"}
+            </div>
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={() => {
+                onEdit(selected);
+                setSelected(null);
+              }}
+              className="px-3 py-2 rounded-md border border-slate-300"
+            >
+              Редактировать
+            </button>
+            <button
+              onClick={() => {
+                onRemove(selected.id);
+                setSelected(null);
+              }}
+              className="px-3 py-2 rounded-md border border-rose-200 text-rose-600"
+            >
+              Удалить
+            </button>
+            <button onClick={() => setSelected(null)} className="px-3 py-2 rounded-md border border-slate-300">
+              Закрыть
+            </button>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extract client filters, table, and form into dedicated subcomponents
- simplify ClientsTab to orchestrate new components and state
- guard against missing start date when showing client experience
- fix helper imports by referencing App module without extension

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6ae7d8b24832b8dac3561261de35b