### PR TITLE
Add Firestore initialization guard

### DIFF
--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -3,7 +3,7 @@ import { useLocation } from "react-router-dom";
 import { TAB_TITLES } from "../components/Tabs";
 import { useToasts } from "../components/Toasts";
 import { doc, onSnapshot, setDoc } from "firebase/firestore";
-import { db } from "../firebase";
+import { db as firestore } from "../firebase";
 import type {
   DB,
   UIState,
@@ -23,7 +23,6 @@ import type {
   TabKey,
 } from "../types";
 
-const fs = db;
 
 export const LS_KEYS = {
   ui: "judo_crm_ui_v1",
@@ -238,7 +237,8 @@ export function makeSeedDB(): DB {
 }
 
 export async function saveDB(data: DB) {
-  if (!fs) return;
+  const fs = firestore;
+  if (!fs) throw new Error("Firestore is not initialized");
   const ref = doc(fs, "app", "main");
   try {
     await setDoc(ref, data);
@@ -340,7 +340,11 @@ export function useAppState() {
   }, [ui.theme]);
 
   useEffect(() => {
-    if (!fs) return;
+    const fs = firestore;
+    if (!fs) {
+      console.error("Firestore is not initialized");
+      return;
+    }
     const ref = doc(fs, "app", "main");
     let unsub = () => {};
     try {


### PR DESCRIPTION
## Summary
- import Firestore database from shared `firebase` module
- ensure Firestore is initialized before accessing it

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c7cfb2b8b0832b80d3accecc2f43fc