### PR TITLE
Ensure persistent state uses current values on unmount

### DIFF
--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { useLocation } from "react-router-dom";
 import { TAB_TITLES } from "../components/Tabs";
@@ -91,6 +91,16 @@ function usePersistentState<T>(
 
   const timeoutRef = useRef<number | null>(null);
 
+  const flush = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    try {
+      localStorage.setItem(key, JSON.stringify(state));
+    } catch {}
+  }, [key, state]);
+
   useEffect(() => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     timeoutRef.current = window.setTimeout(() => {
@@ -105,14 +115,9 @@ function usePersistentState<T>(
 
   useEffect(() => {
     return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-        try {
-          localStorage.setItem(key, JSON.stringify(state));
-        } catch {}
-      }
+      flush();
     };
-  }, []);
+  }, [flush]);
 
   return [state, setState];
 }


### PR DESCRIPTION
## Summary
- wrap the localStorage flush logic in a memoized callback inside usePersistentState
- use the flush helper from the cleanup effect so the latest state is persisted when the hook unmounts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9cba7d89c832b839dc718cd2d028b