### PR TITLE
Fix client table modal reference and typings

### DIFF
--- a/src/components/VirtualizedTable.tsx
+++ b/src/components/VirtualizedTable.tsx
@@ -25,7 +25,7 @@ type VirtualizedTableProps<T> = {
   items: T[];
   rowHeight: number;
   height?: number;
-  renderRow: (item: T, style: React.CSSProperties) => React.ReactNode;
+  renderRow: (item: T, style: React.CSSProperties) => React.ReactElement;
 };
 
 export default function VirtualizedTable<T>({

--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -1,19 +1,19 @@
 import React, { useState } from "react";
 import VirtualizedTable from "../VirtualizedTable";
-import Modal from "../Modal";
-import { fmtMoney, calcAgeYears, calcExperience, fmtDate } from "../../state/utils";
-import type { Client, UIState } from "../../types";
+import ClientDetailsModal from "./ClientDetailsModal";
+import { fmtMoney, fmtDate } from "../../state/utils";
+import type { Client, Currency } from "../../types";
 
 type Props = {
-  list: Client[],
-  ui: UIState,
-  onEdit: (c: Client) => void,
-  onRemove: (id: string) => void,
-  onTogglePayFact: (id: string, value: boolean) => void,
-  onCreateTask: (client: Client) => void,
+  list: Client[];
+  currency: Currency;
+  onEdit: (c: Client) => void;
+  onRemove: (id: string) => void;
+  onTogglePayFact: (id: string, value: boolean) => void;
+  onCreateTask: (client: Client) => void;
 };
 
-export default function ClientTable({ list, ui, onEdit, onRemove, onTogglePayFact, onCreateTask }: Props) {
+export default function ClientTable({ list, currency, onEdit, onRemove, onTogglePayFact, onCreateTask }: Props) {
 
   const [selected, setSelected] = useState<Client | null>(null);
 
@@ -58,7 +58,7 @@ export default function ClientTable({ list, ui, onEdit, onRemove, onTogglePayFac
                 {c.payStatus}
               </span>
             </td>
-            <td className="p-2">{c.payAmount != null ? fmtMoney(c.payAmount, ui.currency) : "—"}</td>
+            <td className="p-2">{c.payAmount != null ? fmtMoney(c.payAmount, currency) : "—"}</td>
             <td className="p-2 text-center">
               <input
                 type="checkbox"


### PR DESCRIPTION
## Summary
- import and use the client details modal within the client table and pass currency explicitly
- tighten the virtualized table row render typing to return React elements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbcd053610832bb04098c820f23db7