### PR TITLE
fix: point client components to appState utilities

### DIFF
--- a/src/components/ClientsTab.jsx
+++ b/src/components/ClientsTab.jsx
@@ -4,8 +4,8 @@ import Breadcrumbs from "./Breadcrumbs";
 import ClientFilters from "./clients/ClientFilters";
 import ClientTable from "./clients/ClientTable";
 import ClientForm from "./clients/ClientForm";
-import { uid, todayISO, parseDateInput, saveDB } from "../App";
-import type { DB, UIState, Client, Area, Group, PaymentStatus } from "../App";
+import { uid, todayISO, parseDateInput, saveDB } from "../state/appState";
+import type { DB, UIState, Client, Area, Group, PaymentStatus } from "../types";
 
 
 export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) => void; ui: UIState }) {

--- a/src/components/__tests__/ClientsTab.test.jsx
+++ b/src/components/__tests__/ClientsTab.test.jsx
@@ -9,7 +9,7 @@ jest.mock('react-window', () => ({
   ),
 }), { virtual: true });
 
-jest.mock('../../App.jsx', () => ({
+jest.mock('../../state/appState', () => ({
   __esModule: true,
   uid: jest.fn(),
   todayISO: jest.fn(),
@@ -19,7 +19,7 @@ jest.mock('../../App.jsx', () => ({
 }));
 
 import ClientsTab from '../ClientsTab';
-import { uid, todayISO, saveDB, parseDateInput, fmtMoney } from '../../App.jsx';
+import { uid, todayISO, saveDB, parseDateInput, fmtMoney } from '../../state/appState';
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/src/components/clients/ClientFilters.jsx
+++ b/src/components/clients/ClientFilters.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React from "react";
-import type { DB, Area, Group, PaymentStatus } from "../../App";
+import type { DB, Area, Group, PaymentStatus } from "../../types";
 
 type Props = {
   db: DB,

--- a/src/components/clients/ClientForm.jsx
+++ b/src/components/clients/ClientForm.jsx
@@ -4,8 +4,8 @@ import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import Modal from "../Modal";
-import { todayISO } from "../../App";
-import type { DB, Client } from "../../App";
+import { todayISO } from "../../state/appState";
+import type { DB, Client } from "../../types";
 
 type Props = {
   db: DB,

--- a/src/components/clients/ClientTable.jsx
+++ b/src/components/clients/ClientTable.jsx
@@ -2,8 +2,8 @@
 import React, { useState } from "react";
 import VirtualizedTable from "../VirtualizedTable";
 import Modal from "../Modal";
-import { fmtMoney, calcAgeYears, calcExperience } from "../../App";
-import type { Client, UIState } from "../../App";
+import { fmtMoney, calcAgeYears, calcExperience } from "../../state/appState";
+import type { Client, UIState } from "../../types";
 
 type Props = {
   list: Client[],


### PR DESCRIPTION
## Summary
- adjust client-related components and tests to import utilities from `state/appState`
- import shared types from `types` instead of `App`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68c6d6b777c4832b8c20b098661811d8