### PR TITLE
Update Firestore rules for authenticated access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,6 +2,12 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    // Разрешаем доступ только авторизованным пользователям к документам приложения
+    match /app/{documentId} {
+      allow read, write: if request.auth != null;
+    }
+
+    // По умолчанию запрещаем любые другие операции
     match /{document=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
## Summary
- allow authenticated users to read and write application documents in Firestore
- keep a deny-by-default fallback for all other documents

## Testing
- `firebase deploy --only firestore:rules` *(fails: requires firebase login credentials in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8db67d6c832b817efb8920ba284c