### PR TITLE
Add placeholder Appeals page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,10 +5,11 @@ import Tabs from "./components/Tabs";
 import Dashboard from "./components/Dashboard";
 import ClientsTab from "./components/ClientsTab";
 import AttendanceTab from "./components/AttendanceTab";
+import TasksTab from "./components/TasksTab";
 import ScheduleTab from "./components/ScheduleTab";
 import LeadsTab from "./components/LeadsTab";
-import TasksTab from "./components/TasksTab";
 import SettingsTab from "./components/SettingsTab";
+import AppealsTab from "./components/AppealsTab";
 import QuickAddModal from "./components/QuickAddModal";
 import Toasts from "./components/Toasts";
 import ErrorBoundary from "./components/ErrorBoundary";
@@ -61,6 +62,16 @@ export default function App() {
               }
             />
             <Route
+              path="/tasks"
+              element={
+                can(ui.role, "tasks") ? (
+                  <TasksTab db={db} setDB={setDB} />
+                ) : (
+                  <Navigate to="/dashboard" replace />
+                )
+              }
+            />
+            <Route
               path="/schedule"
               element={
                 can(ui.role, "schedule") ? (
@@ -81,10 +92,10 @@ export default function App() {
               }
             />
             <Route
-              path="/tasks"
+              path="/appeals"
               element={
-                can(ui.role, "tasks") ? (
-                  <TasksTab db={db} setDB={setDB} />
+                can(ui.role, "appeals") ? (
+                  <AppealsTab />
                 ) : (
                   <Navigate to="/dashboard" replace />
                 )

--- a/src/components/AppealsTab.jsx
+++ b/src/components/AppealsTab.jsx
@@ -1,0 +1,14 @@
+// @flow
+import React from "react";
+import Breadcrumbs from "./Breadcrumbs";
+
+export default function AppealsTab() {
+  return (
+    <div className="space-y-3">
+      <Breadcrumbs items={["Обращения"]} />
+      <div className="p-3 rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
+        В этом разделе появится чат с клиентами.
+      </div>
+    </div>
+  );
+}

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -12,9 +12,10 @@ const TABS: TabConfig[] = [
   { key: "dashboard", title: "Дашборд" },
   { key: "clients", title: "Клиенты", need: r => can(r, "manage_clients") },
   { key: "attendance", title: "Посещаемость", need: r => can(r, "attendance") },
+  { key: "tasks", title: "Задачи", need: r => can(r, "tasks") },
   { key: "schedule", title: "Расписание", need: r => can(r, "schedule") },
   { key: "leads", title: "Лиды", need: r => can(r, "leads") },
-  { key: "tasks", title: "Задачи", need: r => can(r, "tasks") },
+  { key: "appeals", title: "Обращения", need: r => can(r, "appeals") },
   { key: "settings", title: "Настройки", need: r => can(r, "settings") },
 ];
 

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -268,11 +268,12 @@ export function can(
     | "schedule"
     | "leads"
     | "tasks"
+    | "appeals"
     | "settings",
 ) {
   if (role === "Администратор") return true;
   if (role === "Менеджер") {
-    return ["manage_clients", "leads", "tasks", "attendance", "schedule"].includes(
+    return ["manage_clients", "leads", "tasks", "attendance", "schedule", "appeals"].includes(
       feature,
     );
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,9 +126,10 @@ export type TabKey =
   | "dashboard"
   | "clients"
   | "attendance"
+  | "tasks"
   | "schedule"
   | "leads"
-  | "tasks"
+  | "appeals"
   | "settings";
 
 export type Toast = { id: string; text: string; type?: "success" | "error" | "info" };


### PR DESCRIPTION
## Summary
- add placeholder page for client communications
- wire new Appeals tab with routing and permissions
- reorder top navigation tabs per feedback

## Testing
- `npm install --legacy-peer-deps`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c70c8373c8832bb144caea56f84fe3