### PR TITLE
chore: target ES2020 for TypeScript

### DIFF
--- a/src/components/ClientsTab.jsx
+++ b/src/components/ClientsTab.jsx
@@ -70,7 +70,7 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
   };
 
   const removeClient = (id: string) => {
-    if (!confirm("Удалить клиента?")) return;
+    if (!window.confirm("Удалить клиента?")) return;
     const next = {
       ...db,
       clients: db.clients.filter(c => c.id !== id),

--- a/src/components/LeadsTab.jsx
+++ b/src/components/LeadsTab.jsx
@@ -112,7 +112,7 @@ function LeadModal(
   };
 
   const remove = () => {
-    if (!confirm("Удалить лид?")) return;
+    if (!window.confirm("Удалить лид?")) return;
     const next = {
       ...db,
       leads: db.leads.filter(l => l.id !== lead.id),

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -32,7 +32,7 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
     setDB(next); saveDB(next);
   };
   const deleteArea = (name: string) => {
-    if (!confirm(`Удалить район ${name}?`)) return;
+    if (!window.confirm(`Удалить район ${name}?`)) return;
     const next = {
       ...db,
       settings: { ...db.settings, areas: db.settings.areas.filter(a => a !== name) },
@@ -81,7 +81,7 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
     setDB(next); saveDB(next);
   };
   const deleteSlot = (id: string) => {
-    if (!confirm("Удалить группу?")) return;
+    if (!window.confirm("Удалить группу?")) return;
     const next = { ...db, schedule: db.schedule.filter(x => x.id !== id) };
     setDB(next); saveDB(next);
   };

--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -22,7 +22,7 @@ export default function TasksTab({ db, setDB }: { db: DB; setDB: (db: DB) => voi
     setDB(next); saveDB(next);
   };
   const remove = (id: string) => {
-    if (!confirm("Удалить задачу?")) return;
+    if (!window.confirm("Удалить задачу?")) return;
     const next = { ...db, tasks: db.tasks.filter(t => t.id !== id) };
     setDB(next); saveDB(next);
   };

--- a/src/components/__tests__/ClientsTab.test.jsx
+++ b/src/components/__tests__/ClientsTab.test.jsx
@@ -27,7 +27,7 @@ beforeEach(() => {
   todayISO.mockReturnValue('2024-01-01T00:00:00.000Z');
   parseDateInput.mockImplementation((v) => (v ? v + 'T00:00:00.000Z' : ''));
   fmtMoney.mockImplementation((v, c) => v + ' ' + c);
-  global.confirm = jest.fn(() => true);
+  window.confirm = jest.fn(() => true);
 });
 
 const makeDB = () => ({
@@ -174,7 +174,7 @@ test('delete: removes client after confirmation', async () => {
 
   await userEvent.click(screen.getByText('Удалить'));
 
-  expect(global.confirm).toHaveBeenCalled();
+  expect(window.confirm).toHaveBeenCalled();
   await waitFor(() => expect(screen.queryByText('Del')).not.toBeInTheDocument());
   expect(getDB().clients.find(c => c.id === 'c1')).toBeUndefined();
 });

--- a/src/components/__tests__/LeadsTab.test.jsx
+++ b/src/components/__tests__/LeadsTab.test.jsx
@@ -22,7 +22,7 @@ import { todayISO, uid, saveDB } from '../../state/appState';
 
 beforeEach(() => {
   jest.clearAllMocks();
-  global.confirm = jest.fn(() => true);
+  window.confirm = jest.fn(() => true);
   global.prompt = jest.fn();
 });
 
@@ -153,7 +153,7 @@ test('delete: removes lead from list', async () => {
   const { getDB } = renderLeads();
   await userEvent.click(screen.getByRole('button', { name: 'Лид2' }));
   await userEvent.click(screen.getByText('Удалить'));
-  expect(global.confirm).toHaveBeenCalled();
+  expect(window.confirm).toHaveBeenCalled();
   await waitFor(() => expect(getDB().leads.find(l => l.id === 'l2')).toBeUndefined());
   expect(screen.queryByText('Лид2')).not.toBeInTheDocument();
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES2020",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- compile TypeScript to ES2020 instead of the outdated ES5
- fix ESLint complaints by using `window.confirm` in deletion handlers and tests

## Testing
- `CI=true npm test -- --watchAll=false`
- `CI=true npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6dc1a181c832b9a12c018732d54a2