### PR TITLE
Fix Firestore subscription effect dependencies

### DIFF
--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -153,7 +153,7 @@ export function useAppState(): AppState {
       return;
     }
     const ref = doc(firestore, "app", "main");
-    let unsub = () => {};
+    let unsub: (() => void) | undefined;
     try {
       unsub = onSnapshot(ref, async snap => {
         try {
@@ -173,8 +173,12 @@ export function useAppState(): AppState {
       console.error("Failed to subscribe to snapshot", err);
       push("Не удалось подписаться на обновления", "error");
     }
-    return () => unsub();
-  }, []);
+    return () => {
+      if (unsub) {
+        unsub();
+      }
+    };
+  }, [push, setDB]);
 
   useEffect(() => {
     const onStorage = (e: StorageEvent) => {


### PR DESCRIPTION
## Summary
- update the Firestore snapshot subscription effect to retain its unsubscribe handler and guard cleanup
- include the snapshot handlers in the dependency list to satisfy the exhaustive-deps lint rule

## Testing
- npx eslint src/state/appState.ts

------
https://chatgpt.com/codex/tasks/task_e_68c9cba8b728832b966445ee9895d183