### PR TITLE
Handle local-only mode when Firestore is unavailable

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ import AppealsTab from "./components/AppealsTab";
 import QuickAddModal from "./components/QuickAddModal";
 import Toasts from "./components/Toasts";
 import ErrorBoundary from "./components/ErrorBoundary";
-import { useAppState, can } from "./state/appState";
+import { useAppState, can, LOCAL_ONLY_MESSAGE } from "./state/appState";
 
 export default function App() {
   /** @type {import("./state/appState").AppState} */
@@ -27,6 +27,7 @@ export default function App() {
     setUI,
     roles,
     toasts,
+    isLocalOnly,
     quickOpen,
     onQuickAdd,
     setQuickOpen,
@@ -38,6 +39,13 @@ export default function App() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-white to-sky-50 text-slate-900 dark:from-slate-900 dark:to-slate-950 dark:text-slate-100">
       <Topbar ui={ui} setUI={setUI} roleList={roles} onQuickAdd={onQuickAdd} />
+      {isLocalOnly ? (
+        <div className="bg-amber-100 border-y border-amber-200 text-amber-900 dark:bg-amber-900/70 dark:border-amber-800 dark:text-amber-100">
+          <div className="max-w-7xl mx-auto px-3 py-2 text-sm font-medium" role="alert">
+            {LOCAL_ONLY_MESSAGE}
+          </div>
+        </div>
+      ) : null}
       <Tabs role={ui.role} />
 
       <main className="max-w-7xl mx-auto p-3 space-y-3">

--- a/src/state/__tests__/useAppState.firebase.test.tsx
+++ b/src/state/__tests__/useAppState.firebase.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 
-import { useAppState } from "../appState";
+import { LOCAL_ONLY_MESSAGE, useAppState } from "../appState";
 
 const mockPush = jest.fn();
 
@@ -26,12 +26,13 @@ describe("useAppState without firebase configuration", () => {
     mockPush.mockClear();
   });
 
-  it("shows the offline toast only once", async () => {
+  it("shows the local-only toast only once", async () => {
     const wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
 
-    renderHook(() => useAppState(), { wrapper });
+    const { result } = renderHook(() => useAppState(), { wrapper });
 
     await waitFor(() => expect(mockPush).toHaveBeenCalledTimes(1));
-    expect(mockPush).toHaveBeenCalledWith("Нет подключения к базе данных", "error");
+    expect(mockPush).toHaveBeenCalledWith(LOCAL_ONLY_MESSAGE, "warning");
+    expect(result.current.isLocalOnly).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- track an `isLocalOnly` flag in the app state, logging and showing a toast whenever the app falls back to local data and resetting it once Firestore sync resumes
- surface a persistent banner in the UI to warn users when data is stored locally only
- update the Firebase-less app state test to cover the new warning behavior

## Testing
- npm test -- --runTestsByPath src/state/__tests__/useAppState.firebase.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cbfc0267d8832bbecc7cc8e8547a97