### PR TITLE
Fix virtualized table alignment and add local persistence fallback

### DIFF
--- a/src/components/AttendanceTab.tsx
+++ b/src/components/AttendanceTab.tsx
@@ -16,6 +16,7 @@ export default function AttendanceTab({
   setDB: Dispatch<SetStateAction<DB>>;
   currency: Currency;
 }) {
+  const COLUMN_TEMPLATE = "220px 1fr 1fr 180px";
   const [area, setArea] = useState<Area | "all">("all");
   const [group, setGroup] = useState<Group | "all">("all");
   const [selected, setSelected] = useState<Client | null>(null);
@@ -73,11 +74,15 @@ export default function AttendanceTab({
       <VirtualizedTable
         header={(
           <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-            <tr>
+            <tr
+              style={{ display: "grid", gridTemplateColumns: COLUMN_TEMPLATE, alignItems: "center" }}
+            >
               <th className="text-left p-2">Ученик</th>
               <th className="text-left p-2">Район</th>
               <th className="text-left p-2">Группа</th>
-              <th className="text-left p-2">Отметка</th>
+              <th className="text-left p-2" style={{ justifySelf: "end" }}>
+                Отметка
+              </th>
             </tr>
           </thead>
         )}
@@ -86,7 +91,16 @@ export default function AttendanceTab({
         renderRow={(c, style) => {
           const m = todayMarks.get(c.id);
           return (
-            <tr key={c.id} style={style} className="border-t border-slate-100 dark:border-slate-700">
+            <tr
+              key={c.id}
+              style={{
+                ...style,
+                display: "grid",
+                gridTemplateColumns: COLUMN_TEMPLATE,
+                alignItems: "center",
+              }}
+              className="border-t border-slate-100 dark:border-slate-700"
+            >
               <td className="p-2">
                 <button
                   type="button"
@@ -98,8 +112,15 @@ export default function AttendanceTab({
               </td>
               <td className="p-2">{c.area}</td>
               <td className="p-2">{c.group}</td>
-              <td className="p-2">
-                <button onClick={() => toggle(c.id)} className={`px-3 py-1 rounded-md text-xs border ${m?.came ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700" : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"}`}>
+              <td className="p-2 flex justify-end">
+                <button
+                  onClick={() => toggle(c.id)}
+                  className={`px-3 py-1 rounded-md text-xs border ${
+                    m?.came
+                      ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700"
+                      : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"
+                  }`}
+                >
                   {m?.came ? "пришёл" : "не отмечен"}
                 </button>
               </td>

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -16,6 +16,7 @@ export default function PerformanceTab({
   setDB: Dispatch<SetStateAction<DB>>;
   currency: Currency;
 }) {
+  const COLUMN_TEMPLATE = "220px 1fr 1fr 200px";
   const [area, setArea] = useState<Area | "all">("all");
   const [group, setGroup] = useState<Group | "all">("all");
   const [selected, setSelected] = useState<Client | null>(null);
@@ -95,11 +96,15 @@ export default function PerformanceTab({
       <VirtualizedTable
         header={(
           <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-            <tr>
+            <tr
+              style={{ display: "grid", gridTemplateColumns: COLUMN_TEMPLATE, alignItems: "center" }}
+            >
               <th className="text-left p-2">Ученик</th>
               <th className="text-left p-2">Район</th>
               <th className="text-left p-2">Группа</th>
-              <th className="text-left p-2">Оценка</th>
+              <th className="text-left p-2" style={{ justifySelf: "end" }}>
+                Оценка
+              </th>
             </tr>
           </thead>
         )}
@@ -108,7 +113,16 @@ export default function PerformanceTab({
         renderRow={(c, style) => {
           const m = todayMarks.get(c.id);
           return (
-            <tr key={c.id} style={style} className="border-t border-slate-100 dark:border-slate-700">
+            <tr
+              key={c.id}
+              style={{
+                ...style,
+                display: "grid",
+                gridTemplateColumns: COLUMN_TEMPLATE,
+                alignItems: "center",
+              }}
+              className="border-t border-slate-100 dark:border-slate-700"
+            >
               <td className="p-2">
                 <button
                   type="button"
@@ -120,7 +134,7 @@ export default function PerformanceTab({
               </td>
               <td className="p-2">{c.area}</td>
               <td className="p-2">{c.group}</td>
-              <td className="p-2">
+              <td className="p-2 flex justify-end">
                 <button
                   onClick={() => toggle(c.id)}
                   className={`px-3 py-1 rounded-md text-xs border ${

--- a/src/components/VirtualizedTable.tsx
+++ b/src/components/VirtualizedTable.tsx
@@ -25,7 +25,7 @@ type VirtualizedTableProps<T> = {
   items: T[];
   rowHeight: number;
   height?: number;
-  renderRow: (item: T, style: React.CSSProperties) => React.ReactNode;
+  renderRow: (item: T, style: React.CSSProperties) => React.ReactElement;
 };
 
 export default function VirtualizedTable<T>({

--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -1,19 +1,33 @@
 import React, { useState } from "react";
 import VirtualizedTable from "../VirtualizedTable";
-import Modal from "../Modal";
-import { fmtMoney, calcAgeYears, calcExperience, fmtDate } from "../../state/utils";
-import type { Client, UIState } from "../../types";
+import ClientDetailsModal from "./ClientDetailsModal";
+import { fmtMoney, fmtDate } from "../../state/utils";
+import type { Client, Currency } from "../../types";
 
 type Props = {
-  list: Client[],
-  ui: UIState,
-  onEdit: (c: Client) => void,
-  onRemove: (id: string) => void,
-  onTogglePayFact: (id: string, value: boolean) => void,
-  onCreateTask: (client: Client) => void,
+  list: Client[];
+  currency: Currency;
+  onEdit: (c: Client) => void;
+  onRemove: (id: string) => void;
+  onTogglePayFact: (id: string, value: boolean) => void;
+  onCreateTask: (client: Client) => void;
 };
 
-export default function ClientTable({ list, ui, onEdit, onRemove, onTogglePayFact, onCreateTask }: Props) {
+const COLUMN_WIDTHS = [
+  "220px", // name
+  "150px", // phone
+  "140px", // area
+  "140px", // group
+  "160px", // payment status
+  "150px", // payment amount
+  "120px", // payment fact
+  "150px", // payment date
+  "260px", // actions
+];
+
+const COLUMN_TEMPLATE = COLUMN_WIDTHS.join(" ");
+
+export default function ClientTable({ list, currency, onEdit, onRemove, onTogglePayFact, onCreateTask }: Props) {
 
   const [selected, setSelected] = useState<Client | null>(null);
 
@@ -22,29 +36,74 @@ export default function ClientTable({ list, ui, onEdit, onRemove, onTogglePayFac
       <VirtualizedTable
         header={(
           <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-            <tr>
-              <th className="text-left p-2">Имя</th>
-              <th className="text-left p-2">Телефон</th>
-              <th className="text-left p-2">Район</th>
-              <th className="text-left p-2">Группа</th>
-              <th className="text-left p-2">Статус оплаты</th>
-              <th className="text-left p-2">Сумма оплаты</th>
-              <th className="text-center p-2">Факт оплаты</th>
-              <th className="text-left p-2">Дата оплаты</th>
-              <th className="text-right p-2">Действия</th>
+            <tr
+              className="w-full"
+              style={{ display: "grid", gridTemplateColumns: COLUMN_TEMPLATE, alignItems: "center" }}
+            >
+              <th className="text-left p-2">
+                Имя
+              </th>
+              <th className="text-left p-2">
+                Телефон
+              </th>
+              <th className="text-left p-2">
+                Район
+              </th>
+              <th className="text-left p-2">
+                Группа
+              </th>
+              <th className="text-left p-2">
+                Статус оплаты
+              </th>
+              <th className="text-left p-2">
+                Сумма оплаты
+              </th>
+              <th className="text-center p-2">
+                Факт оплаты
+              </th>
+              <th className="text-left p-2">
+                Дата оплаты
+              </th>
+              <th className="text-right p-2" style={{ justifySelf: "end" }}>
+                Действия
+              </th>
             </tr>
           </thead>
         )}
         items={list}
         rowHeight={48}
         renderRow={(c, style) => (
-          <tr key={c.id} style={style} className="border-t border-slate-100 dark:border-slate-700">
-            <td className="p-2 cursor-pointer" onClick={() => setSelected(c)}>
-              {c.firstName} {c.lastName}
+          <tr
+            key={c.id}
+            style={{
+              ...style,
+              display: "grid",
+              gridTemplateColumns: COLUMN_TEMPLATE,
+              alignItems: "center",
+            }}
+            className="border-t border-slate-100 dark:border-slate-700"
+          >
+            <td className="p-2" onClick={() => setSelected(c)}>
+              <button
+                type="button"
+                onClick={e => {
+                  e.stopPropagation();
+                  onEdit(c);
+                }}
+                className="text-left text-sky-600 hover:underline focus:outline-none dark:text-sky-400"
+              >
+                {c.firstName} {c.lastName}
+              </button>
             </td>
-            <td className="p-2">{c.phone}</td>
-            <td className="p-2">{c.area}</td>
-            <td className="p-2">{c.group}</td>
+            <td className="p-2">
+              {c.phone}
+            </td>
+            <td className="p-2">
+              {c.area}
+            </td>
+            <td className="p-2">
+              {c.group}
+            </td>
             <td className="p-2">
               <span
                 className={`px-2 py-1 rounded-full text-xs ${
@@ -58,7 +117,9 @@ export default function ClientTable({ list, ui, onEdit, onRemove, onTogglePayFac
                 {c.payStatus}
               </span>
             </td>
-            <td className="p-2">{c.payAmount != null ? fmtMoney(c.payAmount, ui.currency) : "—"}</td>
+            <td className="p-2">
+              {c.payAmount != null ? fmtMoney(c.payAmount, currency) : "—"}
+            </td>
             <td className="p-2 text-center">
               <input
                 type="checkbox"
@@ -67,17 +128,19 @@ export default function ClientTable({ list, ui, onEdit, onRemove, onTogglePayFac
                 onChange={e => onTogglePayFact(c.id, e.target.checked)}
               />
             </td>
-            <td className="p-2">{c.payDate ? fmtDate(c.payDate) : "—"}</td>
-            <td className="p-2 text-right">
+            <td className="p-2">
+              {c.payDate ? fmtDate(c.payDate) : "—"}
+            </td>
+            <td className="p-2 flex justify-end gap-1">
               <button
                 onClick={() => onCreateTask(c)}
-                className="px-2 py-1 text-xs rounded-md border border-sky-200 text-sky-600 hover:bg-sky-50 mr-1 dark:border-sky-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+                className="px-2 py-1 text-xs rounded-md border border-sky-200 text-sky-600 hover:bg-sky-50 dark:border-sky-700 dark:bg-slate-800 dark:hover:bg-slate-700"
               >
                 Создать задачу
               </button>
               <button
                 onClick={() => onEdit(c)}
-                className="px-2 py-1 text-xs rounded-md border border-slate-300 mr-1 dark:border-slate-700 dark:bg-slate-800"
+                className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
               >
                 Редактировать
               </button>


### PR DESCRIPTION
## Summary
- render the client, attendance, and performance tables with shared CSS grid templates so virtualized rows stay aligned with their headers
- let client names trigger edit actions while keeping row clicks available for the details modal
- persist database updates to localStorage whenever Firestore/auth are unavailable and sync local storage when snapshots arrive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbcd053610832bb04098c820f23db7