### PR TITLE
feat: persist client filters and unify client modals across tabs

### DIFF
--- a/src/components/AttendanceTab.tsx
+++ b/src/components/AttendanceTab.tsx
@@ -1,11 +1,24 @@
-import React, { useState, useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import VirtualizedTable from "./VirtualizedTable";
 import ClientDetailsModal from "./clients/ClientDetailsModal";
-import { fmtDate, uid } from "../state/utils";
+import ClientForm from "./clients/ClientForm";
+import ColumnSettings from "./ColumnSettings";
+import { compareValues, toggleSort, type SortState } from "./tableUtils";
+import { fmtDate, todayISO, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
-import type { DB, Area, Group, AttendanceEntry, Client, Currency } from "../types";
+import { buildGroupsByArea, requiresManualRemainingLessons } from "../state/lessons";
+import { transformClientFormValues } from "./clients/clientMutations";
+import type {
+  Area,
+  AttendanceEntry,
+  Client,
+  ClientFormValues,
+  Currency,
+  DB,
+  Group,
+} from "../types";
 
 export default function AttendanceTab({
   db,
@@ -16,22 +29,40 @@ export default function AttendanceTab({
   setDB: Dispatch<SetStateAction<DB>>;
   currency: Currency;
 }) {
-  const COLUMN_TEMPLATE = "220px 1fr 1fr 180px";
-  const [area, setArea] = useState<Area | "all">("all");
-  const [group, setGroup] = useState<Group | "all">("all");
+  const [area, setArea] = useState<Area | null>(null);
+  const [group, setGroup] = useState<Group | null>(null);
   const [selected, setSelected] = useState<Client | null>(null);
-  const today = new Date();
-  const todayStr = today.toISOString().slice(0, 10);
+  const [editing, setEditing] = useState<Client | null>(null);
+  const [visibleColumns, setVisibleColumns] = useState<string[]>(["name", "area", "group", "mark"]);
+  const [sort, setSort] = useState<SortState | null>(null);
+
+  const groupsByArea = useMemo(() => buildGroupsByArea(db.schedule), [db.schedule]);
+  const areaOptions = useMemo(() => Array.from(groupsByArea.keys()), [groupsByArea]);
+  const availableGroups = useMemo(() => {
+    if (!area) return [];
+    return groupsByArea.get(area) ?? [];
+  }, [area, groupsByArea]);
+
+  useEffect(() => {
+    if (area && group && !availableGroups.includes(group)) {
+      setGroup(null);
+    }
+  }, [area, availableGroups, group]);
+
+  const todayStr = useMemo(() => todayISO().slice(0, 10), []);
 
   const list = useMemo(() => {
-    return db.clients.filter(c => (area === "all" || c.area === area) && (group === "all" || c.group === group));
-  }, [db.clients, area, group]);
+    if (!area || !group) {
+      return [];
+    }
+    return db.clients.filter(client => client.area === area && client.group === group);
+  }, [area, group, db.clients]);
 
   const todayMarks = useMemo(() => {
     const map: Map<string, AttendanceEntry> = new Map();
-    db.attendance.forEach(a => {
-      if (a.date.slice(0, 10) === todayStr) {
-        map.set(a.clientId, a);
+    db.attendance.forEach(entry => {
+      if (entry.date.slice(0, 10) === todayStr) {
+        map.set(entry.clientId, entry);
       }
     });
     return map;
@@ -39,16 +70,47 @@ export default function AttendanceTab({
 
   const toggle = async (clientId: string) => {
     const mark = todayMarks.get(clientId);
+    const client = db.clients.find(c => c.id === clientId);
+    if (!client) return;
+    const manual = requiresManualRemainingLessons(client.group);
+
     if (mark) {
       const updated = { ...mark, came: !mark.came };
-      const next = { ...db, attendance: db.attendance.map(a => a.id === mark.id ? updated : a) };
+      const nextClients = !manual
+        ? db.clients
+        : db.clients.map(c => {
+            if (c.id !== clientId) return c;
+            const delta = updated.came ? -1 : 1;
+            const current = c.remainingLessons ?? 0;
+            const nextRemaining = Math.max(0, current + delta);
+            if (nextRemaining === current) {
+              return c;
+            }
+            return { ...c, remainingLessons: nextRemaining };
+          });
+      const next = {
+        ...db,
+        attendance: db.attendance.map(entry => (entry.id === mark.id ? updated : entry)),
+        clients: nextClients,
+      };
       const ok = await commitDBUpdate(next, setDB);
       if (!ok) {
         window.alert("Не удалось обновить отметку посещаемости. Проверьте доступ к базе данных.");
       }
     } else {
       const entry: AttendanceEntry = { id: uid(), clientId, date: new Date().toISOString(), came: true };
-      const next = { ...db, attendance: [entry, ...db.attendance] };
+      const nextClients = !manual
+        ? db.clients
+        : db.clients.map(c => {
+            if (c.id !== clientId) return c;
+            const current = c.remainingLessons ?? 0;
+            const nextRemaining = Math.max(0, current - 1);
+            if (nextRemaining === current) {
+              return c;
+            }
+            return { ...c, remainingLessons: nextRemaining };
+          });
+      const next = { ...db, attendance: [entry, ...db.attendance], clients: nextClients };
       const ok = await commitDBUpdate(next, setDB);
       if (!ok) {
         window.alert("Не удалось сохранить отметку посещаемости. Проверьте доступ к базе данных.");
@@ -56,84 +118,238 @@ export default function AttendanceTab({
     }
   };
 
+  const columns = useMemo(() => {
+    return [
+      {
+        id: "name",
+        label: "Ученик",
+        width: "minmax(200px, max-content)",
+        renderCell: (client: Client) => (
+          <span className="font-medium text-slate-800 dark:text-slate-100">{client.firstName} {client.lastName}</span>
+        ),
+        sortValue: (client: Client) => `${client.firstName} ${client.lastName ?? ""}`.trim().toLowerCase(),
+      },
+      {
+        id: "area",
+        label: "Район",
+        width: "minmax(140px, max-content)",
+        renderCell: (client: Client) => client.area,
+        sortValue: (client: Client) => client.area,
+      },
+      {
+        id: "group",
+        label: "Группа",
+        width: "minmax(140px, max-content)",
+        renderCell: (client: Client) => client.group,
+        sortValue: (client: Client) => client.group,
+      },
+      {
+        id: "mark",
+        label: "Отметка",
+        width: "minmax(180px, 1fr)",
+        headerAlign: "right" as const,
+        cellClassName: "text-right",
+        renderCell: (client: Client) => {
+          const mark = todayMarks.get(client.id);
+          const label = mark?.came ? "пришёл" : mark ? "не пришёл" : "не отмечен";
+          const tone = mark?.came
+            ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700"
+            : mark
+            ? "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:border-amber-700"
+            : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700";
+          return (
+            <button
+              type="button"
+              onClick={event => {
+                event.stopPropagation();
+                toggle(client.id);
+              }}
+              className={`inline-flex items-center justify-center rounded-md border px-3 py-1 text-xs font-semibold ${tone}`}
+            >
+              {label}
+            </button>
+          );
+        },
+        sortValue: (client: Client) => {
+          const mark = todayMarks.get(client.id);
+          if (!mark) return 0;
+          return mark.came ? 2 : 1;
+        },
+      },
+    ];
+  }, [todayMarks]);
+
+  const activeColumns = useMemo(
+    () => columns.filter(column => visibleColumns.includes(column.id)),
+    [columns, visibleColumns],
+  );
+
+  const sortedClients = useMemo(() => {
+    if (!sort) return list;
+    const column = columns.find(col => col.id === sort.columnId);
+    if (!column?.sortValue) return list;
+    const copy = [...list];
+    copy.sort((a, b) => {
+      const compare = compareValues(column.sortValue!(a), column.sortValue!(b));
+      return sort.direction === "asc" ? compare : -compare;
+    });
+    return copy;
+  }, [columns, list, sort]);
+
+  const columnTemplate = activeColumns.length ? activeColumns.map(column => column.width).join(" ") : "1fr";
+
+  const startEdit = (client: Client) => {
+    setEditing(client);
+  };
+
+  const saveClient = async (values: ClientFormValues) => {
+    if (!editing) return;
+    const prepared = transformClientFormValues(values, editing);
+    const updated: Client = { ...editing, ...prepared };
+    const next = {
+      ...db,
+      clients: db.clients.map(client => (client.id === editing.id ? updated : client)),
+    };
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось сохранить изменения клиента. Проверьте доступ к базе данных.");
+      return;
+    }
+    setEditing(null);
+    setSelected(updated);
+  };
+
   return (
     <div className="space-y-3">
       <Breadcrumbs items={["Посещаемость"]} />
       <div className="flex flex-wrap items-center gap-2">
-        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200" value={area} onChange={e => setArea(e.target.value)}>
-          <option value="all">Все районы</option>
-          {db.settings.areas.map(a => <option key={a}>{a}</option>)}
+        <select
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={area ?? ""}
+          onChange={e => setArea(e.target.value ? (e.target.value as Area) : null)}
+        >
+          <option value="">Выберите район</option>
+          {areaOptions.map(option => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
         </select>
-        <select className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200" value={group} onChange={e => setGroup(e.target.value)}>
-          <option value="all">Все группы</option>
-          {db.settings.groups.map(g => <option key={g}>{g}</option>)}
+        <select
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={group ?? ""}
+          onChange={e => setGroup(e.target.value ? (e.target.value as Group) : null)}
+          disabled={!area}
+        >
+          <option value="">Выберите группу</option>
+          {availableGroups.map(option => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
         </select>
-        <div className="text-xs text-slate-500">Сегодня: {fmtDate(today.toISOString())}</div>
+        <div className="text-xs text-slate-500">Сегодня: {fmtDate(new Date().toISOString())}</div>
+        <div className="grow" />
+        <ColumnSettings
+          options={columns.map(column => ({ id: column.id, label: column.label }))}
+          value={visibleColumns}
+          onChange={setVisibleColumns}
+        />
+      </div>
+      <div className="text-xs text-slate-500">
+        {area && group ? `Найдено: ${list.length}` : "Выберите район и группу"}
       </div>
 
       <VirtualizedTable
         header={(
           <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
             <tr
-              style={{ display: "grid", gridTemplateColumns: COLUMN_TEMPLATE, alignItems: "center" }}
+              style={{ display: "grid", gridTemplateColumns: columnTemplate, alignItems: "center" }}
             >
-              <th className="text-left p-2">Ученик</th>
-              <th className="text-left p-2">Район</th>
-              <th className="text-left p-2">Группа</th>
-              <th className="text-left p-2" style={{ justifySelf: "end" }}>
-                Отметка
-              </th>
+              {activeColumns.map(column => {
+                const canSort = Boolean(column.sortValue);
+                const isSorted = sort?.columnId === column.id;
+                const indicator = isSorted ? (sort?.direction === "asc" ? "↑" : "↓") : null;
+                const alignment = column.headerAlign ?? "left";
+                const justify =
+                  alignment === "right" ? "justify-end" : alignment === "center" ? "justify-center" : "";
+                const content = (
+                  <div className={`flex items-center gap-1 ${justify}`}>
+                    <span>{column.label}</span>
+                    {indicator && <span className="text-xs">{indicator}</span>}
+                  </div>
+                );
+                return (
+                  <th
+                    key={column.id}
+                    className={`p-2 ${
+                      alignment === "right"
+                        ? "text-right"
+                        : alignment === "center"
+                        ? "text-center"
+                        : "text-left"
+                    }`}
+                    style={{ cursor: canSort ? "pointer" : "default" }}
+                  >
+                    {canSort ? (
+                      <button
+                        type="button"
+                        className="flex w-full items-center justify-between gap-1 focus:outline-none"
+                        onClick={() => setSort(prev => toggleSort(prev, column.id))}
+                      >
+                        {content}
+                      </button>
+                    ) : (
+                      content
+                    )}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
         )}
-        items={list}
-        rowHeight={44}
-        renderRow={(c, style) => {
-          const m = todayMarks.get(c.id);
-          return (
-            <tr
-              key={c.id}
-              style={{
-                ...style,
-                display: "grid",
-                gridTemplateColumns: COLUMN_TEMPLATE,
-                alignItems: "center",
-              }}
-              className="border-t border-slate-100 dark:border-slate-700"
-            >
-              <td className="p-2">
-                <button
-                  type="button"
-                  onClick={() => setSelected(c)}
-                  className="text-sky-600 hover:underline focus:outline-none dark:text-sky-400"
-                >
-                  {c.firstName} {c.lastName}
-                </button>
+        items={sortedClients}
+        rowHeight={48}
+        renderRow={(client, style) => (
+          <tr
+            key={client.id}
+            style={{
+              ...style,
+              display: "grid",
+              gridTemplateColumns: columnTemplate,
+              alignItems: "center",
+              cursor: "pointer",
+            }}
+            className="border-t border-slate-100 transition hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
+            onClick={() => setSelected(client)}
+          >
+            {activeColumns.map(column => (
+              <td key={column.id} className={`p-2 ${column.cellClassName ?? ""}`}>
+                {column.renderCell(client)}
               </td>
-              <td className="p-2">{c.area}</td>
-              <td className="p-2">{c.group}</td>
-              <td className="p-2 flex justify-end">
-                <button
-                  onClick={() => toggle(c.id)}
-                  className={`px-3 py-1 rounded-md text-xs border ${
-                    m?.came
-                      ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700"
-                      : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"
-                  }`}
-                >
-                  {m?.came ? "пришёл" : "не отмечен"}
-                </button>
-              </td>
-            </tr>
-          );
-        }}
+            ))}
+          </tr>
+        )}
       />
 
       {selected && (
         <ClientDetailsModal
           client={selected}
           currency={currency}
+          schedule={db.schedule}
+          attendance={db.attendance}
+          performance={db.performance}
+          onEdit={startEdit}
           onClose={() => setSelected(null)}
+        />
+      )}
+
+      {editing && (
+        <ClientForm
+          db={db}
+          editing={editing}
+          onSave={saveClient}
+          onClose={() => setEditing(null)}
         />
       )}
     </div>

--- a/src/components/ClientsTab.tsx
+++ b/src/components/ClientsTab.tsx
@@ -1,11 +1,15 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import ClientFilters from "./clients/ClientFilters";
 import ClientTable from "./clients/ClientTable";
 import ClientForm from "./clients/ClientForm";
-import { uid, todayISO, parseDateInput, fmtMoney } from "../state/utils";
+import { uid, todayISO, fmtMoney } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
+import { applyPaymentStatusRules } from "../state/payments";
+import { buildGroupsByArea } from "../state/lessons";
+import { readDailySelection, writeDailySelection, clearDailySelection } from "../state/filterPersistence";
+import { transformClientFormValues } from "./clients/clientMutations";
 import type { DB, UIState, Client, Area, Group, PaymentStatus, ClientFormValues, TaskItem } from "../types";
 
 
@@ -13,27 +17,63 @@ export default function ClientsTab({
   db,
   setDB,
   ui,
+  initialArea = null,
+  initialGroup = null,
+  initialPay = "all",
 }: {
   db: DB;
   setDB: Dispatch<SetStateAction<DB>>;
   ui: UIState;
+  initialArea?: Area | null;
+  initialGroup?: Group | null;
+  initialPay?: PaymentStatus | "all";
 }) {
-  const [area, setArea] = useState<Area | "all">("all");
-  const [group, setGroup] = useState<Group | "all">("all");
-  const [pay, setPay] = useState<PaymentStatus | "all">("all");
+  const storedFilters = useMemo(() => readDailySelection("clients"), []);
+  const [area, setArea] = useState<Area | null>(initialArea ?? storedFilters.area);
+  const [group, setGroup] = useState<Group | null>(initialGroup ?? storedFilters.group);
+  const [pay, setPay] = useState<PaymentStatus | "all">(initialPay);
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<Client | null>(null);
 
   const search = ui.search.toLowerCase();
+  const groupsByArea = useMemo(() => buildGroupsByArea(db.schedule), [db.schedule]);
+  const availableGroups = useMemo(() => {
+    if (!area) return [];
+    return groupsByArea.get(area) ?? [];
+  }, [area, groupsByArea]);
+
+  useEffect(() => {
+    if (area || group) {
+      writeDailySelection("clients", area ?? null, group ?? null);
+    } else {
+      clearDailySelection("clients");
+    }
+  }, [area, group]);
+
+  useEffect(() => {
+    if (!area) {
+      if (group !== null) {
+        setGroup(null);
+      }
+      return;
+    }
+    if (group && !availableGroups.includes(group)) {
+      setGroup(null);
+    }
+  }, [area, availableGroups, group]);
 
   const list = useMemo(() => {
+    if (!area || !group) {
+      return [];
+    }
     return db.clients.filter(c =>
-      (area === "all" || c.area === area) &&
-      (group === "all" || c.group === group) &&
+      c.area === area &&
+      c.group === group &&
       (pay === "all" || c.payStatus === pay) &&
       (!ui.search || `${c.firstName} ${c.lastName ?? ""} ${c.phone ?? ""}`.toLowerCase().includes(search))
     );
   }, [db.clients, area, group, pay, ui.search, search]);
+
 
   const openAddModal = () => {
     setEditing(null);
@@ -46,12 +86,7 @@ export default function ClientsTab({
   };
 
   const saveClient = async (data: ClientFormValues) => {
-    const prepared = {
-      ...data,
-      birthDate: parseDateInput(data.birthDate),
-      startDate: parseDateInput(data.startDate),
-      payDate: parseDateInput(data.payDate),
-    };
+    const prepared = transformClientFormValues(data, editing);
     if (editing) {
       const updated: Client = { ...editing, ...prepared };
       const next = {
@@ -69,8 +104,6 @@ export default function ClientsTab({
         id: uid(),
         ...prepared,
         coachId: db.staff.find(s => s.role === "Тренер")?.id,
-        payAmount: 0,
-        payConfirmed: false,
       };
       const next = {
         ...db,
@@ -85,23 +118,6 @@ export default function ClientsTab({
     }
     setModalOpen(false);
     setEditing(null);
-  };
-
-  const togglePayFact = async (id: string, value: boolean) => {
-    const target = db.clients.find(c => c.id === id);
-    if (!target) return;
-    const next = {
-      ...db,
-      clients: db.clients.map(c => (c.id === id ? { ...c, payConfirmed: value } : c)),
-      changelog: [
-        ...db.changelog,
-        { id: uid(), who: "UI", what: `Обновлён факт оплаты ${target.firstName}`, when: todayISO() },
-      ],
-    };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert("Не удалось обновить факт оплаты. Проверьте доступ к базе данных.");
-    }
   };
 
   const createPaymentTask = async (client: Client) => {
@@ -122,9 +138,12 @@ export default function ClientsTab({
       assigneeId: client.id,
     };
 
+    const nextTasks = [task, ...db.tasks];
+    const nextClients = applyPaymentStatusRules(db.clients, nextTasks);
     const next = {
       ...db,
-      tasks: [task, ...db.tasks],
+      tasks: nextTasks,
+      clients: nextClients,
       changelog: [
         ...db.changelog,
         { id: uid(), who: "UI", what: `Создана задача по оплате ${client.firstName}`, when: todayISO() },
@@ -160,6 +179,7 @@ export default function ClientsTab({
         setGroup={setGroup}
         pay={pay}
         setPay={setPay}
+        groups={availableGroups}
         listLength={list.length}
         onAddClient={openAddModal}
       />
@@ -168,8 +188,10 @@ export default function ClientsTab({
         currency={ui.currency}
         onEdit={startEdit}
         onRemove={removeClient}
-        onTogglePayFact={togglePayFact}
         onCreateTask={createPaymentTask}
+        schedule={db.schedule}
+        attendance={db.attendance}
+        performance={db.performance}
       />
       {modalOpen && (
         <ClientForm

--- a/src/components/ColumnSettings.tsx
+++ b/src/components/ColumnSettings.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useRef, useState } from "react";
+
+export interface ColumnOption {
+  id: string;
+  label: string;
+  disableToggle?: boolean;
+}
+
+interface ColumnSettingsProps {
+  options: ColumnOption[];
+  value: string[];
+  onChange: (next: string[]) => void;
+  className?: string;
+}
+
+export default function ColumnSettings({ options, value, onChange, className }: ColumnSettingsProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  const toggleColumn = (id: string) => {
+    const isActive = value.includes(id);
+    if (isActive) {
+      const next = value.filter(colId => colId !== id);
+      if (next.length === 0) {
+        return;
+      }
+      onChange(next);
+    } else {
+      const order = options.map(option => option.id);
+      const withNew = [...value, id];
+      const sorted = [...withNew].sort((a, b) => order.indexOf(a) - order.indexOf(b));
+      onChange(sorted);
+    }
+  };
+
+  return (
+    <div className={`relative ${className ?? ""}`} ref={containerRef}>
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen(prev => !prev)}
+        className="px-3 py-2 rounded-md border border-slate-300 text-sm bg-white shadow-sm hover:bg-slate-50 dark:bg-slate-800 dark:border-slate-600 dark:hover:bg-slate-700"
+      >
+        Настроить столбцы
+      </button>
+      {open && (
+        <div className="absolute right-0 z-30 mt-2 w-60 max-h-80 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2 text-sm shadow-lg dark:border-slate-700 dark:bg-slate-800">
+          <div className="px-1 pb-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Отображение столбцов
+          </div>
+          <ul className="space-y-1">
+            {options.map(option => {
+              const checked = value.includes(option.id);
+              const disabled = option.disableToggle || (checked && value.length === 1);
+              return (
+                <li key={option.id}>
+                  <label className={`flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 transition hover:bg-slate-100 dark:hover:bg-slate-700 ${disabled ? "opacity-60" : ""}`}>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={disabled}
+                      onChange={() => toggleColumn(option.id)}
+                    />
+                    <span>{option.label}</span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -1,11 +1,24 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import VirtualizedTable from "./VirtualizedTable";
 import ClientDetailsModal from "./clients/ClientDetailsModal";
-import { fmtDate, uid } from "../state/utils";
+import ClientForm from "./clients/ClientForm";
+import ColumnSettings from "./ColumnSettings";
+import { compareValues, toggleSort, type SortState } from "./tableUtils";
+import { fmtDate, todayISO, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
-import type { Area, Currency, DB, Group, PerformanceEntry, Client } from "../types";
+import { buildGroupsByArea } from "../state/lessons";
+import { transformClientFormValues } from "./clients/clientMutations";
+import type {
+  Area,
+  Client,
+  ClientFormValues,
+  Currency,
+  DB,
+  Group,
+  PerformanceEntry,
+} from "../types";
 
 export default function PerformanceTab({
   db,
@@ -16,24 +29,40 @@ export default function PerformanceTab({
   setDB: Dispatch<SetStateAction<DB>>;
   currency: Currency;
 }) {
-  const COLUMN_TEMPLATE = "220px 1fr 1fr 200px";
-  const [area, setArea] = useState<Area | "all">("all");
-  const [group, setGroup] = useState<Group | "all">("all");
+  const [area, setArea] = useState<Area | null>(null);
+  const [group, setGroup] = useState<Group | null>(null);
   const [selected, setSelected] = useState<Client | null>(null);
-  const today = new Date();
-  const todayStr = today.toISOString().slice(0, 10);
+  const [editing, setEditing] = useState<Client | null>(null);
+  const [visibleColumns, setVisibleColumns] = useState<string[]>(["name", "area", "group", "mark"]);
+  const [sort, setSort] = useState<SortState | null>(null);
+
+  const groupsByArea = useMemo(() => buildGroupsByArea(db.schedule), [db.schedule]);
+  const areaOptions = useMemo(() => Array.from(groupsByArea.keys()), [groupsByArea]);
+  const availableGroups = useMemo(() => {
+    if (!area) return [];
+    return groupsByArea.get(area) ?? [];
+  }, [area, groupsByArea]);
+
+  useEffect(() => {
+    if (area && group && !availableGroups.includes(group)) {
+      setGroup(null);
+    }
+  }, [area, availableGroups, group]);
+
+  const todayStr = useMemo(() => todayISO().slice(0, 10), []);
 
   const list = useMemo(() => {
-    return db.clients.filter(
-      c => (area === "all" || c.area === area) && (group === "all" || c.group === group),
-    );
-  }, [db.clients, area, group]);
+    if (!area || !group) {
+      return [];
+    }
+    return db.clients.filter(client => client.area === area && client.group === group);
+  }, [area, group, db.clients]);
 
   const todayMarks = useMemo(() => {
     const map: Map<string, PerformanceEntry> = new Map();
-    db.performance.forEach(p => {
-      if (p.date.slice(0, 10) === todayStr) {
-        map.set(p.clientId, p);
+    db.performance.forEach(entry => {
+      if (entry.date.slice(0, 10) === todayStr) {
+        map.set(entry.clientId, entry);
       }
     });
     return map;
@@ -45,7 +74,7 @@ export default function PerformanceTab({
       const updated = { ...mark, successful: !mark.successful };
       const next = {
         ...db,
-        performance: db.performance.map(p => (p.id === mark.id ? updated : p)),
+        performance: db.performance.map(entry => (entry.id === mark.id ? updated : entry)),
       };
       const ok = await commitDBUpdate(next, setDB);
       if (!ok) {
@@ -66,98 +95,238 @@ export default function PerformanceTab({
     }
   };
 
+  const columns = useMemo(() => {
+    return [
+      {
+        id: "name",
+        label: "Ученик",
+        width: "minmax(200px, max-content)",
+        renderCell: (client: Client) => (
+          <span className="font-medium text-slate-800 dark:text-slate-100">{client.firstName} {client.lastName}</span>
+        ),
+        sortValue: (client: Client) => `${client.firstName} ${client.lastName ?? ""}`.trim().toLowerCase(),
+      },
+      {
+        id: "area",
+        label: "Район",
+        width: "minmax(140px, max-content)",
+        renderCell: (client: Client) => client.area,
+        sortValue: (client: Client) => client.area,
+      },
+      {
+        id: "group",
+        label: "Группа",
+        width: "minmax(140px, max-content)",
+        renderCell: (client: Client) => client.group,
+        sortValue: (client: Client) => client.group,
+      },
+      {
+        id: "mark",
+        label: "Оценка",
+        width: "minmax(200px, 1fr)",
+        headerAlign: "right" as const,
+        cellClassName: "text-right",
+        renderCell: (client: Client) => {
+          const mark = todayMarks.get(client.id);
+          const label = mark ? (mark.successful ? "успевает" : "нужна работа") : "не оценён";
+          const tone = mark
+            ? mark.successful
+              ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700"
+              : "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:border-amber-700"
+            : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700";
+          return (
+            <button
+              type="button"
+              onClick={event => {
+                event.stopPropagation();
+                toggle(client.id);
+              }}
+              className={`inline-flex items-center justify-center rounded-md border px-3 py-1 text-xs font-semibold ${tone}`}
+            >
+              {label}
+            </button>
+          );
+        },
+        sortValue: (client: Client) => {
+          const mark = todayMarks.get(client.id);
+          if (!mark) return 0;
+          return mark.successful ? 2 : 1;
+        },
+      },
+    ];
+  }, [todayMarks]);
+
+  const activeColumns = useMemo(
+    () => columns.filter(column => visibleColumns.includes(column.id)),
+    [columns, visibleColumns],
+  );
+
+  const sortedClients = useMemo(() => {
+    if (!sort) return list;
+    const column = columns.find(col => col.id === sort.columnId);
+    if (!column?.sortValue) return list;
+    const copy = [...list];
+    copy.sort((a, b) => {
+      const compare = compareValues(column.sortValue!(a), column.sortValue!(b));
+      return sort.direction === "asc" ? compare : -compare;
+    });
+    return copy;
+  }, [columns, list, sort]);
+
+  const columnTemplate = activeColumns.length ? activeColumns.map(column => column.width).join(" ") : "1fr";
+
+  const startEdit = (client: Client) => {
+    setEditing(client);
+  };
+
+  const saveClient = async (values: ClientFormValues) => {
+    if (!editing) return;
+    const prepared = transformClientFormValues(values, editing);
+    const updated: Client = { ...editing, ...prepared };
+    const next = {
+      ...db,
+      clients: db.clients.map(client => (client.id === editing.id ? updated : client)),
+    };
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось сохранить изменения клиента. Проверьте доступ к базе данных.");
+      return;
+    }
+    setEditing(null);
+    setSelected(updated);
+  };
+
   return (
     <div className="space-y-3">
       <Breadcrumbs items={["Успеваемость"]} />
       <div className="flex flex-wrap items-center gap-2">
         <select
           className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={area}
-          onChange={e => setArea(e.target.value)}
+          value={area ?? ""}
+          onChange={e => setArea(e.target.value ? (e.target.value as Area) : null)}
         >
-          <option value="all">Все районы</option>
-          {db.settings.areas.map(a => (
-            <option key={a}>{a}</option>
+          <option value="">Выберите район</option>
+          {areaOptions.map(option => (
+            <option key={option} value={option}>
+              {option}
+            </option>
           ))}
         </select>
         <select
           className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={group}
-          onChange={e => setGroup(e.target.value)}
+          value={group ?? ""}
+          onChange={e => setGroup(e.target.value ? (e.target.value as Group) : null)}
+          disabled={!area}
         >
-          <option value="all">Все группы</option>
-          {db.settings.groups.map(g => (
-            <option key={g}>{g}</option>
+          <option value="">Выберите группу</option>
+          {availableGroups.map(option => (
+            <option key={option} value={option}>
+              {option}
+            </option>
           ))}
         </select>
-        <div className="text-xs text-slate-500">Сегодня: {fmtDate(today.toISOString())}</div>
+        <div className="text-xs text-slate-500">Сегодня: {fmtDate(new Date().toISOString())}</div>
+        <div className="grow" />
+        <ColumnSettings
+          options={columns.map(column => ({ id: column.id, label: column.label }))}
+          value={visibleColumns}
+          onChange={setVisibleColumns}
+        />
+      </div>
+      <div className="text-xs text-slate-500">
+        {area && group ? `Найдено: ${list.length}` : "Выберите район и группу"}
       </div>
 
       <VirtualizedTable
         header={(
           <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
             <tr
-              style={{ display: "grid", gridTemplateColumns: COLUMN_TEMPLATE, alignItems: "center" }}
+              style={{ display: "grid", gridTemplateColumns: columnTemplate, alignItems: "center" }}
             >
-              <th className="text-left p-2">Ученик</th>
-              <th className="text-left p-2">Район</th>
-              <th className="text-left p-2">Группа</th>
-              <th className="text-left p-2" style={{ justifySelf: "end" }}>
-                Оценка
-              </th>
+              {activeColumns.map(column => {
+                const canSort = Boolean(column.sortValue);
+                const isSorted = sort?.columnId === column.id;
+                const indicator = isSorted ? (sort?.direction === "asc" ? "↑" : "↓") : null;
+                const alignment = column.headerAlign ?? "left";
+                const justify =
+                  alignment === "right" ? "justify-end" : alignment === "center" ? "justify-center" : "";
+                const content = (
+                  <div className={`flex items-center gap-1 ${justify}`}>
+                    <span>{column.label}</span>
+                    {indicator && <span className="text-xs">{indicator}</span>}
+                  </div>
+                );
+                return (
+                  <th
+                    key={column.id}
+                    className={`p-2 ${
+                      alignment === "right"
+                        ? "text-right"
+                        : alignment === "center"
+                        ? "text-center"
+                        : "text-left"
+                    }`}
+                    style={{ cursor: canSort ? "pointer" : "default" }}
+                  >
+                    {canSort ? (
+                      <button
+                        type="button"
+                        className="flex w-full items-center justify-between gap-1 focus:outline-none"
+                        onClick={() => setSort(prev => toggleSort(prev, column.id))}
+                      >
+                        {content}
+                      </button>
+                    ) : (
+                      content
+                    )}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
         )}
-        items={list}
-        rowHeight={44}
-        renderRow={(c, style) => {
-          const m = todayMarks.get(c.id);
-          return (
-            <tr
-              key={c.id}
-              style={{
-                ...style,
-                display: "grid",
-                gridTemplateColumns: COLUMN_TEMPLATE,
-                alignItems: "center",
-              }}
-              className="border-t border-slate-100 dark:border-slate-700"
-            >
-              <td className="p-2">
-                <button
-                  type="button"
-                  onClick={() => setSelected(c)}
-                  className="text-sky-600 hover:underline focus:outline-none dark:text-sky-400"
-                >
-                  {c.firstName} {c.lastName}
-                </button>
+        items={sortedClients}
+        rowHeight={48}
+        renderRow={(client, style) => (
+          <tr
+            key={client.id}
+            style={{
+              ...style,
+              display: "grid",
+              gridTemplateColumns: columnTemplate,
+              alignItems: "center",
+              cursor: "pointer",
+            }}
+            className="border-t border-slate-100 transition hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
+            onClick={() => setSelected(client)}
+          >
+            {activeColumns.map(column => (
+              <td key={column.id} className={`p-2 ${column.cellClassName ?? ""}`}>
+                {column.renderCell(client)}
               </td>
-              <td className="p-2">{c.area}</td>
-              <td className="p-2">{c.group}</td>
-              <td className="p-2 flex justify-end">
-                <button
-                  onClick={() => toggle(c.id)}
-                  className={`px-3 py-1 rounded-md text-xs border ${
-                    m
-                      ? m.successful
-                        ? "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700"
-                        : "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700"
-                      : "bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700"
-                  }`}
-                >
-                  {m ? (m.successful ? "успевает" : "нужна работа") : "не оценён"}
-                </button>
-              </td>
-            </tr>
-          );
-        }}
+            ))}
+          </tr>
+        )}
       />
 
       {selected && (
         <ClientDetailsModal
           client={selected}
           currency={currency}
+          schedule={db.schedule}
+          attendance={db.attendance}
+          performance={db.performance}
+          onEdit={startEdit}
           onClose={() => setSelected(null)}
+        />
+      )}
+
+      {editing && (
+        <ClientForm
+          db={db}
+          editing={editing}
+          onSave={saveClient}
+          onClose={() => setEditing(null)}
         />
       )}
     </div>

--- a/src/components/__tests__/ClientsTab.test.tsx
+++ b/src/components/__tests__/ClientsTab.test.tsx
@@ -30,6 +30,7 @@ import { uid, todayISO, parseDateInput, fmtMoney, fmtDate } from '../../state/ut
 
 beforeEach(() => {
   jest.clearAllMocks();
+  window.localStorage.clear();
   commitDBUpdate.mockImplementation(async (next, setDB) => {
     setDB(next);
     return true;
@@ -46,7 +47,12 @@ beforeEach(() => {
 const makeDB = () => ({
   clients: [],
   attendance: [],
-  schedule: [],
+  performance: [],
+  schedule: [
+    { id: 'slot-1', area: 'Area1', group: 'Group1', coachId: 's1', weekday: 1, time: '10:00', location: '' },
+    { id: 'slot-2', area: 'Area1', group: 'Group2', coachId: 's1', weekday: 2, time: '11:00', location: '' },
+    { id: 'slot-3', area: 'Area2', group: 'Group1', coachId: 's1', weekday: 3, time: '12:00', location: '' },
+  ],
   leads: [],
   tasks: [],
   staff: [{ id: 's1', role: 'Тренер', name: 'Coach1' }],
@@ -70,22 +76,43 @@ const makeUI = () => ({
   theme: 'light',
 });
 
-const renderClients = (db = makeDB(), ui = makeUI()) => {
+const renderClients = (db = makeDB(), ui = makeUI(), initialFilters = {}) => {
   let current = db;
   const Wrapper = () => {
     const [state, setState] = React.useState(db);
     const [uiState] = React.useState(ui);
     const setDB = (next) => { current = next; setState(next); };
-    return <ClientsTab db={state} setDB={setDB} ui={uiState} />;
+    return <ClientsTab db={state} setDB={setDB} ui={uiState} {...initialFilters} />;
   };
   const utils = render(<Wrapper />);
   return { ...utils, getDB: () => current };
 };
 
+const makeClient = (overrides = {}) => ({
+  id: 'client-id',
+  firstName: 'Имя',
+  lastName: '',
+  phone: '',
+  channel: 'Telegram',
+  birthDate: '2010-01-01T00:00:00.000Z',
+  parentName: '',
+  gender: 'м',
+  area: 'Area1',
+  group: 'Group1',
+  startDate: '2024-01-01T00:00:00.000Z',
+  payMethod: 'перевод',
+  payStatus: 'ожидание',
+  status: 'действующий',
+  payDate: '2024-01-10T00:00:00.000Z',
+  payAmount: 55,
+  remainingLessons: 5,
+  ...overrides,
+});
 
 test('create: adds client through modal', async () => {
-  const { getDB } = renderClients();
+  const { getDB, unmount } = renderClients();
 
+  expect(screen.getByText('Выберите район и группу')).toBeInTheDocument();
   await userEvent.click(screen.getByText('+ Добавить клиента'));
   const modal = screen.getByText('Новый клиент').parentElement;
 
@@ -103,39 +130,36 @@ test('create: adds client through modal', async () => {
   await waitFor(() => expect(saveBtn).toBeEnabled());
   await userEvent.click(saveBtn);
 
+  await waitFor(() => expect(getDB().clients).toHaveLength(1));
+  unmount();
+  renderClients(getDB(), makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
   await waitFor(() => expect(screen.getByText(/^Вася/)).toBeInTheDocument());
   expect(getDB().clients).toHaveLength(1);
+  expect(getDB().clients[0].payAmount).toBe(55);
 });
 
-test('read: filters clients by area, group and pay status', async () => {
+test('read: filters clients by area, group and pay status', () => {
   const db = makeDB();
   db.clients = [
-    { id: 'c1', firstName: 'A', lastName: '', phone: '', area: 'Area1', group: 'Group1', payStatus: 'ожидание', payAmount: 0 },
-    { id: 'c2', firstName: 'B', lastName: '', phone: '', area: 'Area2', group: 'Group1', payStatus: 'действует', payAmount: 0 },
-    { id: 'c3', firstName: 'C', lastName: '', phone: '', area: 'Area1', group: 'Group2', payStatus: 'задолженность', payAmount: 0 },
+    makeClient({ id: 'c1', firstName: 'A', area: 'Area1', group: 'Group1', payStatus: 'ожидание' }),
+    makeClient({ id: 'c2', firstName: 'B', area: 'Area2', group: 'Group1', payStatus: 'действует' }),
+    makeClient({ id: 'c3', firstName: 'C', area: 'Area1', group: 'Group2', payStatus: 'задолженность' }),
   ];
-  const { getByText } = renderClients(db);
 
-  expect(getByText('A')).toBeInTheDocument();
-  expect(getByText('B')).toBeInTheDocument();
-  expect(getByText('C')).toBeInTheDocument();
-
-  await userEvent.click(screen.getByRole('button', { name: 'Area1' }));
-  expect(getByText('A')).toBeInTheDocument();
-  expect(getByText('C')).toBeInTheDocument();
+  const view1 = renderClients(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
+  expect(screen.getByText('A')).toBeInTheDocument();
   expect(screen.queryByText('B')).not.toBeInTheDocument();
+  expect(screen.queryByText('C')).not.toBeInTheDocument();
+  view1.unmount();
 
-  await userEvent.click(getByText('Все районы'));
-  const [groupSelect, paySelect] = screen.getAllByRole('combobox');
-
-  await userEvent.selectOptions(groupSelect, 'Group2');
-  expect(getByText('C')).toBeInTheDocument();
+  const view2 = renderClients(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group2' });
+  expect(screen.getByText('C')).toBeInTheDocument();
   expect(screen.queryByText('A')).not.toBeInTheDocument();
   expect(screen.queryByText('B')).not.toBeInTheDocument();
+  view2.unmount();
 
-  await userEvent.selectOptions(groupSelect, 'all');
-  await userEvent.selectOptions(paySelect, 'действует');
-  expect(getByText('B')).toBeInTheDocument();
+  renderClients(db, makeUI(), { initialArea: 'Area2', initialGroup: 'Group1', initialPay: 'действует' });
+  expect(screen.getByText('B')).toBeInTheDocument();
   expect(screen.queryByText('A')).not.toBeInTheDocument();
   expect(screen.queryByText('C')).not.toBeInTheDocument();
 });
@@ -143,22 +167,11 @@ test('read: filters clients by area, group and pay status', async () => {
 test('update: edits client name', async () => {
   const db = makeDB();
   db.clients = [
-    {
-      id: 'c1',
-      firstName: 'Old',
-      lastName: '',
-      phone: '123',
-      area: 'Area1',
-      group: 'Group1',
-      payStatus: 'ожидание',
-      payAmount: 0,
-      birthDate: '2010-01-01T00:00:00.000Z',
-      startDate: '2024-01-01T00:00:00.000Z',
-    },
+    makeClient({ id: 'c1', firstName: 'Old', phone: '123' }),
   ];
-  const { getDB } = renderClients(db);
-
-  await userEvent.click(screen.getByText('Редактировать'));
+  const { getDB } = renderClients(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
+  await waitFor(() => expect(screen.getByRole('button', { name: /Old/ })).toBeInTheDocument());
+  await userEvent.click(screen.getByRole('button', { name: /Old/ }));
   const modal = screen.getByText('Редактирование клиента').parentElement;
   const input = within(modal).getByText('Имя').parentElement.querySelector('input');
   const phone = within(modal).getByText('Телефон').parentElement.querySelector('input');
@@ -180,41 +193,14 @@ test('update: edits client name', async () => {
 
 test('delete: removes client after confirmation', async () => {
   const db = makeDB();
-  db.clients = [
-    { id: 'c1', firstName: 'Del', lastName: '', phone: '', area: 'Area1', group: 'Group1', payStatus: 'ожидание', payAmount: 0 },
-  ];
-  const { getDB } = renderClients(db);
-
+  db.clients = [makeClient({ id: 'c1', firstName: 'Del' })];
+  const { getDB } = renderClients(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
+  await waitFor(() => expect(screen.getByText('Del')).toBeInTheDocument());
   await userEvent.click(screen.getByText('Удалить'));
 
   expect(global.confirm).toHaveBeenCalled();
   await waitFor(() => expect(screen.queryByText('Del')).not.toBeInTheDocument());
   expect(getDB().clients.find(c => c.id === 'c1')).toBeUndefined();
-});
-
-test('updates payment fact when checkbox toggled', async () => {
-  const db = makeDB();
-  db.clients = [
-    {
-      id: 'c1',
-      firstName: 'Client',
-      lastName: '',
-      phone: '',
-      area: 'Area1',
-      group: 'Group1',
-      payStatus: 'ожидание',
-      payAmount: 0,
-      payConfirmed: false,
-    },
-  ];
-  const { getDB } = renderClients(db);
-
-  const checkbox = screen.getByRole('checkbox', { name: 'Факт оплаты Client' });
-  expect(checkbox).not.toBeChecked();
-
-  await userEvent.click(checkbox);
-
-  await waitFor(() => expect(getDB().clients[0].payConfirmed).toBe(true));
 });
 
 test('creates payment task with client info', async () => {
@@ -225,25 +211,20 @@ test('creates payment task with client info', async () => {
 
   const db = makeDB();
   db.clients = [
-    {
+    makeClient({
       id: 'c1',
       firstName: 'Ivan',
       lastName: 'Petrov',
       parentName: 'Parent',
-      phone: '',
-      area: 'Area1',
-      group: 'Group1',
       payStatus: 'действует',
       payAmount: 50,
       payDate: '2024-02-01T00:00:00.000Z',
-      payConfirmed: true,
-    },
+    }),
   ];
 
-  const { getDB } = renderClients(db);
-
-  const row = screen.getByText('Ivan Petrov').closest('tr');
-  const createTaskBtn = within(row).getByRole('button', { name: 'Создать задачу' });
+  const { getDB } = renderClients(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
+  const row = await screen.findByText('Ivan Petrov');
+  const createTaskBtn = within(row.closest('tr')).getByRole('button', { name: 'Создать задачу' });
 
   await userEvent.click(createTaskBtn);
 
@@ -257,4 +238,40 @@ test('creates payment task with client info', async () => {
     assigneeType: 'client',
     assigneeId: 'c1',
   });
+  expect(getDB().clients[0].payStatus).toBe('задолженность');
+});
+
+test('individual group allows custom payment amount', async () => {
+  const db = makeDB();
+  db.settings.groups = ['Group1', 'индивидуальные'];
+  db.schedule.push({ id: 'slot-ind', area: 'Area1', group: 'индивидуальные', coachId: 's1', weekday: 4, time: '13:00', location: '' });
+  const { getDB } = renderClients(db);
+
+  await userEvent.click(screen.getByText('+ Добавить клиента'));
+  const modal = screen.getByText('Новый клиент').parentElement;
+
+  const groupSelect = within(modal).getByText('Группа').parentElement.querySelector('select');
+  await userEvent.selectOptions(groupSelect, 'индивидуальные');
+
+  const firstName = within(modal).getByText('Имя').parentElement.querySelector('input');
+  const phone = within(modal).getByText('Телефон').parentElement.querySelector('input');
+  const birthDate = within(modal).getByText('Дата рождения').parentElement.querySelector('input');
+  const startDate = within(modal).getByText('Дата начала').parentElement.querySelector('input');
+  const payAmount = within(modal).getByText('Сумма оплаты, €').parentElement.querySelector('input');
+
+  await userEvent.type(firstName, 'Люба');
+  await userEvent.type(phone, '999');
+  fireEvent.change(birthDate, { target: { value: '2010-01-01' } });
+  fireEvent.change(startDate, { target: { value: '2024-01-01' } });
+
+  await waitFor(() => expect(payAmount).toHaveValue(125));
+  await userEvent.clear(payAmount);
+  await userEvent.type(payAmount, '200');
+
+  const saveBtn = within(modal).getByText('Сохранить');
+  await waitFor(() => expect(saveBtn).toBeEnabled());
+  await userEvent.click(saveBtn);
+
+  await waitFor(() => expect(getDB().clients[0].group).toBe('индивидуальные'));
+  expect(getDB().clients[0].payAmount).toBe(200);
 });

--- a/src/components/__tests__/ScheduleTab.groups.test.tsx
+++ b/src/components/__tests__/ScheduleTab.groups.test.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import React from "react";
-import { render, screen, within, cleanup } from "@testing-library/react";
+import { render, screen, within, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
@@ -86,7 +86,10 @@ describe("ScheduleTab groups", () => {
     await userEvent.click(screen.getByText("+ группа"));
     const ui = { role: "Администратор", activeTab: "clients", breadcrumbs: [], currency: "EUR", search: "", theme: "light" };
     render(<ClientsTab db={getDb()} setDB={() => {}} ui={ui} />);
-    expect(screen.getByRole("option", { name: "Alpha" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "A1" }));
+    await waitFor(() => expect(screen.getByLabelText("Фильтр по группе")).not.toBeDisabled());
+    const groupSelect = screen.getByLabelText("Фильтр по группе");
+    expect(within(groupSelect).getByRole("option", { name: "Alpha" })).toBeInTheDocument();
   });
 
   test("Update: editing slot changes group and updates settings", async () => {

--- a/src/components/__tests__/TasksTab.test.tsx
+++ b/src/components/__tests__/TasksTab.test.tsx
@@ -19,7 +19,7 @@ import { commitDBUpdate } from '../../state/appState';
 
 function setup(initialTasks) {
   const Wrapper = () => {
-    const [db, setDB] = React.useState({ tasks: initialTasks });
+    const [db, setDB] = React.useState({ tasks: initialTasks, clients: [] });
     return <TasksTab db={db} setDB={setDB} />;
   };
   return render(<Wrapper />);

--- a/src/components/clients/ClientDetailsModal.tsx
+++ b/src/components/clients/ClientDetailsModal.tsx
@@ -1,86 +1,229 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import Modal from "../Modal";
-import { calcAgeYears, calcExperience, fmtMoney } from "../../state/utils";
-import type { Client, Currency } from "../../types";
+import { calcAgeYears, calcExperience, fmtDate, fmtMoney } from "../../state/utils";
+import { getEffectiveRemainingLessons } from "../../state/lessons";
+import type { AttendanceEntry, Client, Currency, PerformanceEntry, ScheduleSlot } from "../../types";
 
 interface Props {
   client: Client;
   currency: Currency;
+  schedule: ScheduleSlot[];
+  attendance: AttendanceEntry[];
+  performance: PerformanceEntry[];
   onClose: () => void;
   onEdit?: (client: Client) => void;
   onRemove?: (id: string) => void;
 }
 
-export default function ClientDetailsModal({ client, currency, onClose, onEdit, onRemove }: Props) {
+export default function ClientDetailsModal({
+  client,
+  currency,
+  schedule,
+  attendance,
+  performance,
+  onClose,
+  onEdit,
+  onRemove,
+}: Props) {
+  const remaining = getEffectiveRemainingLessons(client, schedule);
+  const [section, setSection] = useState<"info" | "attendance" | "performance">("info");
+
+  const attendanceEntries = useMemo(() => {
+    return attendance
+      .filter(entry => entry.clientId === client.id)
+      .slice()
+      .sort((a, b) => b.date.localeCompare(a.date));
+  }, [attendance, client.id]);
+
+  const performanceEntries = useMemo(() => {
+    return performance
+      .filter(entry => entry.clientId === client.id)
+      .slice()
+      .sort((a, b) => b.date.localeCompare(a.date));
+  }, [performance, client.id]);
+
+  const attendedCount = attendanceEntries.filter(entry => entry.came).length;
+  const successfulCount = performanceEntries.filter(entry => entry.successful).length;
+
   return (
-    <Modal size="md" onClose={onClose}>
-      <div className="font-semibold text-slate-800 dark:text-slate-100">
-        {client.firstName} {client.lastName}
-      </div>
-      <div className="grid gap-1 text-sm">
-        <div>
-          <span className="text-slate-500">Телефон:</span> {client.phone || "—"}
+    <Modal size="lg" onClose={onClose}>
+      <div className="flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+              {client.firstName} {client.lastName}
+            </div>
+            <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              {client.area} · {client.group}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            {onEdit && (
+              <button
+                type="button"
+                onClick={() => {
+                  onEdit(client);
+                  onClose();
+                }}
+                className="px-3 py-2 rounded-md border border-slate-300 text-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:hover:bg-slate-700"
+              >
+                Редактировать
+              </button>
+            )}
+            {onRemove && (
+              <button
+                type="button"
+                onClick={() => {
+                  onRemove(client.id);
+                  onClose();
+                }}
+                className="px-3 py-2 rounded-md border border-rose-200 text-sm text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:text-rose-300 dark:hover:bg-rose-900/30"
+              >
+                Удалить
+              </button>
+            )}
+          </div>
         </div>
-        <div>
-          <span className="text-slate-500">Канал:</span> {client.channel}
+
+        <div className="flex flex-wrap gap-2">
+          {[
+            { id: "info", label: "Информация" },
+            { id: "attendance", label: "Посещаемость" },
+            { id: "performance", label: "Успеваемость" },
+          ].map(tab => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setSection(tab.id as typeof section)}
+              className={`px-3 py-1 rounded-full border text-xs font-semibold transition ${
+                section === tab.id
+                  ? "border-sky-500 bg-sky-100 text-sky-700 dark:border-sky-400 dark:bg-sky-900/30 dark:text-sky-200"
+                  : "border-slate-300 bg-white text-slate-600 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
         </div>
-        <div>
-          <span className="text-slate-500">Родитель:</span> {client.parentName || "—"}
-        </div>
-        <div>
-          <span className="text-slate-500">Дата рождения:</span> {client.birthDate?.slice(0, 10)}
-        </div>
-        <div>
-          <span className="text-slate-500">Возраст:</span> {client.birthDate ? `${calcAgeYears(client.birthDate)} лет` : "—"}
-        </div>
-        <div>
-          <span className="text-slate-500">Район:</span> {client.area}
-        </div>
-        <div>
-          <span className="text-slate-500">Группа:</span> {client.group}
-        </div>
-        <div>
-          <span className="text-slate-500">Опыт:</span> {client.startDate ? calcExperience(client.startDate) : "—"}
-        </div>
-        <div>
-          <span className="text-slate-500">Статус оплаты:</span> {client.payStatus}
-        </div>
-        <div>
-          <span className="text-slate-500">Дата оплаты:</span> {client.payDate?.slice(0, 10) || "—"}
-        </div>
-        <div>
-          <span className="text-slate-500">Сумма оплаты:</span> {client.payAmount != null ? fmtMoney(client.payAmount, currency) : "—"}
-        </div>
-      </div>
-      <div className="flex justify-end gap-2">
-        {onEdit && (
+
+        {section === "info" && (
+          <div className="grid gap-2 text-sm sm:grid-cols-2">
+            <InfoRow label="Телефон" value={client.phone || "—"} />
+            <InfoRow label="Канал" value={client.channel} />
+            <InfoRow label="Родитель" value={client.parentName || "—"} />
+            <InfoRow label="Дата рождения" value={client.birthDate?.slice(0, 10) || "—"} />
+            <InfoRow label="Возраст" value={client.birthDate ? `${calcAgeYears(client.birthDate)} лет` : "—"} />
+            <InfoRow label="Дата начала" value={client.startDate?.slice(0, 10) || "—"} />
+            <InfoRow label="Опыт" value={client.startDate ? calcExperience(client.startDate) : "—"} />
+            <InfoRow label="Статус" value={client.status ?? "—"} />
+            <InfoRow label="Статус оплаты" value={client.payStatus} />
+            <InfoRow label="Дата оплаты" value={client.payDate?.slice(0, 10) || "—"} />
+            <InfoRow
+              label="Сумма оплаты"
+              value={client.payAmount != null ? fmtMoney(client.payAmount, currency) : "—"}
+            />
+            <InfoRow label="Остаток занятий" value={remaining != null ? String(remaining) : "—"} />
+          </div>
+        )}
+
+        {section === "attendance" && (
+          <div className="space-y-2">
+            <SummaryPill label="Отметок" value={attendanceEntries.length} />
+            <SummaryPill label="Посетил" value={attendedCount} />
+            <SummaryPill
+              label="Последнее занятие"
+              value={attendanceEntries[0] ? fmtDate(attendanceEntries[0].date) : "—"}
+            />
+            <HistoryList
+              emptyText="Пока нет отметок посещаемости"
+              entries={attendanceEntries.map(entry => ({
+                id: entry.id,
+                date: fmtDate(entry.date),
+                value: entry.came ? "пришёл" : "отсутствовал",
+                tone: entry.came ? "success" : "warning",
+              }))}
+            />
+          </div>
+        )}
+
+        {section === "performance" && (
+          <div className="space-y-2">
+            <SummaryPill label="Оценок" value={performanceEntries.length} />
+            <SummaryPill label="Успешных" value={successfulCount} />
+            <SummaryPill
+              label="Последняя оценка"
+              value={performanceEntries[0] ? fmtDate(performanceEntries[0].date) : "—"}
+            />
+            <HistoryList
+              emptyText="Пока нет отметок успеваемости"
+              entries={performanceEntries.map(entry => ({
+                id: entry.id,
+                date: fmtDate(entry.date),
+                value: entry.successful ? "успевает" : "нужна работа",
+                tone: entry.successful ? "success" : "warning",
+              }))}
+            />
+          </div>
+        )}
+
+        <div className="flex justify-end">
           <button
             type="button"
-            onClick={() => {
-              onEdit(client);
-              onClose();
-            }}
-            className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600"
+            onClick={onClose}
+            className="px-4 py-2 rounded-md border border-slate-300 text-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
           >
-            Редактировать
+            Закрыть
           </button>
-        )}
-        {onRemove && (
-          <button
-            type="button"
-            onClick={() => {
-              onRemove(client.id);
-              onClose();
-            }}
-            className="px-3 py-2 rounded-md border border-rose-200 text-rose-600 dark:border-rose-700"
-          >
-            Удалить
-          </button>
-        )}
-        <button type="button" onClick={onClose} className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600">
-          Закрыть
-        </button>
+        </div>
       </div>
     </Modal>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1 rounded-lg border border-slate-200 bg-white p-3 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-800">
+      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</span>
+      <span className="text-slate-700 dark:text-slate-100">{value}</span>
+    </div>
+  );
+}
+
+function SummaryPill({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+      <span className="uppercase tracking-wide">{label}</span>
+      <span className="text-sm font-semibold text-slate-900 dark:text-slate-100">{value}</span>
+    </div>
+  );
+}
+
+function HistoryList({
+  entries,
+  emptyText,
+}: {
+  entries: { id: string; date: string; value: string; tone: "success" | "warning" }[];
+  emptyText: string;
+}) {
+  if (!entries.length) {
+    return <div className="text-sm text-slate-500 dark:text-slate-400">{emptyText}</div>;
+  }
+
+  return (
+    <ul className="max-h-60 space-y-2 overflow-y-auto pr-1">
+      {entries.map(entry => (
+        <li
+          key={entry.id}
+          className={`rounded-md border px-3 py-2 text-sm ${
+            entry.tone === "success"
+              ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200"
+              : "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
+          }`}
+        >
+          <div className="text-xs uppercase tracking-wide">{entry.date}</div>
+          <div className="font-semibold">{entry.value}</div>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/src/components/clients/ClientFilters.tsx
+++ b/src/components/clients/ClientFilters.tsx
@@ -3,10 +3,11 @@ import type { DB, Area, Group, PaymentStatus } from "../../types";
 
 type Props = {
   db: DB,
-  area: Area | "all",
-  setArea: (a: Area | "all") => void,
-  group: Group | "all",
-  setGroup: (g: Group | "all") => void,
+  area: Area | null,
+  setArea: (a: Area | null) => void,
+  group: Group | null,
+  setGroup: (g: Group | null) => void,
+  groups: Group[],
   pay: PaymentStatus | "all",
   setPay: (p: PaymentStatus | "all") => void,
   listLength: number,
@@ -34,6 +35,7 @@ export default function ClientFilters({
   setArea,
   group,
   setGroup,
+  groups,
   pay,
   setPay,
   listLength,
@@ -42,9 +44,9 @@ export default function ClientFilters({
   return (
     <>
       <div className="flex flex-wrap gap-2 items-center">
-        <Chip active={area === "all"} onClick={() => setArea("all")}>Все районы</Chip>
+        <Chip active={area === null} onClick={() => { setArea(null); setGroup(null); }}>Сбросить район</Chip>
         {db.settings.areas.map(a => (
-          <Chip key={a} active={area === a} onClick={() => setArea(a)}>{a}</Chip>
+          <Chip key={a} active={area === a} onClick={() => { setArea(a); setGroup(null); }}>{a}</Chip>
         ))}
         <div className="flex-1" />
         <button
@@ -58,11 +60,13 @@ export default function ClientFilters({
       <div className="flex flex-wrap gap-2 items-center">
         <select
           className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={group}
-          onChange={e => setGroup(e.target.value)}
+          value={group ?? ""}
+          onChange={e => setGroup(e.target.value ? (e.target.value as Group) : null)}
+          disabled={!area}
+          aria-label="Фильтр по группе"
         >
-          <option value="all">Все группы</option>
-          {db.settings.groups.map(g => (
+          <option value="">Выберите группу</option>
+          {groups.map(g => (
             <option key={g} value={g}>{g}</option>
           ))}
         </select>
@@ -70,13 +74,16 @@ export default function ClientFilters({
           className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
           value={pay}
           onChange={e => setPay(e.target.value as PaymentStatus | "all")}
+          aria-label="Фильтр по статусу оплаты"
         >
           <option value="all">Все статусы оплаты</option>
           <option value="ожидание">ожидание</option>
           <option value="действует">действует</option>
           <option value="задолженность">задолженность</option>
         </select>
-        <div className="text-xs text-slate-500">Найдено: {listLength}</div>
+        <div className="text-xs text-slate-500">
+          {area && group ? `Найдено: ${listLength}` : "Выберите район и группу"}
+        </div>
       </div>
     </>
   );

--- a/src/components/clients/ClientForm.tsx
+++ b/src/components/clients/ClientForm.tsx
@@ -1,11 +1,13 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import type { Resolver } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import Modal from "../Modal";
 import { todayISO } from "../../state/utils";
-import type { DB, Client, ClientFormValues } from "../../types";
+import { getDefaultPayAmount, shouldAllowCustomPayAmount } from "../../state/payments";
+import { buildGroupsByArea, estimateGroupRemainingLessonsByParams, requiresManualRemainingLessons } from "../../state/lessons";
+import type { Area, DB, Client, ClientFormValues, Group } from "../../types";
 
 type Props = {
   db: DB,
@@ -15,21 +17,45 @@ type Props = {
 };
 
 export default function ClientForm({ db, editing, onSave, onClose }: Props) {
+  const groupsByArea = useMemo(() => buildGroupsByArea(db.schedule), [db.schedule]);
+  const firstAreaWithSchedule = useMemo(() => {
+    for (const [area] of groupsByArea) {
+      return area;
+    }
+    return db.settings.areas[0];
+  }, [db.settings.areas, groupsByArea]);
+
+  const firstGroupForArea = useCallback(
+    (area: Area | undefined): Group => {
+      if (area) {
+        const fromSchedule = groupsByArea.get(area);
+        if (fromSchedule?.length) {
+          return fromSchedule[0];
+        }
+      }
+      return db.settings.groups[0];
+    },
+    [db.settings.groups, groupsByArea],
+  );
+
   const blankForm = useCallback((): ClientFormValues => ({
     firstName: "",
     lastName: "",
     phone: "",
     gender: "м",
-    area: db.settings.areas[0],
-    group: db.settings.groups[0],
+    area: firstAreaWithSchedule ?? db.settings.areas[0],
+    group: firstGroupForArea(firstAreaWithSchedule ?? db.settings.areas[0]),
     channel: "Telegram",
     startDate: todayISO().slice(0, 10),
     payMethod: "перевод",
     payStatus: "ожидание",
+    status: "новый",
     birthDate: "2017-01-01",
     payDate: todayISO().slice(0, 10),
     parentName: "",
-  }), [db.settings.areas, db.settings.groups]);
+    payAmount: String(getDefaultPayAmount(db.settings.groups[0]) ?? ""),
+    remainingLessons: "",
+  }), [db.settings.areas, db.settings.groups, firstAreaWithSchedule, firstGroupForArea]);
 
   const schema = yup.object({
     firstName: yup.string().required("Имя обязательно"),
@@ -46,7 +72,7 @@ export default function ClientForm({ db, editing, onSave, onClose }: Props) {
 
   const resolver = yupResolver(schema) as unknown as Resolver<ClientFormValues>;
 
-  const { register, handleSubmit, reset, formState: { errors, isValid } } = useForm<ClientFormValues>({
+  const { register, handleSubmit, reset, formState: { errors, isValid }, watch, setValue } = useForm<ClientFormValues>({
     resolver,
     mode: "onChange",
     defaultValues: blankForm(),
@@ -65,15 +91,82 @@ export default function ClientForm({ db, editing, onSave, onClose }: Props) {
         startDate: editing.startDate?.slice(0, 10) ?? "",
         payMethod: editing.payMethod,
         payStatus: editing.payStatus,
+        status: editing.status ?? "действующий",
         birthDate: editing.birthDate?.slice(0, 10) ?? "",
         payDate: editing.payDate?.slice(0, 10) ?? "",
         parentName: editing.parentName ?? "",
+        payAmount: editing.payAmount != null ? String(editing.payAmount) : String(getDefaultPayAmount(editing.group) ?? ""),
+        remainingLessons: editing.remainingLessons != null ? String(editing.remainingLessons) : "",
       };
       reset(values);
     } else {
       reset(blankForm());
     }
   }, [editing, reset, blankForm]);
+
+  const selectedGroup = watch("group");
+  const currentPayAmount = watch("payAmount");
+  const selectedArea = watch("area");
+  const manualRemaining = requiresManualRemainingLessons(selectedGroup);
+  const areaGroups = useMemo(() => {
+    const manualGroups = db.settings.groups.filter(groupName => requiresManualRemainingLessons(groupName));
+    if (!selectedArea) {
+      return Array.from(new Set([...db.settings.groups, ...manualGroups]));
+    }
+    const scheduled = groupsByArea.get(selectedArea) ?? [];
+    return Array.from(new Set([...scheduled, ...manualGroups]));
+  }, [db.settings.groups, groupsByArea, selectedArea]);
+  const selectedPayDate = watch("payDate");
+  const computedRemaining = useMemo(() => {
+    if (manualRemaining) return null;
+    if (!selectedArea || !selectedGroup) return null;
+    return (
+      estimateGroupRemainingLessonsByParams(selectedArea, selectedGroup, selectedPayDate, db.schedule) ?? null
+    );
+  }, [db.schedule, manualRemaining, selectedArea, selectedGroup, selectedPayDate]);
+  const canEditPayAmount = shouldAllowCustomPayAmount(selectedGroup);
+  const defaultPayAmount = getDefaultPayAmount(selectedGroup);
+  const prevGroupRef = useRef<string | null>(null);
+  const prevAreaRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const previousGroup = prevGroupRef.current;
+    prevGroupRef.current = selectedGroup ?? null;
+
+    if (!canEditPayAmount && defaultPayAmount != null) {
+      const targetValue = String(defaultPayAmount);
+      if (currentPayAmount !== targetValue) {
+        setValue("payAmount", targetValue, { shouldDirty: true, shouldValidate: false });
+      }
+      return;
+    }
+
+    if (canEditPayAmount && defaultPayAmount != null) {
+      const switchedGroup = previousGroup !== selectedGroup;
+      if (!currentPayAmount || switchedGroup) {
+        setValue("payAmount", String(defaultPayAmount), { shouldDirty: false, shouldValidate: false });
+      }
+    }
+  }, [canEditPayAmount, defaultPayAmount, currentPayAmount, selectedGroup, setValue]);
+
+  useEffect(() => {
+    const previousArea = prevAreaRef.current;
+    prevAreaRef.current = selectedArea ?? null;
+
+    if (!selectedArea) {
+      return;
+    }
+
+    if (!areaGroups.length) {
+      return;
+    }
+
+    if (!selectedGroup || !areaGroups.includes(selectedGroup)) {
+      setValue("group", areaGroups[0], {
+        shouldDirty: previousArea !== null && previousArea !== selectedArea,
+      });
+    }
+  }, [areaGroups, selectedArea, selectedGroup, setValue]);
 
   return (
     <Modal size="xl" onClose={onClose}>
@@ -120,8 +213,8 @@ export default function ClientForm({ db, editing, onSave, onClose }: Props) {
           <div className="flex flex-col gap-1">
             <label className="text-xs text-slate-500">Группа</label>
             <select className="px-3 py-2 rounded-md border border-slate-300" {...register("group")}>
-              {db.settings.groups.map(g => (
-                <option key={g}>{g}</option>
+              {areaGroups.map(g => (
+                <option key={g} value={g}>{g}</option>
               ))}
             </select>
           </div>
@@ -149,6 +242,56 @@ export default function ClientForm({ db, editing, onSave, onClose }: Props) {
               <option>действует</option>
               <option>задолженность</option>
             </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Статус</label>
+            <select className="px-3 py-2 rounded-md border border-slate-300" {...register("status")}>
+              <option value="действующий">действующий</option>
+              <option value="отмена">отмена</option>
+              <option value="новый">новый</option>
+              <option value="вернувшийся">вернувшийся</option>
+              <option value="продлившийся">продлившийся</option>
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Дата оплаты</label>
+            <input type="date" className="px-3 py-2 rounded-md border border-slate-300" {...register("payDate")} />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Сумма оплаты, €</label>
+            <input
+              type="number"
+              inputMode="decimal"
+              className="px-3 py-2 rounded-md border border-slate-300"
+              {...register("payAmount")}
+              disabled={!canEditPayAmount && defaultPayAmount != null}
+              placeholder="Укажите сумму"
+            />
+            {!canEditPayAmount && defaultPayAmount != null && (
+              <span className="text-xs text-slate-500">Сумма фиксирована для этой группы</span>
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-slate-500">Остаток занятий</label>
+            {manualRemaining ? (
+              <input
+                type="number"
+                inputMode="numeric"
+                className="px-3 py-2 rounded-md border border-slate-300"
+                {...register("remainingLessons")}
+                placeholder="Укажите количество"
+              />
+            ) : (
+              <input
+                type="text"
+                value={computedRemaining != null ? String(computedRemaining) : "—"}
+                readOnly
+                className="px-3 py-2 rounded-md border border-slate-300 bg-slate-100 text-slate-600"
+              />
+            )}
+            {!manualRemaining && (
+              <span className="text-xs text-slate-500">Значение рассчитывается автоматически от даты оплаты</span>
+            )}
           </div>
         </div>
         <div className="flex justify-end gap-2">

--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -1,76 +1,252 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import VirtualizedTable from "../VirtualizedTable";
 import ClientDetailsModal from "./ClientDetailsModal";
+import ColumnSettings from "../ColumnSettings";
+import { compareValues, toggleSort, type SortState } from "../tableUtils";
 import { fmtMoney, fmtDate } from "../../state/utils";
-import type { Client, Currency } from "../../types";
+import { getEffectiveRemainingLessons } from "../../state/lessons";
+import type { AttendanceEntry, Client, Currency, PerformanceEntry, ScheduleSlot } from "../../types";
 
 type Props = {
   list: Client[];
   currency: Currency;
   onEdit: (c: Client) => void;
   onRemove: (id: string) => void;
-  onTogglePayFact: (id: string, value: boolean) => void;
   onCreateTask: (client: Client) => void;
+  schedule: ScheduleSlot[];
+  attendance: AttendanceEntry[];
+  performance: PerformanceEntry[];
 };
 
-const COLUMN_WIDTHS = [
-  "220px", // name
-  "150px", // phone
-  "140px", // area
-  "140px", // group
-  "160px", // payment status
-  "150px", // payment amount
-  "120px", // payment fact
-  "150px", // payment date
-  "260px", // actions
-];
+type ColumnConfig = {
+  id: string;
+  label: string;
+  width: string;
+  headerClassName?: string;
+  cellClassName?: string;
+  renderCell: (client: Client) => React.ReactNode;
+  sortValue?: (client: Client) => unknown;
+  headerAlign?: "left" | "center" | "right";
+};
 
-const COLUMN_TEMPLATE = COLUMN_WIDTHS.join(" ");
-
-export default function ClientTable({ list, currency, onEdit, onRemove, onTogglePayFact, onCreateTask }: Props) {
-
+export default function ClientTable({ list, currency, onEdit, onRemove, onCreateTask, schedule, attendance, performance }: Props) {
   const [selected, setSelected] = useState<Client | null>(null);
+  const [visibleColumns, setVisibleColumns] = useState<string[]>([
+    "name",
+    "phone",
+    "area",
+    "group",
+    "status",
+    "payStatus",
+    "remainingLessons",
+    "payAmount",
+    "payDate",
+    "actions",
+  ]);
+  const [sort, setSort] = useState<SortState | null>(null);
+  const remainingMap = useMemo(() => {
+    const map = new Map<string, number | null>();
+    list.forEach(client => {
+      map.set(client.id, getEffectiveRemainingLessons(client, schedule));
+    });
+    return map;
+  }, [list, schedule]);
+
+  const columns: ColumnConfig[] = useMemo(() => [
+    {
+      id: "name",
+      label: "Имя",
+      width: "minmax(160px, max-content)",
+      renderCell: client => (
+        <button
+          type="button"
+          onClick={event => {
+            event.stopPropagation();
+            onEdit(client);
+          }}
+          className="text-left text-sky-600 hover:underline focus:outline-none dark:text-sky-400"
+        >
+          {client.firstName} {client.lastName}
+        </button>
+      ),
+      sortValue: client => `${client.firstName} ${client.lastName ?? ""}`.trim().toLowerCase(),
+    },
+    {
+      id: "phone",
+      label: "Телефон",
+      width: "minmax(140px, max-content)",
+      renderCell: client => client.phone ?? "—",
+      sortValue: client => client.phone ?? "",
+    },
+    {
+      id: "area",
+      label: "Район",
+      width: "minmax(120px, max-content)",
+      renderCell: client => client.area,
+      sortValue: client => client.area,
+    },
+    {
+      id: "group",
+      label: "Группа",
+      width: "minmax(120px, max-content)",
+      renderCell: client => client.group,
+      sortValue: client => client.group,
+    },
+    {
+      id: "status",
+      label: "Статус",
+      width: "minmax(140px, max-content)",
+      renderCell: client => client.status ?? "—",
+      sortValue: client => client.status ?? "",
+    },
+    {
+      id: "payStatus",
+      label: "Статус оплаты",
+      width: "minmax(150px, max-content)",
+      renderCell: client => (
+        <span
+          className={`px-2 py-1 text-xs ${
+            client.payStatus === "действует"
+              ? "rounded-full bg-emerald-100 text-emerald-700"
+              : client.payStatus === "задолженность"
+              ? "rounded-full bg-rose-100 text-rose-700"
+              : "rounded-full bg-amber-100 text-amber-700"
+          }`}
+        >
+          {client.payStatus}
+        </span>
+      ),
+      sortValue: client => client.payStatus,
+    },
+    {
+      id: "remainingLessons",
+      label: "Остаток занятий",
+      width: "minmax(150px, max-content)",
+      headerAlign: "center",
+      cellClassName: "text-center",
+      renderCell: client => {
+        const remaining = remainingMap.get(client.id);
+        return remaining != null ? remaining : "—";
+      },
+      sortValue: client => remainingMap.get(client.id) ?? -1,
+    },
+    {
+      id: "payAmount",
+      label: "Сумма оплаты",
+      width: "minmax(130px, max-content)",
+      renderCell: client => (client.payAmount != null ? fmtMoney(client.payAmount, currency) : "—"),
+      sortValue: client => client.payAmount ?? 0,
+    },
+    {
+      id: "payDate",
+      label: "Дата оплаты",
+      width: "minmax(140px, max-content)",
+      renderCell: client => (client.payDate ? fmtDate(client.payDate) : "—"),
+      sortValue: client => client.payDate ?? "",
+    },
+    {
+      id: "actions",
+      label: "Действия",
+      width: "minmax(220px, 1fr)",
+      headerClassName: "text-right",
+      headerAlign: "right",
+      cellClassName: "flex justify-end gap-1",
+      renderCell: client => (
+        <>
+          <button
+            onClick={event => {
+              event.stopPropagation();
+              onCreateTask(client);
+            }}
+            className="px-2 py-1 text-xs rounded-md border border-sky-200 text-sky-600 hover:bg-sky-50 dark:border-sky-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+          >
+            Создать задачу
+          </button>
+          <button
+            onClick={event => {
+              event.stopPropagation();
+              onRemove(client.id);
+            }}
+            className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30"
+          >
+            Удалить
+          </button>
+        </>
+      ),
+    },
+  ], [currency, onCreateTask, onEdit, onRemove, remainingMap]);
+
+  const activeColumns = useMemo(
+    () => columns.filter(column => visibleColumns.includes(column.id)),
+    [columns, visibleColumns],
+  );
+
+  const sortedList = useMemo(() => {
+    if (!sort) return list;
+    const column = columns.find(col => col.id === sort.columnId);
+    if (!column?.sortValue) return list;
+    const copy = [...list];
+    copy.sort((a, b) => {
+      const compare = compareValues(column.sortValue!(a), column.sortValue!(b));
+      return sort.direction === "asc" ? compare : -compare;
+    });
+    return copy;
+  }, [columns, list, sort]);
+
+  const columnTemplate = activeColumns.length ? activeColumns.map(column => column.width).join(" ") : "1fr";
 
   return (
     <>
+      <div className="flex justify-end">
+        <ColumnSettings
+          options={columns.map(column => ({ id: column.id, label: column.label }))}
+          value={visibleColumns}
+          onChange={setVisibleColumns}
+        />
+      </div>
       <VirtualizedTable
         header={(
           <thead className="bg-slate-50 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
             <tr
               className="w-full"
-              style={{ display: "grid", gridTemplateColumns: COLUMN_TEMPLATE, alignItems: "center" }}
+              style={{ display: "grid", gridTemplateColumns: columnTemplate, alignItems: "center" }}
             >
-              <th className="text-left p-2">
-                Имя
-              </th>
-              <th className="text-left p-2">
-                Телефон
-              </th>
-              <th className="text-left p-2">
-                Район
-              </th>
-              <th className="text-left p-2">
-                Группа
-              </th>
-              <th className="text-left p-2">
-                Статус оплаты
-              </th>
-              <th className="text-left p-2">
-                Сумма оплаты
-              </th>
-              <th className="text-center p-2">
-                Факт оплаты
-              </th>
-              <th className="text-left p-2">
-                Дата оплаты
-              </th>
-              <th className="text-right p-2" style={{ justifySelf: "end" }}>
-                Действия
-              </th>
+              {activeColumns.map(column => {
+                const isSorted = sort?.columnId === column.id;
+                const canSort = Boolean(column.sortValue);
+                const indicator = isSorted ? (sort?.direction === "asc" ? "↑" : "↓") : null;
+                const alignment = column.headerAlign ?? "left";
+                const justify = alignment === "right" ? "justify-end" : alignment === "center" ? "justify-center" : "";
+                const content = (
+                  <div className={`flex items-center gap-1 ${justify}`}>
+                    <span>{column.label}</span>
+                    {indicator && <span className="text-xs">{indicator}</span>}
+                  </div>
+                );
+                return (
+                  <th
+                    key={column.id}
+                    className={`p-2 ${column.headerClassName ?? "text-left"}`}
+                    style={{ cursor: canSort ? "pointer" : "default" }}
+                  >
+                    {canSort ? (
+                      <button
+                        type="button"
+                        className="flex w-full items-center justify-between gap-1 focus:outline-none"
+                        onClick={() => setSort(prev => toggleSort(prev, column.id))}
+                      >
+                        {content}
+                      </button>
+                    ) : (
+                      content
+                    )}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
         )}
-        items={list}
+        items={sortedList}
         rowHeight={48}
         renderRow={(c, style) => (
           <tr
@@ -78,79 +254,17 @@ export default function ClientTable({ list, currency, onEdit, onRemove, onToggle
             style={{
               ...style,
               display: "grid",
-              gridTemplateColumns: COLUMN_TEMPLATE,
+              gridTemplateColumns: columnTemplate,
               alignItems: "center",
             }}
             className="border-t border-slate-100 dark:border-slate-700"
+            onClick={() => setSelected(c)}
           >
-            <td className="p-2" onClick={() => setSelected(c)}>
-              <button
-                type="button"
-                onClick={e => {
-                  e.stopPropagation();
-                  onEdit(c);
-                }}
-                className="text-left text-sky-600 hover:underline focus:outline-none dark:text-sky-400"
-              >
-                {c.firstName} {c.lastName}
-              </button>
-            </td>
-            <td className="p-2">
-              {c.phone}
-            </td>
-            <td className="p-2">
-              {c.area}
-            </td>
-            <td className="p-2">
-              {c.group}
-            </td>
-            <td className="p-2">
-              <span
-                className={`px-2 py-1 rounded-full text-xs ${
-                  c.payStatus === "действует"
-                    ? "bg-emerald-100 text-emerald-700"
-                    : c.payStatus === "задолженность"
-                    ? "bg-rose-100 text-rose-700"
-                    : "bg-amber-100 text-amber-700"
-                }`}
-              >
-                {c.payStatus}
-              </span>
-            </td>
-            <td className="p-2">
-              {c.payAmount != null ? fmtMoney(c.payAmount, currency) : "—"}
-            </td>
-            <td className="p-2 text-center">
-              <input
-                type="checkbox"
-                aria-label={`Факт оплаты ${c.firstName}${c.lastName ? ` ${c.lastName}` : ""}`.trim()}
-                checked={Boolean(c.payConfirmed)}
-                onChange={e => onTogglePayFact(c.id, e.target.checked)}
-              />
-            </td>
-            <td className="p-2">
-              {c.payDate ? fmtDate(c.payDate) : "—"}
-            </td>
-            <td className="p-2 flex justify-end gap-1">
-              <button
-                onClick={() => onCreateTask(c)}
-                className="px-2 py-1 text-xs rounded-md border border-sky-200 text-sky-600 hover:bg-sky-50 dark:border-sky-700 dark:bg-slate-800 dark:hover:bg-slate-700"
-              >
-                Создать задачу
-              </button>
-              <button
-                onClick={() => onEdit(c)}
-                className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
-              >
-                Редактировать
-              </button>
-              <button
-                onClick={() => onRemove(c.id)}
-                className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30"
-              >
-                Удалить
-              </button>
-            </td>
+            {activeColumns.map(column => (
+              <td key={column.id} className={`p-2 ${column.cellClassName ?? ""}`}>
+                {column.renderCell(c)}
+              </td>
+            ))}
           </tr>
         )}
       />
@@ -159,6 +273,9 @@ export default function ClientTable({ list, currency, onEdit, onRemove, onToggle
         <ClientDetailsModal
           client={selected}
           currency={currency}
+          schedule={schedule}
+          attendance={attendance}
+          performance={performance}
           onEdit={onEdit}
           onRemove={onRemove}
           onClose={() => setSelected(null)}

--- a/src/components/clients/clientMutations.ts
+++ b/src/components/clients/clientMutations.ts
@@ -1,0 +1,46 @@
+import { getDefaultPayAmount, shouldAllowCustomPayAmount } from "../../state/payments";
+import { parseDateInput } from "../../state/utils";
+import { requiresManualRemainingLessons } from "../../state/lessons";
+import type { Client, ClientFormValues, Group } from "../../types";
+
+export function resolvePayAmount(rawValue: string, group: Group, previous?: number): number | undefined {
+  const defaultAmount = getDefaultPayAmount(group);
+  if (!shouldAllowCustomPayAmount(group) && defaultAmount != null) {
+    return defaultAmount;
+  }
+
+  const parsed = Number.parseFloat(rawValue);
+  if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+    return parsed;
+  }
+
+  if (defaultAmount != null) {
+    return defaultAmount;
+  }
+
+  return previous;
+}
+
+export function transformClientFormValues(
+  data: ClientFormValues,
+  editing?: Client | null,
+): Omit<Client, "id"> {
+  const { payAmount: payAmountRaw, remainingLessons: remainingLessonsRaw, ...rest } = data;
+  const resolvedPayAmount = resolvePayAmount(payAmountRaw, rest.group, editing?.payAmount);
+  let resolvedRemaining: number | undefined;
+  if (requiresManualRemainingLessons(rest.group)) {
+    const parsedRemaining = Number.parseInt(remainingLessonsRaw, 10);
+    if (!Number.isNaN(parsedRemaining)) {
+      resolvedRemaining = parsedRemaining;
+    }
+  }
+
+  return {
+    ...rest,
+    payAmount: resolvedPayAmount,
+    remainingLessons: resolvedRemaining,
+    birthDate: parseDateInput(data.birthDate),
+    startDate: parseDateInput(data.startDate),
+    payDate: parseDateInput(data.payDate),
+  };
+}

--- a/src/components/tableUtils.ts
+++ b/src/components/tableUtils.ts
@@ -1,0 +1,49 @@
+export type SortDirection = "asc" | "desc";
+
+export interface SortState {
+  columnId: string;
+  direction: SortDirection;
+}
+
+export function toggleSort(current: SortState | null, columnId: string): SortState | null {
+  if (!current || current.columnId !== columnId) {
+    return { columnId, direction: "asc" };
+  }
+  if (current.direction === "asc") {
+    return { columnId, direction: "desc" };
+  }
+  return null;
+}
+
+export function compareValues(a: unknown, b: unknown): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return -1;
+  if (b == null) return 1;
+
+  if (typeof a === "number" && typeof b === "number") {
+    return a - b;
+  }
+
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() - b.getTime();
+  }
+
+  const aDate = typeof a === "string" && !Number.isNaN(Date.parse(a)) ? new Date(a) : null;
+  const bDate = typeof b === "string" && !Number.isNaN(Date.parse(b)) ? new Date(b) : null;
+  if (aDate && bDate) {
+    return aDate.getTime() - bDate.getTime();
+  }
+
+  if (typeof a === "boolean" && typeof b === "boolean") {
+    if (a === b) return 0;
+    return a ? 1 : -1;
+  }
+
+  const aNum = Number(a);
+  const bNum = Number(b);
+  if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) {
+    return aNum - bNum;
+  }
+
+  return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: "base" });
+}

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -432,6 +432,7 @@ export function useAppState(): AppState {
       startDate: todayISO(),
       payMethod: "перевод",
       payStatus: "ожидание",
+      status: "новый",
     } as Client;
     const next = { ...db, clients: [c, ...db.clients] };
     if (await commitDBUpdate(next, setDB)) {

--- a/src/state/filterPersistence.ts
+++ b/src/state/filterPersistence.ts
@@ -1,0 +1,66 @@
+import { todayISO } from "./utils";
+import type { Area, Group } from "../types";
+
+const PREFIX = "judo_crm_filters_";
+
+type StoredSelection = {
+  date: string;
+  area: Area | null;
+  group: Group | null;
+};
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return null;
+  }
+  return window.localStorage;
+}
+
+function buildKey(key: string): string {
+  return `${PREFIX}${key}`;
+}
+
+export function readDailySelection(key: string): { area: Area | null; group: Group | null } {
+  const storage = getStorage();
+  if (!storage) {
+    return { area: null, group: null };
+  }
+  const today = todayISO().slice(0, 10);
+  try {
+    const raw = storage.getItem(buildKey(key));
+    if (!raw) {
+      return { area: null, group: null };
+    }
+    const parsed = JSON.parse(raw) as StoredSelection | null;
+    if (!parsed || parsed.date !== today) {
+      storage.removeItem(buildKey(key));
+      return { area: null, group: null };
+    }
+    return { area: parsed.area ?? null, group: parsed.group ?? null };
+  } catch (err) {
+    console.warn("Failed to read persisted selection", err);
+    return { area: null, group: null };
+  }
+}
+
+export function writeDailySelection(key: string, area: Area | null, group: Group | null) {
+  const storage = getStorage();
+  if (!storage) return;
+  const today = todayISO().slice(0, 10);
+  const payload: StoredSelection = { date: today, area, group };
+  try {
+    storage.setItem(buildKey(key), JSON.stringify(payload));
+  } catch (err) {
+    console.warn("Failed to persist selection", err);
+  }
+}
+
+export function clearDailySelection(key: string) {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(buildKey(key));
+  } catch (err) {
+    console.warn("Failed to clear selection", err);
+  }
+}

--- a/src/state/lessons.ts
+++ b/src/state/lessons.ts
@@ -1,0 +1,97 @@
+import type { Area, Client, Group, ScheduleSlot } from "../types";
+import { isAdultGroup, isIndividualGroup } from "./payments";
+
+const MS_IN_DAY = 24 * 60 * 60 * 1000;
+
+export function requiresManualRemainingLessons(group: string): boolean {
+  return isIndividualGroup(group) || isAdultGroup(group);
+}
+
+const isoWeekday = (date: Date): number => {
+  const day = date.getDay();
+  return day === 0 ? 7 : day;
+};
+
+export function estimateGroupRemainingLessons(
+  client: Pick<Client, "area" | "group" | "payDate">,
+  schedule: ScheduleSlot[],
+  today: Date = new Date(),
+): number | null {
+  return estimateGroupRemainingLessonsByParams(client.area, client.group, client.payDate, schedule, today);
+}
+
+export function estimateGroupRemainingLessonsByParams(
+  area: Area,
+  group: Group,
+  payDate: string | undefined,
+  schedule: ScheduleSlot[],
+  today: Date = new Date(),
+): number | null {
+  if (!payDate) return null;
+
+  const until = new Date(payDate);
+  if (Number.isNaN(until.getTime())) return null;
+
+  const from = new Date(today);
+  from.setHours(0, 0, 0, 0);
+  until.setHours(23, 59, 59, 999);
+
+  if (until < from) {
+    return 0;
+  }
+
+  const relevant = schedule.filter(slot => slot.area === area && slot.group === group);
+  if (!relevant.length) return null;
+
+  const sessionsPerWeekday = new Map<number, number>();
+  for (const slot of relevant) {
+    sessionsPerWeekday.set(slot.weekday, (sessionsPerWeekday.get(slot.weekday) ?? 0) + 1);
+  }
+
+  let total = 0;
+  for (let cursor = new Date(from); cursor <= until; cursor = new Date(cursor.getTime() + MS_IN_DAY)) {
+    const weekday = isoWeekday(cursor);
+    const sessions = sessionsPerWeekday.get(weekday);
+    if (sessions) {
+      total += sessions;
+    }
+  }
+
+  return total;
+}
+
+export function getEffectiveRemainingLessons(
+  client: Client,
+  schedule: ScheduleSlot[],
+  today: Date = new Date(),
+): number | null {
+  if (requiresManualRemainingLessons(client.group)) {
+    if (typeof client.remainingLessons === "number") {
+      return client.remainingLessons < 0 ? 0 : client.remainingLessons;
+    }
+    return null;
+  }
+
+  return estimateGroupRemainingLessons(client, schedule, today);
+}
+
+export function buildGroupsByArea(schedule: ScheduleSlot[]): Map<Area, Group[]> {
+  const map = new Map<Area, Group[]>();
+
+  for (const slot of schedule) {
+    const groups = map.get(slot.area);
+    if (groups) {
+      if (!groups.includes(slot.group)) {
+        groups.push(slot.group);
+      }
+    } else {
+      map.set(slot.area, [slot.group]);
+    }
+  }
+
+  for (const [, groups] of map) {
+    groups.sort();
+  }
+
+  return map;
+}

--- a/src/state/payments.ts
+++ b/src/state/payments.ts
@@ -1,0 +1,59 @@
+import type { Client, PaymentStatus, TaskItem } from "../types";
+
+const INDIVIDUAL_GROUP_NAMES = ["индивидуальное", "индивидуальные", "индивидуальная", "индивидуал"];
+const ADULT_GROUP_NAMES = ["взрослое", "взрослые", "взрослая"];
+
+const normalize = (value: string | undefined | null) => value?.trim().toLowerCase() ?? "";
+
+export function isIndividualGroup(group: string): boolean {
+  const normalized = normalize(group);
+  return INDIVIDUAL_GROUP_NAMES.some(name => normalized === name);
+}
+
+export function isAdultGroup(group: string): boolean {
+  const normalized = normalize(group);
+  return ADULT_GROUP_NAMES.some(name => normalized === name);
+}
+
+export function shouldAllowCustomPayAmount(group: string): boolean {
+  return isIndividualGroup(group) || isAdultGroup(group);
+}
+
+export function getDefaultPayAmount(group: string): number | null {
+  if (isIndividualGroup(group)) {
+    return 125;
+  }
+  if (isAdultGroup(group)) {
+    return null;
+  }
+  return 55;
+}
+
+export function derivePaymentStatus(client: Client, tasks: TaskItem[]): PaymentStatus {
+  const relatedTasks = tasks.filter(
+    task =>
+      task.topic === "оплата" &&
+      task.assigneeType === "client" &&
+      task.assigneeId === client.id,
+  );
+
+  if (!relatedTasks.length) {
+    return "ожидание";
+  }
+
+  if (relatedTasks.some(task => task.status !== "done")) {
+    return "задолженность";
+  }
+
+  return "действует";
+}
+
+export function applyPaymentStatusRules(clients: Client[], tasks: TaskItem[]): Client[] {
+  return clients.map(client => {
+    const nextStatus = derivePaymentStatus(client, tasks);
+    if (client.payStatus === nextStatus) {
+      return client;
+    }
+    return { ...client, payStatus: nextStatus };
+  });
+}

--- a/src/state/seed.ts
+++ b/src/state/seed.ts
@@ -13,6 +13,7 @@ import type {
   AttendanceEntry,
   PerformanceEntry,
 } from "../types";
+import { requiresManualRemainingLessons } from "./lessons";
 
 export function makeSeedDB(): DB {
   const areas: Area[] = ["Махмутлар", "Центр", "Джикджилли"];
@@ -97,6 +98,7 @@ export function makeSeedDB(): DB {
     const gender: Gender = Math.random() < 0.5 ? "м" : "ж";
     const area = areas[rnd(0, areas.length - 1)];
     const group = groups[rnd(0, groups.length - 1)];
+    const manual = requiresManualRemainingLessons(group);
     const start = new Date();
     start.setMonth(start.getMonth() - rnd(0, 6));
     return {
@@ -113,9 +115,10 @@ export function makeSeedDB(): DB {
       startDate: start.toISOString(),
       payMethod: "перевод",
       payStatus: "действует",
+      status: "действующий",
       payDate: start.toISOString(),
       payAmount: rnd(50, 100),
-      payConfirmed: Math.random() < 0.7,
+      remainingLessons: manual ? rnd(4, 12) : undefined,
     } as Client;
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export type PaymentMethod = "наличные" | "перевод";
 
 export type PaymentStatus = "ожидание" | "действует" | "задолженность";
 
+export type ClientStatus = "действующий" | "отмена" | "новый" | "вернувшийся" | "продлившийся";
+
 export type LeadStage = "Очередь" | "Задержка" | "Пробное" | "Ожидание оплаты" | "Оплаченный абонемент" | "Отмена";
 
 export type Currency = "EUR" | "TRY" | "RUB";
@@ -31,9 +33,10 @@ export interface Client {
   startDate: string; // ISO
   payMethod: PaymentMethod;
   payStatus: PaymentStatus;
+  status: ClientStatus;
   payDate?: string; // ISO
   payAmount?: number;
-  payConfirmed?: boolean;
+  remainingLessons?: number;
   // Автополя (рассчитываются на лету)
 }
 
@@ -50,7 +53,10 @@ export interface ClientFormValues {
   startDate: string;
   payMethod: PaymentMethod;
   payStatus: PaymentStatus;
+  status: ClientStatus;
   payDate: string;
+  payAmount: string;
+  remainingLessons: string;
 }
 
 export interface AttendanceEntry {


### PR DESCRIPTION
## Summary
- persist the selected area and group for the clients tab per-day via local storage and reuse the common form transformation helpers
- upgrade the shared client details modal with editable actions plus attendance and performance history tabs and feed it attendance/performance data
- require explicit area/group choices for attendance and performance views, align their column sizing and editing flow with the clients table, and surface the same modal and client form there

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cc6c797404832bbfef3fc3089bddaf