### PR TITLE
Add warning toast variant

### DIFF
--- a/src/components/Toasts.tsx
+++ b/src/components/Toasts.tsx
@@ -29,7 +29,9 @@ export default function Toasts({ toasts }: { toasts: Toast[] }) {
               ? "bg-emerald-50 border-emerald-200 text-emerald-800 dark:bg-emerald-900/30 dark:border-emerald-700 dark:text-emerald-300"
               : t.type === "error"
                 ? "bg-rose-50 border-rose-200 text-rose-800 dark:bg-rose-900/30 dark:border-rose-700 dark:text-rose-300"
-                : "bg-slate-50 border-slate-200 text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+                : t.type === "warning"
+                  ? "bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-900/30 dark:border-amber-700 dark:text-amber-300"
+                  : "bg-slate-50 border-slate-200 text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
           }`}
         >
           {t.text}

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,5 +165,9 @@ export type TabKey =
   | "appeals"
   | "settings";
 
-export type Toast = { id: string; text: string; type?: "success" | "error" | "info" };
+export type Toast = {
+  id: string;
+  text: string;
+  type?: "success" | "error" | "info" | "warning";
+};
 


### PR DESCRIPTION
## Summary
- allow warning toast type in shared Toast type definition
- render warning toasts with amber styling so they stand out in the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc009fc544832b89fc5875cf5b7943