### PR TITLE
Fix Firebase config and TypeScript compatibility

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,9 +1,7 @@
-// src/firebase.js (пример)
-import { initializeApp } from "firebase/app";
-import { getFirestore } from "firebase/firestore"; // если нужна Firestore
-// импортируйте другие SDK по необходимости
-
 {
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "emulators": {
     "dataconnect": {
       "dataDir": "dataconnect/.dataconnect/pgliteData"
@@ -13,17 +11,3 @@ import { getFirestore } from "firebase/firestore"; // если нужна Firest
     "source": "dataconnect"
   }
 }
-
-const firebaseConfig = {
-  apiKey: "AIzaSyAulX_16s1hU8Y-WT0IaWQmmoZJhr_0Xy0",
-  authDomain: "precise-slice-397909.firebaseapp.com",
-  projectId: "precise-slice-397909",
-  storageBucket: "precise-slice-397909.firebasestorage.app",
-  messagingSenderId: "952584870116",
-  appId: "1:952584870116:web:4d801cf061511d8c5934f1"
-};
-
-const app = initializeApp(firebaseConfig);
-const db = getFirestore(app); // пример для Firestore
-
-export { app, db };

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.4",
-        "typescript": "^5.9.2"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5258,7 +5258,7 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5268,7 +5268,7 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -7897,7 +7897,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -19567,17 +19567,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.4",
-    "typescript": "^5.9.2"
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
## Summary
- replace the invalid firebase.json script with valid JSON configuration and reference Firestore rules
- add the Firestore rules file that the Firebase CLI expects
- pin TypeScript to ^4.9.5 so react-scripts installs without peer dependency conflicts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c7f6bd1dc4832b8842dc9c77c39daa