### PR TITLE
Fix node version in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.19.0.
+          node-version: 22.19.0
           cache: 'npm'
 
       - run: npm ci                 # установка зависимостей из package-lock.json


### PR DESCRIPTION
## Summary
- fix node version specification in CI workflow to valid 22.19.0

## Testing
- `npm ci` (fails: could not resolve dependency)
- `npm test -- --watchAll=false` (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_68c6dc19b7c0832ba2b114d13771553d