### PR TITLE
Remove duplicate appeals route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -102,16 +102,6 @@ export default function App() {
               }
             />
             <Route
-              path="/appeals"
-              element={
-                can(ui.role, "appeals") ? (
-                  <AppealsTab />
-                ) : (
-                  <Navigate to="/dashboard" replace />
-                )
-              }
-            />
-            <Route
               path="/settings"
               element={
                 can(ui.role, "settings") ? (


### PR DESCRIPTION
## Summary
- remove the duplicate /appeals route definition from the router configuration
- ensure only one appeals route remains

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c920c47de0832bae48104bc2dca3c0