### PR TITLE
Fix tab synchronization effect dependencies

### DIFF
--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -77,7 +77,7 @@ function usePersistentState<T>(
   key: string,
   defaultValue: T,
   delay: number = 300,
-): [T, (v: T) => void] {
+): [T, Dispatch<SetStateAction<T>>] {
   const [state, setState] = useState<T>(() => {
     try {
       const raw = localStorage.getItem(key);
@@ -121,7 +121,7 @@ export interface AppState {
   db: DB;
   setDB: Dispatch<SetStateAction<DB>>;
   ui: UIState;
-  setUI: (ui: UIState) => void;
+  setUI: Dispatch<SetStateAction<UIState>>;
   roles: Role[];
   toasts: Toast[];
   quickOpen: boolean;
@@ -187,7 +187,7 @@ export function useAppState(): AppState {
     };
     window.addEventListener("storage", onStorage);
     return () => window.removeEventListener("storage", onStorage);
-  }, []);
+  }, [setUI]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -204,11 +204,15 @@ export function useAppState(): AppState {
     let key = location.pathname.replace(/^\/+/, "");
     if (key === "") key = "dashboard";
     if (!TAB_TITLES[key as TabKey]) key = "dashboard";
-    if (ui.activeTab !== key) {
-      const next = { ...ui, activeTab: key as TabKey, breadcrumbs: [TAB_TITLES[key as TabKey]] };
-      setUI(next);
-    }
-  }, [location.pathname]);
+    const tabKey = key as TabKey;
+    const breadcrumb = TAB_TITLES[tabKey];
+    setUI(prev => {
+      if (prev.activeTab === tabKey) {
+        return prev;
+      }
+      return { ...prev, activeTab: tabKey, breadcrumbs: [breadcrumb] };
+    });
+  }, [location.pathname, setUI]);
 
   const onQuickAdd = () => setQuickOpen(true);
   const addQuickClient = async () => {


### PR DESCRIPTION
## Summary
- expose a Dispatch-based setter from usePersistentState so setUI accepts functional updates
- align AppState typing and storage listener dependencies with the setter changes
- update the route/tab synchronization effect to use a functional setUI call with the proper dependency array

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9cbb0669c832b9c03c996d46b9746