### PR TITLE
Add Firebase keys to example environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,21 @@
 # Example environment configuration
 DISABLE_ESLINT_PLUGIN=true
 API_URL=http://localhost:3000
+
+# Firebase API key
+FIREBASE_API_KEY=
+
+# Firebase authentication domain
+FIREBASE_AUTH_DOMAIN=
+
+# Firebase project identifier
+FIREBASE_PROJECT_ID=
+
+# Firebase storage bucket
+FIREBASE_STORAGE_BUCKET=
+
+# Firebase messaging sender ID
+FIREBASE_MESSAGING_SENDER_ID=
+
+# Firebase application ID
+FIREBASE_APP_ID=


### PR DESCRIPTION
## Summary
- document Firebase environment variables in `.env.example`

## Testing
- `npm install --legacy-peer-deps`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71adb0168832b88e82cb49477aec1