### PR TITLE
log warning when firestore missing

### DIFF
--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -23,7 +23,7 @@ import type {
   TabKey,
 } from "../types";
 
-const fs = db;
+const firestore = db;
 
 export const LS_KEYS = {
   ui: "judo_crm_ui_v1",
@@ -238,8 +238,11 @@ export function makeSeedDB(): DB {
 }
 
 export async function saveDB(data: DB) {
-  if (!fs) return;
-  const ref = doc(fs, "app", "main");
+  if (!firestore) {
+    console.warn("Firestore not initialized");
+    return;
+  }
+  const ref = doc(firestore, "app", "main");
   try {
     await setDoc(ref, data);
   } catch (err) {
@@ -340,8 +343,12 @@ export function useAppState() {
   }, [ui.theme]);
 
   useEffect(() => {
-    if (!fs) return;
-    const ref = doc(fs, "app", "main");
+    if (!firestore) {
+      console.warn("Firestore not initialized");
+      push("Нет подключения к базе данных", "error");
+      return;
+    }
+    const ref = doc(firestore, "app", "main");
     let unsub = () => {};
     try {
       unsub = onSnapshot(ref, async snap => {


### PR DESCRIPTION
## Summary
- warn when Firestore instance is missing before saving data
- notify user with toast and console warning if Firestore is unavailable when subscribing to updates

## Testing
- `CI=true npm test --silent -- --watchAll=false`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c7cfb3e728832bb1d01f6aa76b277d