### PR TITLE
chore: target ES2020 for TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES2020",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- compile TypeScript to ES2020 instead of the outdated ES5

## Testing
- `CI=true npm test -- --watchAll=false`
- `CI=true npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6dc1a181c832b9a12c018732d54a2