### PR TITLE
Fix ClientsTab useMemo dependencies

### DIFF
--- a/src/components/ClientsTab.tsx
+++ b/src/components/ClientsTab.tsx
@@ -24,7 +24,7 @@ export default function ClientsTab({ db, setDB, ui }: { db: DB; setDB: (db: DB) 
       (pay === "all" || c.payStatus === pay) &&
       (!ui.search || `${c.firstName} ${c.lastName ?? ""} ${c.phone ?? ""}`.toLowerCase().includes(search))
     );
-  }, [db.clients, area, group, pay, ui.search]);
+  }, [db.clients, area, group, pay, ui.search, search]);
 
   const openAddModal = () => {
     setEditing(null);


### PR DESCRIPTION
## Summary
- add the derived `search` term to the ClientsTab useMemo dependency array so eslint no longer warns about missing deps

## Testing
- npx eslint src/components/ClientsTab.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9cb9e9494832b9966b0243342caa0