### PR TITLE
Use functional DB updates when saving settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,9 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import { useAppState, can } from "./state/appState";
 
 export default function App() {
+  /** @type {import("./state/appState").AppState} */
+  const appState = useAppState();
+
   const {
     db,
     setDB,
@@ -29,7 +32,7 @@ export default function App() {
     addQuickClient,
     addQuickLead,
     addQuickTask,
-  } = useAppState();
+  } = appState;
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-white to-sky-50 text-slate-900 dark:from-slate-900 dark:to-slate-950 dark:text-slate-100">

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -3,7 +3,13 @@ import Breadcrumbs from "./Breadcrumbs";
 import { saveDB } from "../state/appState";
 import type { DB } from "../types";
 
-export default function SettingsTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
+export default function SettingsTab({
+  db,
+  setDB,
+}: {
+  db: DB;
+  setDB: React.Dispatch<React.SetStateAction<DB>>;
+}) {
   const [rates, setRates] = useState({
     eurTry: db.settings.currencyRates.TRY,
     eurRub: db.settings.currencyRates.RUB,
@@ -30,15 +36,25 @@ export default function SettingsTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
           tryRub: tryRub ?? rates.tryRub,
         };
         setRates(nextRates);
-        const nextDB = {
-          ...db,
-          settings: {
-            ...db.settings,
-            currencyRates: { EUR: 1, TRY: nextRates.eurTry, RUB: nextRates.eurRub },
-          },
-        };
-        setDB(nextDB);
-        await saveDB(nextDB);
+        setDB(prev => {
+          const hasChanged =
+            prev.settings.currencyRates.TRY !== nextRates.eurTry ||
+            prev.settings.currencyRates.RUB !== nextRates.eurRub;
+
+          if (!hasChanged) {
+            return prev;
+          }
+
+          const updated = {
+            ...prev,
+            settings: {
+              ...prev.settings,
+              currencyRates: { EUR: 1, TRY: nextRates.eurTry, RUB: nextRates.eurRub },
+            },
+          };
+          void saveDB(updated);
+          return updated;
+        });
       } catch (e) {
         console.error(e);
       }

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { useLocation } from "react-router-dom";
 import { TAB_TITLES } from "../components/Tabs";
 import { useToasts } from "../components/Toasts";
@@ -15,6 +16,7 @@ import type {
   Role,
   StaffMember,
   TabKey,
+  Toast,
 } from "../types";
 
 
@@ -115,7 +117,22 @@ function usePersistentState<T>(
   return [state, setState];
 }
 
-export function useAppState() {
+export interface AppState {
+  db: DB;
+  setDB: Dispatch<SetStateAction<DB>>;
+  ui: UIState;
+  setUI: (ui: UIState) => void;
+  roles: Role[];
+  toasts: Toast[];
+  quickOpen: boolean;
+  onQuickAdd: () => void;
+  setQuickOpen: Dispatch<SetStateAction<boolean>>;
+  addQuickClient: () => Promise<void>;
+  addQuickLead: () => Promise<void>;
+  addQuickTask: () => Promise<void>;
+}
+
+export function useAppState(): AppState {
   const [db, setDB] = useState<DB>(makeSeedDB());
   const [ui, setUI] = usePersistentState<UIState>(LS_KEYS.ui, defaultUI, 300);
   const roles: Role[] = ["Администратор", "Менеджер", "Тренер"];


### PR DESCRIPTION
## Summary
- update SettingsTab to accept a React state dispatcher and use functional updates when persisting currency rates
- define an AppState interface so consumers receive the dispatch-typed setter
- skip saving settings when fetched rates did not change

## Testing
- npx tsc --noEmit
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68c9c5503b4c832ba0b2e6ae1a655a61