### PR TITLE
guard firebase initialization

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,11 +1,17 @@
+import type { FirebaseApp, FirebaseOptions } from "firebase/app";
 import { initializeApp } from "firebase/app";
-import { getFirestore } from "firebase/firestore";
+import { getFirestore, type Firestore } from "firebase/firestore";
 
-const firebaseConfig = {
-  apiKey: process.env.REACT_APP_FIREBASE_API_KEY || "demo",
-  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN || "demo.firebaseapp.com",
-  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID || "demo",
+const firebaseConfig: FirebaseOptions = {
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_FIREBASE_APP_ID,
 };
+const app: FirebaseApp | undefined = Object.values(firebaseConfig).every(Boolean)
+  ? initializeApp(firebaseConfig)
+  : (console.warn("Firebase configuration is incomplete. Skipping initialization."), undefined);
 
-const app = initializeApp(firebaseConfig);
-export const db = getFirestore(app);
+export const db: Firestore | null = app ? getFirestore(app) : null;


### PR DESCRIPTION
## Summary
- build Firebase config solely from environment variables
- skip Firebase initialization when config is incomplete and export `null`

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71fc176bc832bab81d3c5ec5e4421