### PR TITLE
fix: use firestore export and type saveDB

### DIFF
--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -3,7 +3,7 @@ import { useLocation } from "react-router-dom";
 import { TAB_TITLES } from "../components/Tabs";
 import { useToasts } from "../components/Toasts";
 import { doc, onSnapshot, setDoc } from "firebase/firestore";
-import { db } from "../firebase";
+import { db as firestore } from "../firebase";
 import type {
   DB,
   UIState,
@@ -23,7 +23,6 @@ import type {
   TabKey,
 } from "../types";
 
-const fs = db;
 
 export const LS_KEYS = {
   ui: "judo_crm_ui_v1",
@@ -237,11 +236,11 @@ export function makeSeedDB(): DB {
   };
 }
 
-export async function saveDB(data: DB) {
-  if (!fs) return;
-  const ref = doc(fs, "app", "main");
+export async function saveDB(db: DB): Promise<void> {
+  if (!firestore) return;
+  const ref = doc(firestore, "app", "main");
   try {
-    await setDoc(ref, data);
+    await setDoc(ref, db);
   } catch (err) {
     console.error("Failed to save DB", err);
     throw err;
@@ -340,8 +339,8 @@ export function useAppState() {
   }, [ui.theme]);
 
   useEffect(() => {
-    if (!fs) return;
-    const ref = doc(fs, "app", "main");
+    if (!firestore) return;
+    const ref = doc(firestore, "app", "main");
     let unsub = () => {};
     try {
       unsub = onSnapshot(ref, async snap => {


### PR DESCRIPTION
## Summary
- import Firestore instance as `firestore` and reference consistently
- define `saveDB(db: DB)` and use Firestore to persist data

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definitions for react)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cfb39d0c832b868b09975edaff16