### PR TITLE
refactor: export firestore db instance

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,6 @@
 import type { FirebaseApp, FirebaseOptions } from "firebase/app";
 import { initializeApp } from "firebase/app";
-import { getFirestore, type Firestore } from "firebase/firestore";
+import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig: FirebaseOptions = {
 
@@ -15,4 +15,4 @@ const app: FirebaseApp | undefined = Object.values(firebaseConfig).every(Boolean
   ? initializeApp(firebaseConfig)
   : (console.warn("Firebase configuration is incomplete. Skipping initialization."), undefined);
 
-export const db: Firestore | undefined = app ? getFirestore(app) : undefined;
+export const db = app ? getFirestore(app) : undefined;


### PR DESCRIPTION
## Summary
- export Firestore `db` instance with conditional initialization
- clean up unused Firestore type import

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7cfb2a764832b89815db52d3e4479