### PR TITLE
feat: customize tables and automate payments

### DIFF
--- a/src/components/AttendanceTab.tsx
+++ b/src/components/AttendanceTab.tsx
@@ -5,6 +5,8 @@ import VirtualizedTable from "./VirtualizedTable";
 import ClientDetailsModal from "./clients/ClientDetailsModal";
 import { fmtDate, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
+import ColumnSettings from "./ColumnSettings";
+import { compareValues, toggleSort, type SortState } from "./tableUtils";
 import type { DB, Area, Group, AttendanceEntry, Client, Currency } from "../types";
 
 export default function AttendanceTab({
@@ -16,10 +18,11 @@ export default function AttendanceTab({
   setDB: Dispatch<SetStateAction<DB>>;
   currency: Currency;
 }) {
-  const COLUMN_TEMPLATE = "220px 1fr 1fr 180px";
   const [area, setArea] = useState<Area | "all">("all");
   const [group, setGroup] = useState<Group | "all">("all");
   const [selected, setSelected] = useState<Client | null>(null);
+  const [visibleColumns, setVisibleColumns] = useState<string[]>(["name", "area", "group", "mark"]);
+  const [sort, setSort] = useState<SortState | null>(null);
   const today = new Date();
   const todayStr = today.toISOString().slice(0, 10);
 
@@ -56,6 +59,88 @@ export default function AttendanceTab({
     }
   };
 
+  const columns = useMemo(
+    () => [
+      {
+        id: "name",
+        label: "Ученик",
+        width: "220px",
+        renderCell: (client: Client) => (
+          <button
+            type="button"
+            onClick={() => setSelected(client)}
+            className="text-sky-600 hover:underline focus:outline-none dark:text-sky-400"
+          >
+            {client.firstName} {client.lastName}
+          </button>
+        ),
+        sortValue: (client: Client) => `${client.firstName} ${client.lastName ?? ""}`.trim().toLowerCase(),
+      },
+      {
+        id: "area",
+        label: "Район",
+        width: "1fr",
+        renderCell: (client: Client) => client.area,
+        sortValue: (client: Client) => client.area,
+      },
+      {
+        id: "group",
+        label: "Группа",
+        width: "1fr",
+        renderCell: (client: Client) => client.group,
+        sortValue: (client: Client) => client.group,
+      },
+      {
+        id: "mark",
+        label: "Отметка",
+        width: "180px",
+        headerAlign: "right",
+        renderCell: (client: Client) => {
+          const mark = todayMarks.get(client.id);
+          return (
+            <div className="flex justify-end">
+              <button
+                onClick={() => toggle(client.id)}
+                className={`px-3 py-1 rounded-md text-xs border ${
+                  mark?.came
+                    ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700"
+                    : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"
+                }`}
+              >
+                {mark?.came ? "пришёл" : "не отмечен"}
+              </button>
+            </div>
+          );
+        },
+        sortValue: (client: Client) => {
+          const mark = todayMarks.get(client.id);
+          if (!mark) return 0;
+          return mark.came ? 2 : 1;
+        },
+      },
+    ],
+    [setSelected, todayMarks, toggle],
+  );
+
+  const activeColumns = useMemo(
+    () => columns.filter(column => visibleColumns.includes(column.id)),
+    [columns, visibleColumns],
+  );
+
+  const sortedClients = useMemo(() => {
+    if (!sort) return list;
+    const column = columns.find(col => col.id === sort.columnId);
+    if (!column?.sortValue) return list;
+    const copy = [...list];
+    copy.sort((a, b) => {
+      const compare = compareValues(column.sortValue!(a), column.sortValue!(b));
+      return sort.direction === "asc" ? compare : -compare;
+    });
+    return copy;
+  }, [columns, list, sort]);
+
+  const columnTemplate = activeColumns.length ? activeColumns.map(column => column.width).join(" ") : "1fr";
+
   return (
     <div className="space-y-3">
       <Breadcrumbs items={["Посещаемость"]} />
@@ -69,61 +154,74 @@ export default function AttendanceTab({
           {db.settings.groups.map(g => <option key={g}>{g}</option>)}
         </select>
         <div className="text-xs text-slate-500">Сегодня: {fmtDate(today.toISOString())}</div>
+        <div className="grow" />
+        <ColumnSettings
+          options={columns.map(column => ({ id: column.id, label: column.label }))}
+          value={visibleColumns}
+          onChange={setVisibleColumns}
+        />
       </div>
 
       <VirtualizedTable
         header={(
           <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
             <tr
-              style={{ display: "grid", gridTemplateColumns: COLUMN_TEMPLATE, alignItems: "center" }}
+              style={{ display: "grid", gridTemplateColumns: columnTemplate, alignItems: "center" }}
             >
-              <th className="text-left p-2">Ученик</th>
-              <th className="text-left p-2">Район</th>
-              <th className="text-left p-2">Группа</th>
-              <th className="text-left p-2" style={{ justifySelf: "end" }}>
-                Отметка
-              </th>
+              {activeColumns.map(column => {
+                const canSort = Boolean(column.sortValue);
+                const isSorted = sort?.columnId === column.id;
+                const indicator = isSorted ? (sort?.direction === "asc" ? "↑" : "↓") : null;
+                const alignment = column.headerAlign ?? "left";
+                const justify = alignment === "right" ? "justify-end" : alignment === "center" ? "justify-center" : "";
+                const content = (
+                  <div className={`flex items-center gap-1 ${justify}`}>
+                    <span>{column.label}</span>
+                    {indicator && <span className="text-xs">{indicator}</span>}
+                  </div>
+                );
+                return (
+                  <th
+                    key={column.id}
+                    className={`p-2 ${alignment === "right" ? "text-right" : alignment === "center" ? "text-center" : "text-left"}`}
+                    style={{ cursor: canSort ? "pointer" : "default" }}
+                  >
+                    {canSort ? (
+                      <button
+                        type="button"
+                        className="flex w-full items-center justify-between gap-1 focus:outline-none"
+                        onClick={() => setSort(prev => toggleSort(prev, column.id))}
+                      >
+                        {content}
+                      </button>
+                    ) : (
+                      content
+                    )}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
         )}
-        items={list}
+        items={sortedClients}
         rowHeight={44}
         renderRow={(c, style) => {
-          const m = todayMarks.get(c.id);
           return (
             <tr
               key={c.id}
               style={{
                 ...style,
                 display: "grid",
-                gridTemplateColumns: COLUMN_TEMPLATE,
+                gridTemplateColumns: columnTemplate,
                 alignItems: "center",
               }}
               className="border-t border-slate-100 dark:border-slate-700"
             >
-              <td className="p-2">
-                <button
-                  type="button"
-                  onClick={() => setSelected(c)}
-                  className="text-sky-600 hover:underline focus:outline-none dark:text-sky-400"
-                >
-                  {c.firstName} {c.lastName}
-                </button>
-              </td>
-              <td className="p-2">{c.area}</td>
-              <td className="p-2">{c.group}</td>
-              <td className="p-2 flex justify-end">
-                <button
-                  onClick={() => toggle(c.id)}
-                  className={`px-3 py-1 rounded-md text-xs border ${
-                    m?.came
-                      ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700"
-                      : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"
-                  }`}
-                >
-                  {m?.came ? "пришёл" : "не отмечен"}
-                </button>
-              </td>
+              {activeColumns.map(column => (
+                <td key={column.id} className="p-2">
+                  {column.renderCell(c)}
+                </td>
+              ))}
             </tr>
           );
         }}

--- a/src/components/ColumnSettings.tsx
+++ b/src/components/ColumnSettings.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useRef, useState } from "react";
+
+export interface ColumnOption {
+  id: string;
+  label: string;
+  disableToggle?: boolean;
+}
+
+interface ColumnSettingsProps {
+  options: ColumnOption[];
+  value: string[];
+  onChange: (next: string[]) => void;
+  className?: string;
+}
+
+export default function ColumnSettings({ options, value, onChange, className }: ColumnSettingsProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  const toggleColumn = (id: string) => {
+    const isActive = value.includes(id);
+    if (isActive) {
+      const next = value.filter(colId => colId !== id);
+      if (next.length === 0) {
+        return;
+      }
+      onChange(next);
+    } else {
+      onChange([...value, id]);
+    }
+  };
+
+  return (
+    <div className={`relative ${className ?? ""}`} ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen(prev => !prev)}
+        className="px-3 py-2 rounded-md border border-slate-300 text-sm bg-white shadow-sm hover:bg-slate-50 dark:bg-slate-800 dark:border-slate-600 dark:hover:bg-slate-700"
+      >
+        Настроить столбцы
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-60 max-h-80 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2 text-sm shadow-lg dark:border-slate-700 dark:bg-slate-800">
+          <div className="px-1 pb-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Отображение столбцов
+          </div>
+          <ul className="space-y-1">
+            {options.map(option => {
+              const checked = value.includes(option.id);
+              const disabled = option.disableToggle || (checked && value.length === 1);
+              return (
+                <li key={option.id}>
+                  <label className={`flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 transition hover:bg-slate-100 dark:hover:bg-slate-700 ${disabled ? "opacity-60" : ""}`}>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={disabled}
+                      onChange={() => toggleColumn(option.id)}
+                    />
+                    <span>{option.label}</span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -5,6 +5,8 @@ import VirtualizedTable from "./VirtualizedTable";
 import ClientDetailsModal from "./clients/ClientDetailsModal";
 import { fmtDate, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
+import ColumnSettings from "./ColumnSettings";
+import { compareValues, toggleSort, type SortState } from "./tableUtils";
 import type { Area, Currency, DB, Group, PerformanceEntry, Client } from "../types";
 
 export default function PerformanceTab({
@@ -16,10 +18,11 @@ export default function PerformanceTab({
   setDB: Dispatch<SetStateAction<DB>>;
   currency: Currency;
 }) {
-  const COLUMN_TEMPLATE = "220px 1fr 1fr 200px";
   const [area, setArea] = useState<Area | "all">("all");
   const [group, setGroup] = useState<Group | "all">("all");
   const [selected, setSelected] = useState<Client | null>(null);
+  const [visibleColumns, setVisibleColumns] = useState<string[]>(["name", "area", "group", "mark"]);
+  const [sort, setSort] = useState<SortState | null>(null);
   const today = new Date();
   const todayStr = today.toISOString().slice(0, 10);
 
@@ -66,6 +69,90 @@ export default function PerformanceTab({
     }
   };
 
+  const columns = useMemo(
+    () => [
+      {
+        id: "name",
+        label: "Ученик",
+        width: "220px",
+        renderCell: (client: Client) => (
+          <button
+            type="button"
+            onClick={() => setSelected(client)}
+            className="text-sky-600 hover:underline focus:outline-none dark:text-sky-400"
+          >
+            {client.firstName} {client.lastName}
+          </button>
+        ),
+        sortValue: (client: Client) => `${client.firstName} ${client.lastName ?? ""}`.trim().toLowerCase(),
+      },
+      {
+        id: "area",
+        label: "Район",
+        width: "1fr",
+        renderCell: (client: Client) => client.area,
+        sortValue: (client: Client) => client.area,
+      },
+      {
+        id: "group",
+        label: "Группа",
+        width: "1fr",
+        renderCell: (client: Client) => client.group,
+        sortValue: (client: Client) => client.group,
+      },
+      {
+        id: "mark",
+        label: "Оценка",
+        width: "200px",
+        headerAlign: "right",
+        renderCell: (client: Client) => {
+          const mark = todayMarks.get(client.id);
+          return (
+            <div className="flex justify-end">
+              <button
+                onClick={() => toggle(client.id)}
+                className={`px-3 py-1 rounded-md text-xs border ${
+                  mark
+                    ? mark.successful
+                      ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700"
+                      : "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700"
+                    : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"
+                }`}
+              >
+                {mark ? (mark.successful ? "успевает" : "нужна работа") : "не оценён"}
+              </button>
+            </div>
+          );
+        },
+        sortValue: (client: Client) => {
+          const mark = todayMarks.get(client.id);
+          if (!mark) return 0;
+          return mark.successful ? 2 : 1;
+        },
+      },
+    ],
+    [setSelected, todayMarks, toggle],
+  );
+
+  const activeColumns = useMemo(
+    () => columns.filter(column => visibleColumns.includes(column.id)),
+    [columns, visibleColumns],
+  );
+
+  const sortedClients = useMemo(() => {
+    if (!sort) return list;
+    const column = columns.find(col => col.id === sort.columnId);
+    if (!column?.sortValue) return list;
+    const copy = [...list];
+    copy.sort((a, b) => {
+      const compare = compareValues(column.sortValue!(a), column.sortValue!(b));
+      return sort.direction === "asc" ? compare : -compare;
+    });
+    return copy;
+  }, [columns, list, sort]);
+
+  const columnTemplate = activeColumns.length ? activeColumns.map(column => column.width).join(" ") : "1fr";
+
   return (
     <div className="space-y-3">
       <Breadcrumbs items={["Успеваемость"]} />
@@ -91,63 +178,74 @@ export default function PerformanceTab({
           ))}
         </select>
         <div className="text-xs text-slate-500">Сегодня: {fmtDate(today.toISOString())}</div>
+        <div className="grow" />
+        <ColumnSettings
+          options={columns.map(column => ({ id: column.id, label: column.label }))}
+          value={visibleColumns}
+          onChange={setVisibleColumns}
+        />
       </div>
 
       <VirtualizedTable
         header={(
           <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
             <tr
-              style={{ display: "grid", gridTemplateColumns: COLUMN_TEMPLATE, alignItems: "center" }}
+              style={{ display: "grid", gridTemplateColumns: columnTemplate, alignItems: "center" }}
             >
-              <th className="text-left p-2">Ученик</th>
-              <th className="text-left p-2">Район</th>
-              <th className="text-left p-2">Группа</th>
-              <th className="text-left p-2" style={{ justifySelf: "end" }}>
-                Оценка
-              </th>
+              {activeColumns.map(column => {
+                const canSort = Boolean(column.sortValue);
+                const isSorted = sort?.columnId === column.id;
+                const indicator = isSorted ? (sort?.direction === "asc" ? "↑" : "↓") : null;
+                const alignment = column.headerAlign ?? "left";
+                const justify = alignment === "right" ? "justify-end" : alignment === "center" ? "justify-center" : "";
+                const content = (
+                  <div className={`flex items-center gap-1 ${justify}`}>
+                    <span>{column.label}</span>
+                    {indicator && <span className="text-xs">{indicator}</span>}
+                  </div>
+                );
+                return (
+                  <th
+                    key={column.id}
+                    className={`p-2 ${alignment === "right" ? "text-right" : alignment === "center" ? "text-center" : "text-left"}`}
+                    style={{ cursor: canSort ? "pointer" : "default" }}
+                  >
+                    {canSort ? (
+                      <button
+                        type="button"
+                        className="flex w-full items-center justify-between gap-1 focus:outline-none"
+                        onClick={() => setSort(prev => toggleSort(prev, column.id))}
+                      >
+                        {content}
+                      </button>
+                    ) : (
+                      content
+                    )}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
         )}
-        items={list}
+        items={sortedClients}
         rowHeight={44}
         renderRow={(c, style) => {
-          const m = todayMarks.get(c.id);
           return (
             <tr
               key={c.id}
               style={{
                 ...style,
                 display: "grid",
-                gridTemplateColumns: COLUMN_TEMPLATE,
+                gridTemplateColumns: columnTemplate,
                 alignItems: "center",
               }}
               className="border-t border-slate-100 dark:border-slate-700"
             >
-              <td className="p-2">
-                <button
-                  type="button"
-                  onClick={() => setSelected(c)}
-                  className="text-sky-600 hover:underline focus:outline-none dark:text-sky-400"
-                >
-                  {c.firstName} {c.lastName}
-                </button>
-              </td>
-              <td className="p-2">{c.area}</td>
-              <td className="p-2">{c.group}</td>
-              <td className="p-2 flex justify-end">
-                <button
-                  onClick={() => toggle(c.id)}
-                  className={`px-3 py-1 rounded-md text-xs border ${
-                    m
-                      ? m.successful
-                        ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700"
-                        : "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700"
-                      : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"
-                  }`}
-                >
-                  {m ? (m.successful ? "успевает" : "нужна работа") : "не оценён"}
-                </button>
-              </td>
+              {activeColumns.map(column => (
+                <td key={column.id} className="p-2">
+                  {column.renderCell(c)}
+                </td>
+              ))}
             </tr>
           );
         }}

--- a/src/components/__tests__/TasksTab.test.tsx
+++ b/src/components/__tests__/TasksTab.test.tsx
@@ -19,7 +19,7 @@ import { commitDBUpdate } from '../../state/appState';
 
 function setup(initialTasks) {
   const Wrapper = () => {
-    const [db, setDB] = React.useState({ tasks: initialTasks });
+    const [db, setDB] = React.useState({ tasks: initialTasks, clients: [] });
     return <TasksTab db={db} setDB={setDB} />;
   };
   return render(<Wrapper />);

--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import VirtualizedTable from "../VirtualizedTable";
 import ClientDetailsModal from "./ClientDetailsModal";
+import ColumnSettings from "../ColumnSettings";
+import { compareValues, toggleSort, type SortState } from "../tableUtils";
 import { fmtMoney, fmtDate } from "../../state/utils";
 import type { Client, Currency } from "../../types";
 
@@ -9,68 +11,210 @@ type Props = {
   currency: Currency;
   onEdit: (c: Client) => void;
   onRemove: (id: string) => void;
-  onTogglePayFact: (id: string, value: boolean) => void;
   onCreateTask: (client: Client) => void;
 };
 
-const COLUMN_WIDTHS = [
-  "220px", // name
-  "150px", // phone
-  "140px", // area
-  "140px", // group
-  "160px", // payment status
-  "150px", // payment amount
-  "120px", // payment fact
-  "150px", // payment date
-  "260px", // actions
-];
+type ColumnConfig = {
+  id: string;
+  label: string;
+  width: string;
+  headerClassName?: string;
+  cellClassName?: string;
+  renderCell: (client: Client) => React.ReactNode;
+  sortValue?: (client: Client) => unknown;
+  headerAlign?: "left" | "center" | "right";
+};
 
-const COLUMN_TEMPLATE = COLUMN_WIDTHS.join(" ");
-
-export default function ClientTable({ list, currency, onEdit, onRemove, onTogglePayFact, onCreateTask }: Props) {
-
+export default function ClientTable({ list, currency, onEdit, onRemove, onCreateTask }: Props) {
   const [selected, setSelected] = useState<Client | null>(null);
+  const [visibleColumns, setVisibleColumns] = useState<string[]>([
+    "name",
+    "phone",
+    "area",
+    "group",
+    "payStatus",
+    "payAmount",
+    "payDate",
+    "actions",
+  ]);
+  const [sort, setSort] = useState<SortState | null>(null);
+
+  const columns: ColumnConfig[] = useMemo(() => [
+    {
+      id: "name",
+      label: "Имя",
+      width: "220px",
+      renderCell: client => (
+        <button
+          type="button"
+          onClick={event => {
+            event.stopPropagation();
+            onEdit(client);
+          }}
+          className="text-left text-sky-600 hover:underline focus:outline-none dark:text-sky-400"
+        >
+          {client.firstName} {client.lastName}
+        </button>
+      ),
+      sortValue: client => `${client.firstName} ${client.lastName ?? ""}`.trim().toLowerCase(),
+    },
+    {
+      id: "phone",
+      label: "Телефон",
+      width: "150px",
+      renderCell: client => client.phone ?? "—",
+      sortValue: client => client.phone ?? "",
+    },
+    {
+      id: "area",
+      label: "Район",
+      width: "140px",
+      renderCell: client => client.area,
+      sortValue: client => client.area,
+    },
+    {
+      id: "group",
+      label: "Группа",
+      width: "140px",
+      renderCell: client => client.group,
+      sortValue: client => client.group,
+    },
+    {
+      id: "payStatus",
+      label: "Статус оплаты",
+      width: "160px",
+      renderCell: client => (
+        <span
+          className={`px-2 py-1 text-xs ${
+            client.payStatus === "действует"
+              ? "rounded-full bg-emerald-100 text-emerald-700"
+              : client.payStatus === "задолженность"
+              ? "rounded-full bg-rose-100 text-rose-700"
+              : "rounded-full bg-amber-100 text-amber-700"
+          }`}
+        >
+          {client.payStatus}
+        </span>
+      ),
+      sortValue: client => client.payStatus,
+    },
+    {
+      id: "payAmount",
+      label: "Сумма оплаты",
+      width: "150px",
+      renderCell: client => (client.payAmount != null ? fmtMoney(client.payAmount, currency) : "—"),
+      sortValue: client => client.payAmount ?? 0,
+    },
+    {
+      id: "payDate",
+      label: "Дата оплаты",
+      width: "150px",
+      renderCell: client => (client.payDate ? fmtDate(client.payDate) : "—"),
+      sortValue: client => client.payDate ?? "",
+    },
+    {
+      id: "actions",
+      label: "Действия",
+      width: "260px",
+      headerClassName: "text-right",
+      headerAlign: "right",
+      cellClassName: "flex justify-end gap-1",
+      renderCell: client => (
+        <>
+          <button
+            onClick={event => {
+              event.stopPropagation();
+              onCreateTask(client);
+            }}
+            className="px-2 py-1 text-xs rounded-md border border-sky-200 text-sky-600 hover:bg-sky-50 dark:border-sky-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+          >
+            Создать задачу
+          </button>
+          <button
+            onClick={event => {
+              event.stopPropagation();
+              onRemove(client.id);
+            }}
+            className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30"
+          >
+            Удалить
+          </button>
+        </>
+      ),
+    },
+  ], [currency, onCreateTask, onEdit, onRemove]);
+
+  const activeColumns = useMemo(
+    () => columns.filter(column => visibleColumns.includes(column.id)),
+    [columns, visibleColumns],
+  );
+
+  const sortedList = useMemo(() => {
+    if (!sort) return list;
+    const column = columns.find(col => col.id === sort.columnId);
+    if (!column?.sortValue) return list;
+    const copy = [...list];
+    copy.sort((a, b) => {
+      const compare = compareValues(column.sortValue!(a), column.sortValue!(b));
+      return sort.direction === "asc" ? compare : -compare;
+    });
+    return copy;
+  }, [columns, list, sort]);
+
+  const columnTemplate = activeColumns.length ? activeColumns.map(column => column.width).join(" ") : "1fr";
 
   return (
     <>
+      <div className="flex justify-end">
+        <ColumnSettings
+          options={columns.map(column => ({ id: column.id, label: column.label }))}
+          value={visibleColumns}
+          onChange={setVisibleColumns}
+        />
+      </div>
       <VirtualizedTable
         header={(
           <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
             <tr
               className="w-full"
-              style={{ display: "grid", gridTemplateColumns: COLUMN_TEMPLATE, alignItems: "center" }}
+              style={{ display: "grid", gridTemplateColumns: columnTemplate, alignItems: "center" }}
             >
-              <th className="text-left p-2">
-                Имя
-              </th>
-              <th className="text-left p-2">
-                Телефон
-              </th>
-              <th className="text-left p-2">
-                Район
-              </th>
-              <th className="text-left p-2">
-                Группа
-              </th>
-              <th className="text-left p-2">
-                Статус оплаты
-              </th>
-              <th className="text-left p-2">
-                Сумма оплаты
-              </th>
-              <th className="text-center p-2">
-                Факт оплаты
-              </th>
-              <th className="text-left p-2">
-                Дата оплаты
-              </th>
-              <th className="text-right p-2" style={{ justifySelf: "end" }}>
-                Действия
-              </th>
+              {activeColumns.map(column => {
+                const isSorted = sort?.columnId === column.id;
+                const canSort = Boolean(column.sortValue);
+                const indicator = isSorted ? (sort?.direction === "asc" ? "↑" : "↓") : null;
+                const alignment = column.headerAlign ?? "left";
+                const justify = alignment === "right" ? "justify-end" : alignment === "center" ? "justify-center" : "";
+                const content = (
+                  <div className={`flex items-center gap-1 ${justify}`}>
+                    <span>{column.label}</span>
+                    {indicator && <span className="text-xs">{indicator}</span>}
+                  </div>
+                );
+                return (
+                  <th
+                    key={column.id}
+                    className={`p-2 ${column.headerClassName ?? "text-left"}`}
+                    style={{ cursor: canSort ? "pointer" : "default" }}
+                  >
+                    {canSort ? (
+                      <button
+                        type="button"
+                        className="flex w-full items-center justify-between gap-1 focus:outline-none"
+                        onClick={() => setSort(prev => toggleSort(prev, column.id))}
+                      >
+                        {content}
+                      </button>
+                    ) : (
+                      content
+                    )}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
         )}
-        items={list}
+        items={sortedList}
         rowHeight={48}
         renderRow={(c, style) => (
           <tr
@@ -78,79 +222,17 @@ export default function ClientTable({ list, currency, onEdit, onRemove, onToggle
             style={{
               ...style,
               display: "grid",
-              gridTemplateColumns: COLUMN_TEMPLATE,
+              gridTemplateColumns: columnTemplate,
               alignItems: "center",
             }}
             className="border-t border-slate-100 dark:border-slate-700"
+            onClick={() => setSelected(c)}
           >
-            <td className="p-2" onClick={() => setSelected(c)}>
-              <button
-                type="button"
-                onClick={e => {
-                  e.stopPropagation();
-                  onEdit(c);
-                }}
-                className="text-left text-sky-600 hover:underline focus:outline-none dark:text-sky-400"
-              >
-                {c.firstName} {c.lastName}
-              </button>
-            </td>
-            <td className="p-2">
-              {c.phone}
-            </td>
-            <td className="p-2">
-              {c.area}
-            </td>
-            <td className="p-2">
-              {c.group}
-            </td>
-            <td className="p-2">
-              <span
-                className={`px-2 py-1 rounded-full text-xs ${
-                  c.payStatus === "действует"
-                    ? "bg-emerald-100 text-emerald-700"
-                    : c.payStatus === "задолженность"
-                    ? "bg-rose-100 text-rose-700"
-                    : "bg-amber-100 text-amber-700"
-                }`}
-              >
-                {c.payStatus}
-              </span>
-            </td>
-            <td className="p-2">
-              {c.payAmount != null ? fmtMoney(c.payAmount, currency) : "—"}
-            </td>
-            <td className="p-2 text-center">
-              <input
-                type="checkbox"
-                aria-label={`Факт оплаты ${c.firstName}${c.lastName ? ` ${c.lastName}` : ""}`.trim()}
-                checked={Boolean(c.payConfirmed)}
-                onChange={e => onTogglePayFact(c.id, e.target.checked)}
-              />
-            </td>
-            <td className="p-2">
-              {c.payDate ? fmtDate(c.payDate) : "—"}
-            </td>
-            <td className="p-2 flex justify-end gap-1">
-              <button
-                onClick={() => onCreateTask(c)}
-                className="px-2 py-1 text-xs rounded-md border border-sky-200 text-sky-600 hover:bg-sky-50 dark:border-sky-700 dark:bg-slate-800 dark:hover:bg-slate-700"
-              >
-                Создать задачу
-              </button>
-              <button
-                onClick={() => onEdit(c)}
-                className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
-              >
-                Редактировать
-              </button>
-              <button
-                onClick={() => onRemove(c.id)}
-                className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30"
-              >
-                Удалить
-              </button>
-            </td>
+            {activeColumns.map(column => (
+              <td key={column.id} className={`p-2 ${column.cellClassName ?? ""}`}>
+                {column.renderCell(c)}
+              </td>
+            ))}
           </tr>
         )}
       />

--- a/src/components/tableUtils.ts
+++ b/src/components/tableUtils.ts
@@ -1,0 +1,49 @@
+export type SortDirection = "asc" | "desc";
+
+export interface SortState {
+  columnId: string;
+  direction: SortDirection;
+}
+
+export function toggleSort(current: SortState | null, columnId: string): SortState | null {
+  if (!current || current.columnId !== columnId) {
+    return { columnId, direction: "asc" };
+  }
+  if (current.direction === "asc") {
+    return { columnId, direction: "desc" };
+  }
+  return null;
+}
+
+export function compareValues(a: unknown, b: unknown): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return -1;
+  if (b == null) return 1;
+
+  if (typeof a === "number" && typeof b === "number") {
+    return a - b;
+  }
+
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() - b.getTime();
+  }
+
+  const aDate = typeof a === "string" && !Number.isNaN(Date.parse(a)) ? new Date(a) : null;
+  const bDate = typeof b === "string" && !Number.isNaN(Date.parse(b)) ? new Date(b) : null;
+  if (aDate && bDate) {
+    return aDate.getTime() - bDate.getTime();
+  }
+
+  if (typeof a === "boolean" && typeof b === "boolean") {
+    if (a === b) return 0;
+    return a ? 1 : -1;
+  }
+
+  const aNum = Number(a);
+  const bNum = Number(b);
+  if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) {
+    return aNum - bNum;
+  }
+
+  return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: "base" });
+}

--- a/src/state/payments.ts
+++ b/src/state/payments.ts
@@ -1,0 +1,59 @@
+import type { Client, PaymentStatus, TaskItem } from "../types";
+
+const INDIVIDUAL_GROUP_NAMES = ["индивидуальное", "индивидуальные", "индивидуальная", "индивидуал"];
+const ADULT_GROUP_NAMES = ["взрослое", "взрослые", "взрослая"];
+
+const normalize = (value: string | undefined | null) => value?.trim().toLowerCase() ?? "";
+
+export function isIndividualGroup(group: string): boolean {
+  const normalized = normalize(group);
+  return INDIVIDUAL_GROUP_NAMES.some(name => normalized === name);
+}
+
+export function isAdultGroup(group: string): boolean {
+  const normalized = normalize(group);
+  return ADULT_GROUP_NAMES.some(name => normalized === name);
+}
+
+export function shouldAllowCustomPayAmount(group: string): boolean {
+  return isIndividualGroup(group) || isAdultGroup(group);
+}
+
+export function getDefaultPayAmount(group: string): number | null {
+  if (isIndividualGroup(group)) {
+    return 125;
+  }
+  if (isAdultGroup(group)) {
+    return null;
+  }
+  return 55;
+}
+
+export function derivePaymentStatus(client: Client, tasks: TaskItem[]): PaymentStatus {
+  const relatedTasks = tasks.filter(
+    task =>
+      task.topic === "оплата" &&
+      task.assigneeType === "client" &&
+      task.assigneeId === client.id,
+  );
+
+  if (!relatedTasks.length) {
+    return "ожидание";
+  }
+
+  if (relatedTasks.some(task => task.status !== "done")) {
+    return "задолженность";
+  }
+
+  return "действует";
+}
+
+export function applyPaymentStatusRules(clients: Client[], tasks: TaskItem[]): Client[] {
+  return clients.map(client => {
+    const nextStatus = derivePaymentStatus(client, tasks);
+    if (client.payStatus === nextStatus) {
+      return client;
+    }
+    return { ...client, payStatus: nextStatus };
+  });
+}

--- a/src/state/seed.ts
+++ b/src/state/seed.ts
@@ -115,7 +115,6 @@ export function makeSeedDB(): DB {
       payStatus: "действует",
       payDate: start.toISOString(),
       payAmount: rnd(50, 100),
-      payConfirmed: Math.random() < 0.7,
     } as Client;
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,6 @@ export interface Client {
   payStatus: PaymentStatus;
   payDate?: string; // ISO
   payAmount?: number;
-  payConfirmed?: boolean;
   // Автополя (рассчитываются на лету)
 }
 
@@ -51,6 +50,7 @@ export interface ClientFormValues {
   payMethod: PaymentMethod;
   payStatus: PaymentStatus;
   payDate: string;
+  payAmount: string;
 }
 
 export interface AttendanceEntry {


### PR DESCRIPTION
## Summary
- add reusable column settings with sorting for clients, attendance, and performance tables
- enforce group-based payment defaults while allowing individual/adult overrides and update payment statuses from tasks
- synchronize payment statuses when tasks change and clean up obsolete payment fields

## Testing
- CI=1 npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cc6c797404832bbfef3fc3089bddaf