### PR TITLE
Handle Firestore save failures and update tests

### DIFF
--- a/src/components/AttendanceTab.tsx
+++ b/src/components/AttendanceTab.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import VirtualizedTable from "./VirtualizedTable";
 import { fmtDate, uid } from "../state/utils";
-import { saveDB } from "../state/appState";
+import { commitDBUpdate } from "../state/appState";
 import type { DB, Area, Group, AttendanceEntry } from "../types";
 
 export default function AttendanceTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
@@ -30,11 +30,17 @@ export default function AttendanceTab({ db, setDB }: { db: DB; setDB: (db: DB) =
     if (mark) {
       const updated = { ...mark, came: !mark.came };
       const next = { ...db, attendance: db.attendance.map(a => a.id === mark.id ? updated : a) };
-      setDB(next); await saveDB(next);
+      const ok = await commitDBUpdate(next, setDB);
+      if (!ok) {
+        window.alert("Не удалось обновить отметку посещаемости. Проверьте доступ к базе данных.");
+      }
     } else {
       const entry: AttendanceEntry = { id: uid(), clientId, date: new Date().toISOString(), came: true };
       const next = { ...db, attendance: [entry, ...db.attendance] };
-      setDB(next); await saveDB(next);
+      const ok = await commitDBUpdate(next, setDB);
+      if (!ok) {
+        window.alert("Не удалось сохранить отметку посещаемости. Проверьте доступ к базе данных.");
+      }
     }
   };
 

--- a/src/components/TasksTab.tsx
+++ b/src/components/TasksTab.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import Modal from "./Modal";
 import { fmtDate, uid, todayISO } from "../state/utils";
-import { saveDB } from "../state/appState";
+import { commitDBUpdate } from "../state/appState";
 import type { DB, TaskItem } from "../types";
 
 export default function TasksTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
@@ -12,22 +12,36 @@ export default function TasksTab({ db, setDB }: { db: DB; setDB: (db: DB) => voi
       ...db,
       tasks: db.tasks.map<TaskItem>(t => (t.id === id ? { ...t, status: t.status === "open" ? "done" : "open" } : t)),
     };
-    setDB(next); await saveDB(next);
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось обновить задачу. Проверьте доступ к базе данных.");
+    }
   };
   const save = async () => {
     if (!edit) return;
     const next: DB = { ...db, tasks: db.tasks.map<TaskItem>(t => (t.id === edit.id ? edit : t)) };
-    setDB(next); await saveDB(next); setEdit(null);
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось сохранить задачу. Проверьте доступ к базе данных.");
+      return;
+    }
+    setEdit(null);
   };
   const add = async () => {
     const t: TaskItem = { id: uid(), title: "Новая задача", due: todayISO(), status: "open" };
     const next: DB = { ...db, tasks: [t, ...db.tasks] };
-    setDB(next); await saveDB(next);
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось добавить задачу. Проверьте доступ к базе данных.");
+    }
   };
   const remove = async (id: string) => {
     if (!window.confirm("Удалить задачу?")) return;
     const next: DB = { ...db, tasks: db.tasks.filter(t => t.id !== id) };
-    setDB(next); await saveDB(next);
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось удалить задачу. Проверьте доступ к базе данных.");
+    }
   };
   return (
     <div className="space-y-3">

--- a/src/components/__tests__/ClientsTab.test.tsx
+++ b/src/components/__tests__/ClientsTab.test.tsx
@@ -12,7 +12,7 @@ jest.mock('react-window', () => ({
 
 jest.mock('../../state/appState', () => ({
   __esModule: true,
-  saveDB: jest.fn().mockResolvedValue(undefined),
+  commitDBUpdate: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock('../../state/utils', () => ({
@@ -24,16 +24,21 @@ jest.mock('../../state/utils', () => ({
 }));
 
 import ClientsTab from '../ClientsTab';
-import { saveDB } from '../../state/appState';
+import { commitDBUpdate } from '../../state/appState';
 import { uid, todayISO, parseDateInput, fmtMoney } from '../../state/utils';
 
 beforeEach(() => {
   jest.clearAllMocks();
+  commitDBUpdate.mockImplementation(async (next, setDB) => {
+    setDB(next);
+    return true;
+  });
   uid.mockReturnValue('uid-123');
   todayISO.mockReturnValue('2024-01-01T00:00:00.000Z');
   parseDateInput.mockImplementation((v) => (v ? v + 'T00:00:00.000Z' : ''));
   fmtMoney.mockImplementation((v, c) => v + ' ' + c);
   global.confirm = jest.fn(() => true);
+  window.alert = jest.fn();
 });
 
 const makeDB = () => ({

--- a/src/components/__tests__/ScheduleTab.groups.test.tsx
+++ b/src/components/__tests__/ScheduleTab.groups.test.tsx
@@ -6,7 +6,7 @@ import "@testing-library/jest-dom";
 
 jest.mock("../../state/appState", () => ({
   __esModule: true,
-  saveDB: jest.fn().mockResolvedValue(undefined),
+  commitDBUpdate: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock("../../state/utils", () => ({
@@ -23,10 +23,20 @@ jest.mock("../VirtualizedTable", () => (props) => <table>{props.children}</table
 
 import ScheduleTab from "../ScheduleTab";
 import ClientsTab from "../ClientsTab";
+import { commitDBUpdate } from "../../state/appState";
+
+beforeEach(() => {
+  commitDBUpdate.mockImplementation(async (next, setDB) => {
+    setDB(next);
+    return true;
+  });
+  window.alert = jest.fn();
+});
 
 afterEach(() => {
   cleanup();
   jest.restoreAllMocks();
+  commitDBUpdate.mockResolvedValue(true);
 });
 
 function makeDb() {

--- a/src/components/__tests__/ScheduleTab.test.tsx
+++ b/src/components/__tests__/ScheduleTab.test.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom';
 
 jest.mock('../../state/appState', () => ({
   __esModule: true,
-  saveDB: jest.fn().mockResolvedValue(undefined),
+  commitDBUpdate: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock('../../state/utils', () => ({
@@ -22,10 +22,20 @@ jest.mock('../../state/utils', () => ({
 jest.mock('../VirtualizedTable', () => (props) => <table>{props.children}</table>);
 
 import ScheduleTab from '../ScheduleTab';
+import { commitDBUpdate } from '../../state/appState';
+
+beforeEach(() => {
+  commitDBUpdate.mockImplementation(async (next, setDB) => {
+    setDB(next);
+    return true;
+  });
+  window.alert = jest.fn();
+});
 
 afterEach(() => {
   cleanup();
   jest.restoreAllMocks();
+  commitDBUpdate.mockResolvedValue(true);
 });
 
 function makeDb() {

--- a/src/components/__tests__/TasksTab.test.tsx
+++ b/src/components/__tests__/TasksTab.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 jest.mock('../../state/appState', () => ({
   __esModule: true,
-  saveDB: jest.fn().mockResolvedValue(undefined),
+  commitDBUpdate: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock('../../state/utils', () => ({
@@ -15,6 +15,7 @@ jest.mock('../../state/utils', () => ({
   todayISO: () => '2025-01-01T00:00:00.000Z'
 }));
 import TasksTab from '../TasksTab';
+import { commitDBUpdate } from '../../state/appState';
 
 function setup(initialTasks) {
   const Wrapper = () => {
@@ -31,7 +32,12 @@ describe('TasksTab CRUD operations', () => {
   ];
 
   beforeEach(() => {
+    commitDBUpdate.mockImplementation(async (next, setDB) => {
+      setDB(next);
+      return true;
+    });
     window.confirm = jest.fn(() => true);
+    window.alert = jest.fn();
   });
 
   test('Read: renders initial tasks', () => {


### PR DESCRIPTION
## Summary
- add a commitDBUpdate helper that only updates local state after a successful Firestore write and surface errors in quick-add flows
- wrap client, lead, attendance, task, schedule and settings mutations in the new helper so permission failures no longer leave stale UI state
- update component tests to mock commitDBUpdate, invoke setDB and stub window.alert so the suites continue to pass

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cae9393a20832bbfb6b3c92ca4036c