### PR TITLE
Handle Firestore save failures and update tests

### DIFF
--- a/src/components/AttendanceTab.tsx
+++ b/src/components/AttendanceTab.tsx
@@ -1,11 +1,18 @@
 import React, { useState, useMemo } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import VirtualizedTable from "./VirtualizedTable";
 import { fmtDate, uid } from "../state/utils";
-import { saveDB } from "../state/appState";
+import { commitDBUpdate } from "../state/appState";
 import type { DB, Area, Group, AttendanceEntry } from "../types";
 
-export default function AttendanceTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
+export default function AttendanceTab({
+  db,
+  setDB,
+}: {
+  db: DB;
+  setDB: Dispatch<SetStateAction<DB>>;
+}) {
   const [area, setArea] = useState<Area | "all">("all");
   const [group, setGroup] = useState<Group | "all">("all");
   const today = new Date();
@@ -30,11 +37,17 @@ export default function AttendanceTab({ db, setDB }: { db: DB; setDB: (db: DB) =
     if (mark) {
       const updated = { ...mark, came: !mark.came };
       const next = { ...db, attendance: db.attendance.map(a => a.id === mark.id ? updated : a) };
-      setDB(next); await saveDB(next);
+      const ok = await commitDBUpdate(next, setDB);
+      if (!ok) {
+        window.alert("Не удалось обновить отметку посещаемости. Проверьте доступ к базе данных.");
+      }
     } else {
       const entry: AttendanceEntry = { id: uid(), clientId, date: new Date().toISOString(), came: true };
       const next = { ...db, attendance: [entry, ...db.attendance] };
-      setDB(next); await saveDB(next);
+      const ok = await commitDBUpdate(next, setDB);
+      if (!ok) {
+        window.alert("Не удалось сохранить отметку посещаемости. Проверьте доступ к базе данных.");
+      }
     }
   };
 

--- a/src/components/LeadsTab.tsx
+++ b/src/components/LeadsTab.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { useForm } from "react-hook-form";
 import type { Resolver } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -7,10 +8,16 @@ import Breadcrumbs from "./Breadcrumbs";
 import Modal from "./Modal";
 import { FixedSizeList, ListChildComponentProps } from "react-window";
 import { todayISO, uid, fmtDate } from "../state/utils";
-import { saveDB } from "../state/appState";
+import { commitDBUpdate } from "../state/appState";
 import type { DB, Lead, LeadStage, StaffMember, LeadFormValues } from "../types";
 
-export default function LeadsTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
+export default function LeadsTab({
+  db,
+  setDB,
+}: {
+  db: DB;
+  setDB: Dispatch<SetStateAction<DB>>;
+}) {
   const stages: LeadStage[] = ["Очередь", "Задержка", "Пробное", "Ожидание оплаты", "Оплаченный абонемент", "Отмена"];
   const [open, setOpen] = useState<Lead | null>(null);
   const groupedLeads = useMemo((): Record<LeadStage, Lead[]> =>
@@ -23,7 +30,10 @@ export default function LeadsTab({ db, setDB }: { db: DB; setDB: (db: DB) => voi
     const idx = stages.indexOf(l.stage);
     const nextStage = stages[Math.min(stages.length - 1, Math.max(0, idx + dir))];
     const next = { ...db, leads: db.leads.map(x => x.id === id ? { ...x, stage: nextStage, updatedAt: todayISO() } : x) };
-    setDB(next); await saveDB(next);
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось обновить статус лида. Проверьте доступ к базе данных.");
+    }
   };
   return (
     <div className="space-y-3">
@@ -91,7 +101,7 @@ function LeadModal(
     onClose: () => void;
     staff: StaffMember[];
     db: DB;
-    setDB: (db: DB) => void;
+    setDB: Dispatch<SetStateAction<DB>>;
   },
 ) {
   const [edit, setEdit] = useState(false);
@@ -124,7 +134,12 @@ function LeadModal(
       leads: db.leads.map(l => (l.id === lead.id ? nextLead : l)),
       changelog: [...db.changelog, { id: uid(), who: "UI", what: `Обновлён лид ${nextLead.name}`, when: todayISO() }],
     };
-    setDB(next); await saveDB(next); setEdit(false); onClose();
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось сохранить изменения лида. Проверьте доступ к базе данных.");
+      return;
+    }
+    setEdit(false); onClose();
   };
 
   const remove = async () => {
@@ -134,7 +149,12 @@ function LeadModal(
       leads: db.leads.filter(l => l.id !== lead.id),
       changelog: [...db.changelog, { id: uid(), who: "UI", what: `Удалён лид ${lead.id}`, when: todayISO() }],
     };
-    setDB(next); await saveDB(next); onClose();
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось удалить лида. Проверьте доступ к базе данных.");
+      return;
+    }
+    onClose();
   };
 
   return (

--- a/src/components/ScheduleTab.tsx
+++ b/src/components/ScheduleTab.tsx
@@ -1,10 +1,17 @@
 import React, { useMemo } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import { uid } from "../state/utils";
-import { saveDB } from "../state/appState";
+import { commitDBUpdate } from "../state/appState";
 import type { DB, ScheduleSlot } from "../types";
 
-export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => void }) {
+export default function ScheduleTab({
+  db,
+  setDB,
+}: {
+  db: DB;
+  setDB: Dispatch<SetStateAction<DB>>;
+}) {
   const byArea = useMemo(() => {
     const m: Record<string, ScheduleSlot[]> = {};
     for (const a of db.settings.areas) m[a] = [];
@@ -25,7 +32,10 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
       if (!(key in nextLimits)) nextLimits[key] = 0;
     }
     const next = { ...db, settings: { ...db.settings, areas: nextAreas, limits: nextLimits } };
-    setDB(next); await saveDB(next);
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось добавить район. Проверьте доступ к базе данных.");
+    }
   };
   const renameArea = async (oldName: string) => {
     const name = prompt("Новое название района", oldName);
@@ -52,7 +62,10 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
       settings: { ...db.settings, areas: renamedAreas, limits: renamedLimits },
       schedule: db.schedule.map(s => s.area === oldName ? { ...s, area: name } : s),
     };
-    setDB(next); await saveDB(next);
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось переименовать район. Проверьте доступ к базе данных.");
+    }
   };
   const deleteArea = async (name: string) => {
     if (!window.confirm(`Удалить район ${name}?`)) return;
@@ -67,7 +80,10 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
       settings: { ...db.settings, areas: db.settings.areas.filter(a => a !== name), limits: filteredLimits },
       schedule: db.schedule.filter(s => s.area !== name),
     };
-    setDB(next); await saveDB(next);
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось удалить район. Проверьте доступ к базе данных.");
+    }
   };
 
   const pickGroup = (init: string) => {
@@ -91,7 +107,10 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
         ? db.settings
         : { ...db.settings, groups: [...db.settings.groups, group] },
     };
-    setDB(next); await saveDB(next);
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось добавить слот расписания. Проверьте доступ к базе данных.");
+    }
   };
   const editSlot = async (id: string) => {
     const s = db.schedule.find(x => x.id === id);
@@ -107,12 +126,18 @@ export default function ScheduleTab({ db, setDB }: { db: DB; setDB: (db: DB) => 
         ? db.settings
         : { ...db.settings, groups: [...db.settings.groups, group] },
     };
-    setDB(next); await saveDB(next);
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось обновить слот расписания. Проверьте доступ к базе данных.");
+    }
   };
   const deleteSlot = async (id: string) => {
     if (!window.confirm("Удалить группу?")) return;
     const next = { ...db, schedule: db.schedule.filter(x => x.id !== id) };
-    setDB(next); await saveDB(next);
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось удалить слот расписания. Проверьте доступ к базе данных.");
+    }
   };
 
   return (

--- a/src/components/__tests__/ClientsTab.test.tsx
+++ b/src/components/__tests__/ClientsTab.test.tsx
@@ -12,7 +12,7 @@ jest.mock('react-window', () => ({
 
 jest.mock('../../state/appState', () => ({
   __esModule: true,
-  saveDB: jest.fn().mockResolvedValue(undefined),
+  commitDBUpdate: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock('../../state/utils', () => ({
@@ -24,16 +24,21 @@ jest.mock('../../state/utils', () => ({
 }));
 
 import ClientsTab from '../ClientsTab';
-import { saveDB } from '../../state/appState';
+import { commitDBUpdate } from '../../state/appState';
 import { uid, todayISO, parseDateInput, fmtMoney } from '../../state/utils';
 
 beforeEach(() => {
   jest.clearAllMocks();
+  commitDBUpdate.mockImplementation(async (next, setDB) => {
+    setDB(next);
+    return true;
+  });
   uid.mockReturnValue('uid-123');
   todayISO.mockReturnValue('2024-01-01T00:00:00.000Z');
   parseDateInput.mockImplementation((v) => (v ? v + 'T00:00:00.000Z' : ''));
   fmtMoney.mockImplementation((v, c) => v + ' ' + c);
   global.confirm = jest.fn(() => true);
+  window.alert = jest.fn();
 });
 
 const makeDB = () => ({

--- a/src/components/__tests__/ScheduleTab.groups.test.tsx
+++ b/src/components/__tests__/ScheduleTab.groups.test.tsx
@@ -6,7 +6,7 @@ import "@testing-library/jest-dom";
 
 jest.mock("../../state/appState", () => ({
   __esModule: true,
-  saveDB: jest.fn().mockResolvedValue(undefined),
+  commitDBUpdate: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock("../../state/utils", () => ({
@@ -23,10 +23,20 @@ jest.mock("../VirtualizedTable", () => (props) => <table>{props.children}</table
 
 import ScheduleTab from "../ScheduleTab";
 import ClientsTab from "../ClientsTab";
+import { commitDBUpdate } from "../../state/appState";
+
+beforeEach(() => {
+  commitDBUpdate.mockImplementation(async (next, setDB) => {
+    setDB(next);
+    return true;
+  });
+  window.alert = jest.fn();
+});
 
 afterEach(() => {
   cleanup();
   jest.restoreAllMocks();
+  commitDBUpdate.mockResolvedValue(true);
 });
 
 function makeDb() {

--- a/src/components/__tests__/ScheduleTab.test.tsx
+++ b/src/components/__tests__/ScheduleTab.test.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom';
 
 jest.mock('../../state/appState', () => ({
   __esModule: true,
-  saveDB: jest.fn().mockResolvedValue(undefined),
+  commitDBUpdate: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock('../../state/utils', () => ({
@@ -22,10 +22,20 @@ jest.mock('../../state/utils', () => ({
 jest.mock('../VirtualizedTable', () => (props) => <table>{props.children}</table>);
 
 import ScheduleTab from '../ScheduleTab';
+import { commitDBUpdate } from '../../state/appState';
+
+beforeEach(() => {
+  commitDBUpdate.mockImplementation(async (next, setDB) => {
+    setDB(next);
+    return true;
+  });
+  window.alert = jest.fn();
+});
 
 afterEach(() => {
   cleanup();
   jest.restoreAllMocks();
+  commitDBUpdate.mockResolvedValue(true);
 });
 
 function makeDb() {

--- a/src/components/__tests__/TasksTab.test.tsx
+++ b/src/components/__tests__/TasksTab.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 jest.mock('../../state/appState', () => ({
   __esModule: true,
-  saveDB: jest.fn().mockResolvedValue(undefined),
+  commitDBUpdate: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock('../../state/utils', () => ({
@@ -15,6 +15,7 @@ jest.mock('../../state/utils', () => ({
   todayISO: () => '2025-01-01T00:00:00.000Z'
 }));
 import TasksTab from '../TasksTab';
+import { commitDBUpdate } from '../../state/appState';
 
 function setup(initialTasks) {
   const Wrapper = () => {
@@ -31,7 +32,12 @@ describe('TasksTab CRUD operations', () => {
   ];
 
   beforeEach(() => {
+    commitDBUpdate.mockImplementation(async (next, setDB) => {
+      setDB(next);
+      return true;
+    });
     window.confirm = jest.fn(() => true);
+    window.alert = jest.fn();
   });
 
   test('Read: renders initial tasks', () => {


### PR DESCRIPTION
## Summary
- add a commitDBUpdate helper that only updates local state after a successful Firestore write and surface errors in quick-add flows
- wrap client, lead, attendance, task, schedule and settings mutations in the new helper so permission failures no longer leave stale UI state
- update component tests to mock commitDBUpdate, invoke setDB and stub window.alert so the suites continue to pass
- align the tab components' setDB prop types with React's Dispatch<SetStateAction<DB>> so commitDBUpdate can accept the setters without type errors

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cae9393a20832bbfb6b3c92ca4036c