### PR TITLE
feat: store app state in Firestore

### DIFF
--- a/src/components/AttendanceTab.jsx
+++ b/src/components/AttendanceTab.jsx
@@ -25,16 +25,16 @@ export default function AttendanceTab({ db, setDB }: { db: DB; setDB: (db: DB) =
     return map;
   }, [db.attendance, todayStr]);
 
-  const toggle = (clientId: string) => {
+  const toggle = async (clientId: string) => {
     const mark = todayMarks.get(clientId);
     if (mark) {
       const updated = { ...mark, came: !mark.came };
       const next = { ...db, attendance: db.attendance.map(a => a.id === mark.id ? updated : a) };
-      setDB(next); saveDB(next);
+      setDB(next); await saveDB(next);
     } else {
       const entry: AttendanceEntry = { id: uid(), clientId, date: new Date().toISOString(), came: true };
       const next = { ...db, attendance: [entry, ...db.attendance] };
-      setDB(next); saveDB(next);
+      setDB(next); await saveDB(next);
     }
   };
 

--- a/src/components/ClientsTab.jsx
+++ b/src/components/ClientsTab.jsx
@@ -36,7 +36,7 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
     setModalOpen(true);
   };
 
-  const saveClient = (data: any) => {
+  const saveClient = async (data: any) => {
     const prepared = {
       ...data,
       birthDate: parseDateInput(data.birthDate),
@@ -50,7 +50,7 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
         clients: db.clients.map(cl => (cl.id === editing.id ? updated : cl)),
         changelog: [...db.changelog, { id: uid(), who: "UI", what: `Обновлён клиент ${updated.firstName}`, when: todayISO() }],
       };
-      setDB(next); saveDB(next);
+      setDB(next); await saveDB(next);
     } else {
       const c: Client = {
         id: uid(),
@@ -63,20 +63,20 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
         clients: [c, ...db.clients],
         changelog: [...db.changelog, { id: uid(), who: "UI", what: `Создан клиент ${c.firstName}`, when: todayISO() }],
       };
-      setDB(next); saveDB(next);
+      setDB(next); await saveDB(next);
     }
     setModalOpen(false);
     setEditing(null);
   };
 
-  const removeClient = (id: string) => {
+  const removeClient = async (id: string) => {
     if (!window.confirm("Удалить клиента?")) return;
     const next = {
       ...db,
       clients: db.clients.filter(c => c.id !== id),
       changelog: [...db.changelog, { id: uid(), who: "UI", what: `Удалён клиент ${id}`, when: todayISO() }],
     };
-    setDB(next); saveDB(next);
+    setDB(next); await saveDB(next);
   };
 
   return (

--- a/src/components/LeadsTab.jsx
+++ b/src/components/LeadsTab.jsx
@@ -17,12 +17,12 @@ export default function LeadsTab({ db, setDB }: { db: DB; setDB: (db: DB) => voi
       if (acc[l.stage]) acc[l.stage].push(l); else acc[l.stage] = [l];
       return acc;
     }, {}), [db.leads]);
-  const move = (id: string, dir: 1 | -1) => {
+  const move = async (id: string, dir: 1 | -1) => {
     const l = db.leads.find(x => x.id === id); if (!l) return;
     const idx = stages.indexOf(l.stage);
     const nextStage = stages[Math.min(stages.length - 1, Math.max(0, idx + dir))];
     const next = { ...db, leads: db.leads.map(x => x.id === id ? { ...x, stage: nextStage, updatedAt: todayISO() } : x) };
-    setDB(next); saveDB(next);
+    setDB(next); await saveDB(next);
   };
   return (
     <div className="space-y-3">
@@ -101,24 +101,24 @@ function LeadModal(
 
   useEffect(() => reset(lead), [lead, reset]);
 
-  const save = (data: any) => {
+  const save = async (data: any) => {
     const nextLead: Lead = { ...lead, ...data, updatedAt: todayISO() };
     const next = {
       ...db,
       leads: db.leads.map(l => (l.id === lead.id ? nextLead : l)),
       changelog: [...db.changelog, { id: uid(), who: "UI", what: `Обновлён лид ${nextLead.name}`, when: todayISO() }],
     };
-    setDB(next); saveDB(next); setEdit(false); onClose();
+    setDB(next); await saveDB(next); setEdit(false); onClose();
   };
 
-  const remove = () => {
+  const remove = async () => {
     if (!window.confirm("Удалить лид?")) return;
     const next = {
       ...db,
       leads: db.leads.filter(l => l.id !== lead.id),
       changelog: [...db.changelog, { id: uid(), who: "UI", what: `Удалён лид ${lead.id}`, when: todayISO() }],
     };
-    setDB(next); saveDB(next); onClose();
+    setDB(next); await saveDB(next); onClose();
   };
 
   return (

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -14,14 +14,14 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
     return m;
   }, [db.schedule, db.settings.areas]);
 
-  const addArea = () => {
+  const addArea = async () => {
     const name = prompt("Название района");
     if (!name) return;
     if (db.settings.areas.includes(name)) return;
     const next = { ...db, settings: { ...db.settings, areas: [...db.settings.areas, name] } };
-    setDB(next); saveDB(next);
+    setDB(next); await saveDB(next);
   };
-  const renameArea = (oldName: string) => {
+  const renameArea = async (oldName: string) => {
     const name = prompt("Новое название района", oldName);
     if (!name || name === oldName) return;
     const next = {
@@ -29,16 +29,16 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
       settings: { ...db.settings, areas: db.settings.areas.map(a => a === oldName ? name : a) },
       schedule: db.schedule.map(s => s.area === oldName ? { ...s, area: name } : s),
     };
-    setDB(next); saveDB(next);
+    setDB(next); await saveDB(next);
   };
-  const deleteArea = (name: string) => {
+  const deleteArea = async (name: string) => {
     if (!window.confirm(`Удалить район ${name}?`)) return;
     const next = {
       ...db,
       settings: { ...db.settings, areas: db.settings.areas.filter(a => a !== name) },
       schedule: db.schedule.filter(s => s.area !== name),
     };
-    setDB(next); saveDB(next);
+    setDB(next); await saveDB(next);
   };
 
   const pickGroup = (init: string) => {
@@ -49,7 +49,7 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
     if (!isNaN(idx) && idx >= 1 && idx <= db.settings.groups.length) return db.settings.groups[idx - 1];
     return raw;
   };
-  const addSlot = (area: string) => {
+  const addSlot = async (area: string) => {
     const weekday = parseInt(prompt("День недели (1-Пн … 7-Вс)", "1") || "", 10);
     const time = prompt("Время (HH:MM)", "10:00") || "";
     const group = pickGroup(db.settings.groups[0] || "");
@@ -62,9 +62,9 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
         ? db.settings
         : { ...db.settings, groups: [...db.settings.groups, group] },
     };
-    setDB(next); saveDB(next);
+    setDB(next); await saveDB(next);
   };
-  const editSlot = (id: string) => {
+  const editSlot = async (id: string) => {
     const s = db.schedule.find(x => x.id === id);
     if (!s) return;
     const weekday = parseInt(prompt("День недели (1-Пн … 7-Вс)", String(s.weekday)) || "", 10);
@@ -78,12 +78,12 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
         ? db.settings
         : { ...db.settings, groups: [...db.settings.groups, group] },
     };
-    setDB(next); saveDB(next);
+    setDB(next); await saveDB(next);
   };
-  const deleteSlot = (id: string) => {
+  const deleteSlot = async (id: string) => {
     if (!window.confirm("Удалить группу?")) return;
     const next = { ...db, schedule: db.schedule.filter(x => x.id !== id) };
-    setDB(next); saveDB(next);
+    setDB(next); await saveDB(next);
   };
 
   return (

--- a/src/components/SettingsTab.jsx
+++ b/src/components/SettingsTab.jsx
@@ -39,7 +39,7 @@ export default function SettingsTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
           },
         };
         setDB(nextDB);
-        saveDB(nextDB);
+        await saveDB(nextDB);
       } catch (e) {
         console.error(e);
       }
@@ -96,9 +96,9 @@ export default function SettingsTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
                       min={0}
                       className="w-24 px-2 py-1 rounded-md border border-slate-300 bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
                       value={db.settings.limits[key]}
-                      onChange={e => {
+                      onChange={async e => {
                         const next = { ...db, settings: { ...db.settings, limits: { ...db.settings.limits, [key]: Number(e.target.value) } } };
-                        setDB(next); saveDB(next);
+                        setDB(next); await saveDB(next);
                       }}
                     />
                   </div>

--- a/src/components/TasksTab.jsx
+++ b/src/components/TasksTab.jsx
@@ -7,24 +7,24 @@ import type { DB, TaskItem } from "../types";
 
 export default function TasksTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
   const [edit, setEdit] = useState<TaskItem | null>(null);
-  const toggle = (id: string) => {
+  const toggle = async (id: string) => {
     const next = { ...db, tasks: db.tasks.map(t => t.id === id ? { ...t, status: t.status === "open" ? "done" : "open" } : t) };
-    setDB(next); saveDB(next);
+    setDB(next); await saveDB(next);
   };
-  const save = () => {
+  const save = async () => {
     if (!edit) return;
     const next = { ...db, tasks: db.tasks.map(t => t.id === edit.id ? edit : t) };
-    setDB(next); saveDB(next); setEdit(null);
+    setDB(next); await saveDB(next); setEdit(null);
   };
-  const add = () => {
+  const add = async () => {
     const t: TaskItem = { id: uid(), title: "Новая задача", due: todayISO(), status: "open" };
     const next = { ...db, tasks: [t, ...db.tasks] };
-    setDB(next); saveDB(next);
+    setDB(next); await saveDB(next);
   };
-  const remove = (id: string) => {
+  const remove = async (id: string) => {
     if (!window.confirm("Удалить задачу?")) return;
     const next = { ...db, tasks: db.tasks.filter(t => t.id !== id) };
-    setDB(next); saveDB(next);
+    setDB(next); await saveDB(next);
   };
   return (
     <div className="space-y-3">

--- a/src/components/__tests__/ClientsTab.test.jsx
+++ b/src/components/__tests__/ClientsTab.test.jsx
@@ -13,7 +13,7 @@ jest.mock('../../state/appState', () => ({
   __esModule: true,
   uid: jest.fn(),
   todayISO: jest.fn(),
-  saveDB: jest.fn(),
+  saveDB: jest.fn().mockResolvedValue(undefined),
   parseDateInput: jest.fn(),
   fmtMoney: jest.fn(),
 }));

--- a/src/components/__tests__/LeadsTab.test.jsx
+++ b/src/components/__tests__/LeadsTab.test.jsx
@@ -12,7 +12,7 @@ jest.mock('react-window', () => ({
 jest.mock('../../state/appState', () => ({
   todayISO: jest.fn(() => '2024-01-01T00:00:00.000Z'),
   uid: jest.fn(() => 'uid-123'),
-  saveDB: jest.fn(),
+  saveDB: jest.fn().mockResolvedValue(undefined),
   fmtDate: (iso) => iso,
 }));
 
@@ -95,7 +95,7 @@ test('create: adds new lead via modal', async () => {
     const [state, setState] = React.useState(db);
     const [open, setOpen] = React.useState(true);
     const setDB = (next) => { current = next; setState(next); };
-    const addLead = () => {
+  const addLead = async () => {
       const l = {
         id: uid(),
         name: 'Новый лид',
@@ -114,7 +114,7 @@ test('create: adds new lead via modal', async () => {
       };
       const next = { ...state, leads: [l, ...state.leads] };
       setDB(next);
-      saveDB(next);
+      await saveDB(next);
       setOpen(false);
     };
     return (

--- a/src/components/__tests__/ScheduleTab.groups.test.jsx
+++ b/src/components/__tests__/ScheduleTab.groups.test.jsx
@@ -6,7 +6,7 @@ import "@testing-library/jest-dom";
 
 jest.mock("../../state/appState", () => ({
   uid: () => "test-id",
-  saveDB: jest.fn(),
+  saveDB: jest.fn().mockResolvedValue(undefined),
   todayISO: () => new Date().toISOString(),
   parseDateInput: (s) => s,
   fmtMoney: (v) => String(v),

--- a/src/components/__tests__/ScheduleTab.test.jsx
+++ b/src/components/__tests__/ScheduleTab.test.jsx
@@ -7,7 +7,7 @@ import '@testing-library/jest-dom';
 
 jest.mock('../../state/appState', () => ({
   uid: () => 'id-1',
-  saveDB: jest.fn(),
+  saveDB: jest.fn().mockResolvedValue(undefined),
   todayISO: () => new Date().toISOString(),
   parseDateInput: (s) => s,
   fmtMoney: (v) => String(v),

--- a/src/components/__tests__/TasksTab.test.jsx
+++ b/src/components/__tests__/TasksTab.test.jsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom';
 jest.mock('../../state/appState', () => ({
   fmtDate: (iso) => new Intl.DateTimeFormat('ru-RU').format(new Date(iso)),
   uid: () => 'uid',
-  saveDB: () => {},
+  saveDB: jest.fn().mockResolvedValue(undefined),
   todayISO: () => '2025-01-01T00:00:00.000Z'
 }));
 import TasksTab from '../TasksTab';
@@ -26,7 +26,6 @@ describe('TasksTab CRUD operations', () => {
 
   beforeEach(() => {
     window.confirm = jest.fn(() => true);
-    localStorage.clear();
   });
 
   test('Read: renders initial tasks', () => {

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,0 +1,11 @@
+import { initializeApp } from "firebase/app";
+import { getFirestore } from "firebase/firestore";
+
+const firebaseConfig = {
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY || "demo",
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN || "demo.firebaseapp.com",
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID || "demo",
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);


### PR DESCRIPTION
## Summary
- persist DB state in Firestore and listen for real-time updates
- switch components to await async saves
- mock Firestore in unit tests

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71ada55cc832bbdb29897ac97bae2