### PR TITLE
Handle local DB persistence when Firestore unavailable

### DIFF
--- a/src/state/__tests__/useAppState.test.tsx
+++ b/src/state/__tests__/useAppState.test.tsx
@@ -1,0 +1,72 @@
+// @ts-nocheck
+import '@testing-library/jest-dom';
+import { act, renderHook } from '@testing-library/react';
+
+const mockPush = jest.fn();
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    __esModule: true,
+    useLocation: () => ({ pathname: '/' }),
+  }),
+  { virtual: true },
+);
+
+jest.mock('../../components/Toasts', () => ({
+  __esModule: true,
+  useToasts: () => ({ toasts: [], push: mockPush }),
+}));
+
+jest.mock('../../firebase', () => ({
+  __esModule: true,
+  db: undefined,
+  ensureSignedIn: jest.fn().mockResolvedValue(false),
+}));
+
+import { commitDBUpdate, LS_KEYS, LOCAL_ONLY_MESSAGE, useAppState } from '../appState';
+
+describe('useAppState with local persistence', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    localStorage.clear();
+  });
+
+  it('commits updates locally when Firestore is disabled', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAppState());
+
+    await act(async () => {});
+
+    expect(mockPush).toHaveBeenCalledWith(LOCAL_ONLY_MESSAGE, 'warning');
+
+    const next = {
+      ...result.current.db,
+      changelog: [
+        ...result.current.db.changelog,
+        { id: 'local-change', who: 'Тест', what: 'Локальное сохранение', when: new Date().toISOString() },
+      ],
+    };
+
+    let persisted = false;
+    await act(async () => {
+      persisted = await commitDBUpdate(next, result.current.setDB);
+    });
+
+    expect(persisted).toBe(true);
+    expect(result.current.db).toEqual(next);
+
+    const stored = localStorage.getItem(LS_KEYS.db);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored as string)).toEqual(next);
+
+    const errorToastCalls = mockPush.mock.calls.filter(([, type]) => type === 'error');
+    expect(errorToastCalls).toHaveLength(0);
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -128,7 +128,8 @@ function writeLocalDB(dbData: DB) {
 export async function saveDB(dbData: DB): Promise<boolean> {
   if (!firestore) {
     console.warn("Firestore not initialized. Changes cannot be synchronized.");
-    return false;
+    writeLocalDB(dbData);
+    return true;
   }
 
   let signedIn = false;


### PR DESCRIPTION
## Summary
- persist database changes to local storage and report success when Firestore is unavailable
- add a unit test for useAppState to cover local commits without Firestore errors

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cc04ba8a94832b9c7cc6df0e98b833