### PR TITLE
Stabilize toast push handler and cover offline toast

### DIFF
--- a/src/components/Toasts.tsx
+++ b/src/components/Toasts.tsx
@@ -1,17 +1,20 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { uid } from "../state/utils";
 import type { Toast } from "../types";
 
 export function useToasts() {
   const [toasts, setToasts] = useState<Toast[]>([]);
-  const push = (text: string, type: Toast["type"] = "info") => {
-    const t: Toast = { id: uid(), text, type };
-    setToasts((prev: Toast[]) => [...prev, t]);
-    setTimeout(
-      () => setToasts((prev: Toast[]) => prev.filter((x: Toast) => x.id !== t.id)),
-      3500
-    );
-  };
+  const push = useCallback(
+    (text: string, type: Toast["type"] = "info") => {
+      const t: Toast = { id: uid(), text, type };
+      setToasts((prev: Toast[]) => [...prev, t]);
+      setTimeout(
+        () => setToasts((prev: Toast[]) => prev.filter((x: Toast) => x.id !== t.id)),
+        3500,
+      );
+    },
+    [setToasts],
+  );
   return { toasts, push };
 }
 

--- a/src/state/__tests__/useAppState.firebase.test.tsx
+++ b/src/state/__tests__/useAppState.firebase.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { useAppState } from "../appState";
+
+const mockPush = jest.fn();
+
+jest.mock("../../components/Toasts", () => ({
+  useToasts: () => ({ toasts: [], push: mockPush }),
+}));
+
+jest.mock("../../firebase", () => ({
+  db: undefined,
+}));
+
+jest.mock(
+  "react-router-dom",
+  () => ({
+    useLocation: () => ({ pathname: "/" }),
+  }),
+  { virtual: true },
+);
+
+describe("useAppState without firebase configuration", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it("shows the offline toast only once", async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+    renderHook(() => useAppState(), { wrapper });
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledTimes(1));
+    expect(mockPush).toHaveBeenCalledWith("Нет подключения к базе данных", "error");
+  });
+});


### PR DESCRIPTION
## Summary
- memoize the toast push handler with useCallback so dependent effects receive a stable reference
- add a regression test that ensures the offline toast only appears once when Firebase is not configured

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ca7e78155c832b83fa49a2359347fc