### PR TITLE
Add Firebase hosting configuration

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,5 +9,13 @@
   },
   "dataconnect": {
     "source": "dataconnect"
+  },
+  "hosting": {
+    "public": "public",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- add a Firebase Hosting configuration to firebase.json with the public directory and ignore rules

## Testing
- `firebase deploy --only hosting` *(fails: requires authentication via `firebase login`)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cbb2f58c832ba2eac03cb1f56b57