### PR TITLE
Fix Firestore saveDB and db export

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -14,3 +14,5 @@ const firebaseConfig: FirebaseOptions = {
 const app: FirebaseApp | undefined = Object.values(firebaseConfig).every(Boolean)
   ? initializeApp(firebaseConfig)
   : (console.warn("Firebase configuration is incomplete. Skipping initialization."), undefined);
+
+export const db: Firestore | undefined = app ? getFirestore(app) : undefined;

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -3,7 +3,7 @@ import { useLocation } from "react-router-dom";
 import { TAB_TITLES } from "../components/Tabs";
 import { useToasts } from "../components/Toasts";
 import { doc, onSnapshot, setDoc } from "firebase/firestore";
-import { db as fs } from "../firebase";
+import { db } from "../firebase";
 import type {
   DB,
   UIState,
@@ -237,10 +237,10 @@ export function makeSeedDB(): DB {
   };
 }
 
-export function saveDB(db: DB) {
+export async function saveDB(data: DB) {
   const ref = doc(fs, "app", "main");
   try {
-    await setDoc(ref, db);
+    await setDoc(ref, data);
   } catch (err) {
     console.error("Failed to save DB", err);
     throw err;


### PR DESCRIPTION
## Summary
- Export Firestore database instance for reuse
- Make saveDB asynchronous and ensure it uses Firestore reference

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72ba1a8a0832b8e0346502368c506