### PR TITLE
Add tests for QuickAddModal interactions

### DIFF
--- a/src/components/__tests__/QuickAddModal.test.jsx
+++ b/src/components/__tests__/QuickAddModal.test.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import QuickAddModal from '../QuickAddModal';
+
+describe('QuickAddModal', () => {
+  test('calls callbacks when corresponding buttons are clicked', async () => {
+    const onAddClient = jest.fn();
+    const onAddLead = jest.fn();
+    const onAddTask = jest.fn();
+    const onClose = jest.fn();
+
+    render(
+      <QuickAddModal
+        open={true}
+        onAddClient={onAddClient}
+        onAddLead={onAddLead}
+        onAddTask={onAddTask}
+        onClose={onClose}
+      />
+    );
+
+    await userEvent.click(screen.getByText('+ Клиента'));
+    await userEvent.click(screen.getByText('+ Лида'));
+    await userEvent.click(screen.getByText('+ Задачу'));
+    await userEvent.click(screen.getByText('Закрыть'));
+
+    expect(onAddClient).toHaveBeenCalledTimes(1);
+    expect(onAddLead).toHaveBeenCalledTimes(1);
+    expect(onAddTask).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not render content when modal is closed', () => {
+    const { container } = render(
+      <QuickAddModal
+        open={false}
+        onAddClient={jest.fn()}
+        onAddLead={jest.fn()}
+        onAddTask={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('Быстро добавить')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests ensuring QuickAddModal buttons trigger their callbacks
- confirm the modal returns null when closed

## Testing
- CI=true npm test -- QuickAddModal.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68c94ba8a6f4832ba43711041e57a0a5