### PR TITLE
feat: virtualize tables with react-window

### DIFF
--- a/src/components/__tests__/VirtualizedTable.test.tsx
+++ b/src/components/__tests__/VirtualizedTable.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import VirtualizedTable from "../VirtualizedTable";
+
+describe("VirtualizedTable", () => {
+  it("renders rows inside tbody with virtualization styles", () => {
+    const header = (
+      <thead>
+        <tr>
+          <th>Header</th>
+        </tr>
+      </thead>
+    );
+
+    const items = Array.from({ length: 50 }, (_, index) => `Row ${index + 1}`);
+
+    render(
+      <VirtualizedTable
+        header={header}
+        items={items}
+        rowHeight={40}
+        height={120}
+        renderRow={(item, style) => (
+          <tr key={item} style={style}>
+            <td>{item}</td>
+          </tr>
+        )}
+      />,
+    );
+
+    const table = screen.getByRole("table");
+    const tableBody = table.querySelector("tbody");
+    expect(tableBody).not.toBeNull();
+
+    const rows = tableBody!.querySelectorAll("tr");
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0]).toHaveStyle({ position: "absolute" });
+  });
+});


### PR DESCRIPTION
## Summary
- replace the manual mapping in `VirtualizedTable` with a `FixedSizeList` wrapper that keeps the table markup intact and forwards virtualization styles to rows
- memoize table outer element to include the header, preserve list sizing props, and deliver row styles with full width so existing tables continue to render correctly
- add a regression test that renders the virtualized table and asserts rows are positioned via virtualization inside the `<tbody>`

## Testing
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb26c7af8c832bb793eb7dcec23cd3