### PR TITLE
Require Firebase auth before Firestore writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ npm run build     # сборка production-версии в каталог build
    REACT_APP_FIREBASE_STORAGE_BUCKET=...
    REACT_APP_FIREBASE_MESSAGING_SENDER_ID=...
    REACT_APP_FIREBASE_APP_ID=...
+   # Обязательно для работы с защищёнными правилами Firestore:
+   REACT_APP_FIREBASE_AUTH_EMAIL=...
+   REACT_APP_FIREBASE_AUTH_PASSWORD=...
    ```
 
 4. Перезапустите `npm start`, чтобы подтянуть новые переменные окружения.
@@ -63,9 +66,9 @@ npm run build     # сборка production-версии в каталог build
 
 1. Откройте проект в Firebase Console и перейдите в раздел **Build → Authentication**.
 2. Нажмите **Get Started/Начать**, чтобы активировать модуль авторизации.
-3. Включите нужные провайдеры входа (например, Email/Password) и сохраните настройки.
+3. Включите провайдер **Email/Password** (и при необходимости создайте техническую учётку через вкладку Users).
 4. На вкладке **Settings** добавьте домены, с которых будет доступно приложение (например, `localhost` для разработки).
-5. После включения авторизации импортируйте `auth` из `src/firebase.ts`, чтобы использовать `signInWithEmailAndPassword`, `onAuthStateChanged` и другие методы SDK в приложении.
+5. Убедитесь, что переменные окружения `REACT_APP_FIREBASE_AUTH_EMAIL/REACT_APP_FIREBASE_AUTH_PASSWORD` указывают на существующего пользователя. Эти данные используются приложением для фоновой авторизации перед любой записью в Firestore.
 
 ### Устранение неполадок
 


### PR DESCRIPTION
## Summary
- fail fast when Firebase auth credentials are missing so Firestore writes never run unauthenticated
- ensure the Firestore seed write authenticates before creating the `/app/main` document
- document the need to enable the Email/Password provider and supply service credentials in the environment

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cb104b7c44832baa243b9dd0b572e0