### PR TITLE
Add tests for QuickAddModal interactions

### DIFF
--- a/src/components/__tests__/QuickAddModal.test.jsx
+++ b/src/components/__tests__/QuickAddModal.test.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import QuickAddModal from '../QuickAddModal';
+
+describe('QuickAddModal', () => {
+  test('calls callbacks when corresponding buttons are clicked', async () => {
+    const onAddClient = jest.fn();
+    const onAddLead = jest.fn();
+    const onAddTask = jest.fn();
+    const onClose = jest.fn();
+
+    render(
+      <QuickAddModal
+        open={true}
+        onAddClient={onAddClient}
+        onAddLead={onAddLead}
+        onAddTask={onAddTask}
+        onClose={onClose}
+      />
+    );
+
+    await userEvent.click(screen.getByText('+ Клиента'));
+    await userEvent.click(screen.getByText('+ Лида'));
+    await userEvent.click(screen.getByText('+ Задачу'));
+    await userEvent.click(screen.getByText('Закрыть'));
+
+    expect(onAddClient).toHaveBeenCalledTimes(1);
+    expect(onAddLead).toHaveBeenCalledTimes(1);
+    expect(onAddTask).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not render content when modal is closed', () => {
+    const { container } = render(
+      <QuickAddModal
+        open={false}
+        onAddClient={jest.fn()}
+        onAddLead={jest.fn()}
+        onAddTask={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('Быстро добавить')).not.toBeInTheDocument();
+  });
+});

--- a/src/types/react-window.d.ts
+++ b/src/types/react-window.d.ts
@@ -1,0 +1,72 @@
+import { Component, ComponentClass, ComponentType, CSSProperties, FunctionComponent, Key, Ref } from "react";
+
+declare module "react-window" {
+  export type CSSDirection = "ltr" | "rtl";
+  export type Direction = "vertical" | "horizontal";
+  export type Layout = "vertical" | "horizontal";
+  export type ScrollDirection = "forward" | "backward";
+  export type Align = "auto" | "smart" | "center" | "end" | "start";
+
+  export interface ListChildComponentProps<T = any> {
+    index: number;
+    style: CSSProperties;
+    data: T;
+    isScrolling?: boolean | undefined;
+  }
+
+  export type ReactElementType =
+    | FunctionComponent<any>
+    | ComponentClass<any>
+    | string;
+
+  export interface CommonProps<T = any> {
+    className?: string | undefined;
+    innerElementType?: ReactElementType | undefined;
+    innerRef?: Ref<any> | undefined;
+    innerTagName?: string | undefined;
+    itemData?: T | undefined;
+    outerElementType?: ReactElementType | undefined;
+    outerRef?: Ref<any> | undefined;
+    outerTagName?: string | undefined;
+    style?: CSSProperties | undefined;
+    useIsScrolling?: boolean | undefined;
+  }
+
+  export type ListItemKeySelector<T = any> = (index: number, data: T) => Key;
+
+  export interface ListOnItemsRenderedProps {
+    overscanStartIndex: number;
+    overscanStopIndex: number;
+    visibleStartIndex: number;
+    visibleStopIndex: number;
+  }
+
+  export interface ListOnScrollProps {
+    scrollDirection: ScrollDirection;
+    scrollOffset: number;
+    scrollUpdateWasRequested: boolean;
+  }
+
+  export interface ListProps<T = any> extends CommonProps<T> {
+    children: ComponentType<ListChildComponentProps<T>>;
+    height: number | string;
+    itemCount: number;
+    width: number | string;
+    direction?: CSSDirection | Direction | undefined;
+    layout?: Layout | undefined;
+    initialScrollOffset?: number | undefined;
+    itemKey?: ListItemKeySelector<T> | undefined;
+    overscanCount?: number | undefined;
+    onItemsRendered?: ((props: ListOnItemsRenderedProps) => any) | undefined;
+    onScroll?: ((props: ListOnScrollProps) => any) | undefined;
+  }
+
+  export interface FixedSizeListProps<T = any> extends ListProps<T> {
+    itemSize: number;
+  }
+
+  export class FixedSizeList<T = any> extends Component<FixedSizeListProps<T>> {
+    scrollTo(scrollOffset: number): void;
+    scrollToItem(index: number, align?: Align): void;
+  }
+}


### PR DESCRIPTION
## Summary
- add unit tests ensuring QuickAddModal buttons trigger their callbacks
- confirm the modal returns null when closed
- add local react-window type declarations so TypeScript can resolve the module during tests

## Testing
- CI=true npm test -- QuickAddModal.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68c94ba8a6f4832ba43711041e57a0a5