### PR TITLE
Add performance tracking view and client detail modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Tabs from "./components/Tabs";
 import Dashboard from "./components/Dashboard";
 import ClientsTab from "./components/ClientsTab";
 import AttendanceTab from "./components/AttendanceTab";
+import PerformanceTab from "./components/PerformanceTab";
 import TasksTab from "./components/TasksTab";
 import ScheduleTab from "./components/ScheduleTab";
 import LeadsTab from "./components/LeadsTab";
@@ -58,7 +59,17 @@ export default function App() {
               path="/attendance"
               element={
                 can(ui.role, "attendance") ? (
-                  <AttendanceTab db={db} setDB={setDB} />
+                  <AttendanceTab db={db} setDB={setDB} currency={ui.currency} />
+                ) : (
+                  <Navigate to="/dashboard" replace />
+                )
+              }
+            />
+            <Route
+              path="/performance"
+              element={
+                can(ui.role, "performance") ? (
+                  <PerformanceTab db={db} setDB={setDB} currency={ui.currency} />
                 ) : (
                   <Navigate to="/dashboard" replace />
                 )

--- a/src/components/ClientsTab.tsx
+++ b/src/components/ClientsTab.tsx
@@ -115,7 +115,7 @@ export default function ClientsTab({
       />
       <ClientTable
         list={list}
-        ui={ui}
+        currency={ui.currency}
         onEdit={startEdit}
         onRemove={removeClient}
       />

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -1,13 +1,13 @@
-import React, { useState, useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import VirtualizedTable from "./VirtualizedTable";
 import ClientDetailsModal from "./clients/ClientDetailsModal";
 import { fmtDate, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
-import type { DB, Area, Group, AttendanceEntry, Client, Currency } from "../types";
+import type { Area, Currency, DB, Group, PerformanceEntry, Client } from "../types";
 
-export default function AttendanceTab({
+export default function PerformanceTab({
   db,
   setDB,
   currency,
@@ -23,49 +23,71 @@ export default function AttendanceTab({
   const todayStr = today.toISOString().slice(0, 10);
 
   const list = useMemo(() => {
-    return db.clients.filter(c => (area === "all" || c.area === area) && (group === "all" || c.group === group));
+    return db.clients.filter(
+      c => (area === "all" || c.area === area) && (group === "all" || c.group === group),
+    );
   }, [db.clients, area, group]);
 
   const todayMarks = useMemo(() => {
-    const map: Map<string, AttendanceEntry> = new Map();
-    db.attendance.forEach(a => {
-      if (a.date.slice(0, 10) === todayStr) {
-        map.set(a.clientId, a);
+    const map: Map<string, PerformanceEntry> = new Map();
+    db.performance.forEach(p => {
+      if (p.date.slice(0, 10) === todayStr) {
+        map.set(p.clientId, p);
       }
     });
     return map;
-  }, [db.attendance, todayStr]);
+  }, [db.performance, todayStr]);
 
   const toggle = async (clientId: string) => {
     const mark = todayMarks.get(clientId);
     if (mark) {
-      const updated = { ...mark, came: !mark.came };
-      const next = { ...db, attendance: db.attendance.map(a => a.id === mark.id ? updated : a) };
+      const updated = { ...mark, successful: !mark.successful };
+      const next = {
+        ...db,
+        performance: db.performance.map(p => (p.id === mark.id ? updated : p)),
+      };
       const ok = await commitDBUpdate(next, setDB);
       if (!ok) {
-        window.alert("Не удалось обновить отметку посещаемости. Проверьте доступ к базе данных.");
+        window.alert("Не удалось обновить отметку успеваемости. Проверьте доступ к базе данных.");
       }
     } else {
-      const entry: AttendanceEntry = { id: uid(), clientId, date: new Date().toISOString(), came: true };
-      const next = { ...db, attendance: [entry, ...db.attendance] };
+      const entry: PerformanceEntry = {
+        id: uid(),
+        clientId,
+        date: new Date().toISOString(),
+        successful: true,
+      };
+      const next = { ...db, performance: [entry, ...db.performance] };
       const ok = await commitDBUpdate(next, setDB);
       if (!ok) {
-        window.alert("Не удалось сохранить отметку посещаемости. Проверьте доступ к базе данных.");
+        window.alert("Не удалось сохранить отметку успеваемости. Проверьте доступ к базе данных.");
       }
     }
   };
 
   return (
     <div className="space-y-3">
-      <Breadcrumbs items={["Посещаемость"]} />
+      <Breadcrumbs items={["Успеваемость"]} />
       <div className="flex flex-wrap items-center gap-2">
-        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200" value={area} onChange={e => setArea(e.target.value)}>
+        <select
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={area}
+          onChange={e => setArea(e.target.value)}
+        >
           <option value="all">Все районы</option>
-          {db.settings.areas.map(a => <option key={a}>{a}</option>)}
+          {db.settings.areas.map(a => (
+            <option key={a}>{a}</option>
+          ))}
         </select>
-        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200" value={group} onChange={e => setGroup(e.target.value)}>
+        <select
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={group}
+          onChange={e => setGroup(e.target.value)}
+        >
           <option value="all">Все группы</option>
-          {db.settings.groups.map(g => <option key={g}>{g}</option>)}
+          {db.settings.groups.map(g => (
+            <option key={g}>{g}</option>
+          ))}
         </select>
         <div className="text-xs text-slate-500">Сегодня: {fmtDate(today.toISOString())}</div>
       </div>
@@ -77,7 +99,7 @@ export default function AttendanceTab({
               <th className="text-left p-2">Ученик</th>
               <th className="text-left p-2">Район</th>
               <th className="text-left p-2">Группа</th>
-              <th className="text-left p-2">Отметка</th>
+              <th className="text-left p-2">Оценка</th>
             </tr>
           </thead>
         )}
@@ -99,8 +121,17 @@ export default function AttendanceTab({
               <td className="p-2">{c.area}</td>
               <td className="p-2">{c.group}</td>
               <td className="p-2">
-                <button onClick={() => toggle(c.id)} className={`px-3 py-1 rounded-md text-xs border ${m?.came ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700" : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"}`}>
-                  {m?.came ? "пришёл" : "не отмечен"}
+                <button
+                  onClick={() => toggle(c.id)}
+                  className={`px-3 py-1 rounded-md text-xs border ${
+                    m
+                      ? m.successful
+                        ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700"
+                        : "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700"
+                      : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"
+                  }`}
+                >
+                  {m ? (m.successful ? "успевает" : "нужна работа") : "не оценён"}
                 </button>
               </td>
             </tr>

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -12,6 +12,7 @@ const TABS: TabConfig[] = [
   { key: "dashboard", title: "Дашборд" },
   { key: "clients", title: "Клиенты", need: r => can(r, "manage_clients") },
   { key: "attendance", title: "Посещаемость", need: r => can(r, "attendance") },
+  { key: "performance", title: "Успеваемость", need: r => can(r, "performance") },
   { key: "tasks", title: "Задачи", need: r => can(r, "tasks") },
   { key: "schedule", title: "Расписание", need: r => can(r, "schedule") },
   { key: "leads", title: "Лиды", need: r => can(r, "leads") },

--- a/src/components/clients/ClientDetailsModal.tsx
+++ b/src/components/clients/ClientDetailsModal.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import Modal from "../Modal";
+import { calcAgeYears, calcExperience, fmtMoney } from "../../state/utils";
+import type { Client, Currency } from "../../types";
+
+interface Props {
+  client: Client;
+  currency: Currency;
+  onClose: () => void;
+  onEdit?: (client: Client) => void;
+  onRemove?: (id: string) => void;
+}
+
+export default function ClientDetailsModal({ client, currency, onClose, onEdit, onRemove }: Props) {
+  return (
+    <Modal size="md" onClose={onClose}>
+      <div className="font-semibold text-slate-800 dark:text-slate-100">
+        {client.firstName} {client.lastName}
+      </div>
+      <div className="grid gap-1 text-sm">
+        <div>
+          <span className="text-slate-500">Телефон:</span> {client.phone || "—"}
+        </div>
+        <div>
+          <span className="text-slate-500">Канал:</span> {client.channel}
+        </div>
+        <div>
+          <span className="text-slate-500">Родитель:</span> {client.parentName || "—"}
+        </div>
+        <div>
+          <span className="text-slate-500">Дата рождения:</span> {client.birthDate?.slice(0, 10)}
+        </div>
+        <div>
+          <span className="text-slate-500">Возраст:</span> {client.birthDate ? `${calcAgeYears(client.birthDate)} лет` : "—"}
+        </div>
+        <div>
+          <span className="text-slate-500">Район:</span> {client.area}
+        </div>
+        <div>
+          <span className="text-slate-500">Группа:</span> {client.group}
+        </div>
+        <div>
+          <span className="text-slate-500">Опыт:</span> {client.startDate ? calcExperience(client.startDate) : "—"}
+        </div>
+        <div>
+          <span className="text-slate-500">Статус оплаты:</span> {client.payStatus}
+        </div>
+        <div>
+          <span className="text-slate-500">Дата оплаты:</span> {client.payDate?.slice(0, 10) || "—"}
+        </div>
+        <div>
+          <span className="text-slate-500">Сумма оплаты:</span> {client.payAmount != null ? fmtMoney(client.payAmount, currency) : "—"}
+        </div>
+      </div>
+      <div className="flex justify-end gap-2">
+        {onEdit && (
+          <button
+            type="button"
+            onClick={() => {
+              onEdit(client);
+              onClose();
+            }}
+            className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600"
+          >
+            Редактировать
+          </button>
+        )}
+        {onRemove && (
+          <button
+            type="button"
+            onClick={() => {
+              onRemove(client.id);
+              onClose();
+            }}
+            className="px-3 py-2 rounded-md border border-rose-200 text-rose-600 dark:border-rose-700"
+          >
+            Удалить
+          </button>
+        )}
+        <button type="button" onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600">
+          Закрыть
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from "react";
 import VirtualizedTable from "../VirtualizedTable";
-import Modal from "../Modal";
-import { fmtMoney, calcAgeYears, calcExperience } from "../../state/utils";
-import type { Client, UIState } from "../../types";
+import ClientDetailsModal from "./ClientDetailsModal";
+import { fmtMoney } from "../../state/utils";
+import type { Client, Currency } from "../../types";
 
 type Props = {
-  list: Client[],
-  ui: UIState,
-  onEdit: (c: Client) => void,
-  onRemove: (id: string) => void,
+  list: Client[];
+  currency: Currency;
+  onEdit: (c: Client) => void;
+  onRemove: (id: string) => void;
 };
 
-export default function ClientTable({ list, ui, onEdit, onRemove }: Props) {
+export default function ClientTable({ list, currency, onEdit, onRemove }: Props) {
   const [selected, setSelected] = useState<Client | null>(null);
 
   return (
@@ -53,7 +53,7 @@ export default function ClientTable({ list, ui, onEdit, onRemove }: Props) {
                 {c.payStatus}
               </span>
             </td>
-            <td className="p-2">{c.payAmount != null ? fmtMoney(c.payAmount, ui.currency) : "—"}</td>
+            <td className="p-2">{c.payAmount != null ? fmtMoney(c.payAmount, currency) : "—"}</td>
             <td className="p-2 text-right">
               <button
                 onClick={() => onEdit(c)}
@@ -73,71 +73,14 @@ export default function ClientTable({ list, ui, onEdit, onRemove }: Props) {
       />
 
       {selected && (
-        <Modal size="md" onClose={() => setSelected(null)}>
-          <div className="font-semibold text-slate-800">
-            {selected.firstName} {selected.lastName}
-          </div>
-          <div className="grid gap-1 text-sm">
-            <div>
-              <span className="text-slate-500">Телефон:</span> {selected.phone || "—"}
-            </div>
-            <div>
-              <span className="text-slate-500">Канал:</span> {selected.channel}
-            </div>
-            <div>
-              <span className="text-slate-500">Родитель:</span> {selected.parentName || "—"}
-            </div>
-            <div>
-              <span className="text-slate-500">Дата рождения:</span> {selected.birthDate?.slice(0, 10)}
-            </div>
-            <div>
-              <span className="text-slate-500">Возраст:</span> {selected.birthDate ? `${calcAgeYears(selected.birthDate)} лет` : "—"}
-            </div>
-            <div>
-              <span className="text-slate-500">Район:</span> {selected.area}
-            </div>
-            <div>
-              <span className="text-slate-500">Группа:</span> {selected.group}
-            </div>
-            <div>
-              <span className="text-slate-500">Опыт:</span> {selected.startDate ? calcExperience(selected.startDate) : "—"}
-            </div>
-            <div>
-              <span className="text-slate-500">Статус оплаты:</span> {selected.payStatus}
-            </div>
-            <div>
-              <span className="text-slate-500">Дата оплаты:</span> {selected.payDate?.slice(0, 10) || "—"}
-            </div>
-            <div>
-              <span className="text-slate-500">Сумма оплаты:</span> {selected.payAmount != null ? fmtMoney(selected.payAmount, ui.currency) : "—"}
-            </div>
-          </div>
-          <div className="flex justify-end gap-2">
-            <button
-              onClick={() => {
-                onEdit(selected);
-                setSelected(null);
-              }}
-              className="px-3 py-2 rounded-md border border-slate-300"
-            >
-              Редактировать
-            </button>
-            <button
-              onClick={() => {
-                onRemove(selected.id);
-                setSelected(null);
-              }}
-              className="px-3 py-2 rounded-md border border-rose-200 text-rose-600"
-            >
-              Удалить
-            </button>
-            <button onClick={() => setSelected(null)} className="px-3 py-2 rounded-md border border-slate-300">
-              Закрыть
-            </button>
-          </div>
-        </Modal>
+        <ClientDetailsModal
+          client={selected}
+          currency={currency}
+          onEdit={onEdit}
+          onRemove={onRemove}
+          onClose={() => setSelected(null)}
+        />
       )}
     </>
   );
 }
-

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -71,6 +71,7 @@ export function can(
     | "all"
     | "manage_clients"
     | "attendance"
+    | "performance"
     | "schedule"
     | "leads"
     | "tasks"
@@ -79,12 +80,12 @@ export function can(
 ) {
   if (role === "Администратор") return true;
   if (role === "Менеджер") {
-    return ["manage_clients", "leads", "tasks", "attendance", "schedule", "appeals"].includes(
+    return ["manage_clients", "leads", "tasks", "attendance", "performance", "schedule", "appeals"].includes(
       feature,
     );
   }
   if (role === "Тренер") {
-    return ["attendance", "schedule"].includes(feature);
+    return ["attendance", "performance", "schedule"].includes(feature);
   }
   return false;
 }

--- a/src/state/seed.ts
+++ b/src/state/seed.ts
@@ -11,6 +11,7 @@ import type {
   StaffMember,
   TaskItem,
   AttendanceEntry,
+  PerformanceEntry,
 } from "../types";
 
 export function makeSeedDB(): DB {
@@ -127,12 +128,19 @@ export function makeSeedDB(): DB {
 
   const leads: Lead[] = [];
   const attendance: AttendanceEntry[] = [];
+  const performance: PerformanceEntry[] = [];
   for (const c of clients) {
     const entries = rnd(3, 8);
     for (let i = 0; i < entries; i++) {
       const d = new Date();
       d.setDate(d.getDate() - rnd(1, 25));
       attendance.push({ id: uid(), clientId: c.id, date: d.toISOString(), came: Math.random() < 0.8 });
+    }
+    const perfEntries = rnd(2, 5);
+    for (let i = 0; i < perfEntries; i++) {
+      const d = new Date();
+      d.setDate(d.getDate() - rnd(1, 30));
+      performance.push({ id: uid(), clientId: c.id, date: d.toISOString(), successful: Math.random() < 0.7 });
     }
   }
 
@@ -170,6 +178,7 @@ export function makeSeedDB(): DB {
   return {
     clients,
     attendance,
+    performance,
     schedule,
     leads,
     tasks,

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,14 @@ export interface AttendanceEntry {
   sourceArea?: Area; // для отработок
 }
 
+export interface PerformanceEntry {
+  id: string;
+  clientId: string;
+  date: string; // ISO
+  successful: boolean;
+  note?: string;
+}
+
 export interface ScheduleSlot {
   id: string;
   area: Area;
@@ -127,6 +135,7 @@ export interface Settings {
 export interface DB {
   clients: Client[];
   attendance: AttendanceEntry[];
+  performance: PerformanceEntry[];
   schedule: ScheduleSlot[];
   leads: Lead[];
   tasks: TaskItem[];
@@ -148,6 +157,7 @@ export type TabKey =
   | "dashboard"
   | "clients"
   | "attendance"
+  | "performance"
   | "tasks"
   | "schedule"
   | "leads"


### PR DESCRIPTION
## Summary
- make attendance names open the client details modal for quick access to profile information
- extract a reusable client details modal and reuse it in the clients list
- add a new "Успеваемость" tab with daily performance tracking backed by seeded demo data
- extend routing, permissions, and types to support performance records

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cb276af804832bb9f1d14500afb908