### PR TITLE
Normalize todayISO to local date

### DIFF
--- a/src/state/__tests__/utils.test.ts
+++ b/src/state/__tests__/utils.test.ts
@@ -1,0 +1,37 @@
+const originalTZ = process.env.TZ;
+process.env.TZ = "Europe/Moscow";
+
+import { todayISO } from "../utils";
+
+describe("todayISO", () => {
+  const RealDate = Date;
+
+  afterAll(() => {
+    process.env.TZ = originalTZ;
+    global.Date = RealDate as DateConstructor;
+  });
+
+  afterEach(() => {
+    global.Date = RealDate as DateConstructor;
+  });
+
+  it("returns ISO string matching the local day even near midnight", () => {
+    const fixed = new RealDate("2024-03-01T00:05:00");
+    const MockDate = class extends RealDate {
+      constructor(value?: number | string | Date) {
+        if (value === undefined) {
+          return new RealDate(fixed.getTime()) as unknown as Date;
+        }
+        return super(value as string | number | Date);
+      }
+
+      static now() {
+        return fixed.getTime();
+      }
+    };
+
+    global.Date = MockDate as unknown as DateConstructor;
+
+    expect(todayISO().slice(0, 10)).toBe("2024-03-01");
+  });
+});

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -6,7 +6,11 @@ export const rnd = (min: number, max: number) =>
 export const uid = () =>
   Math.random().toString(36).slice(2, 10) + Date.now().toString(36).slice(-4);
 
-export const todayISO = () => new Date().toISOString();
+export const todayISO = () => {
+  const now = new Date();
+  const normalized = new Date(now.getTime() - now.getTimezoneOffset() * 60 * 1000);
+  return normalized.toISOString();
+};
 
 export const fmtDate = (iso: string) =>
   new Intl.DateTimeFormat("ru-RU").format(new Date(iso));


### PR DESCRIPTION
## Summary
- adjust todayISO to return ISO strings aligned with the user's local day by compensating for the timezone offset
- add a regression test that freezes Date to a post-midnight scenario in a custom timezone to ensure the local date is preserved

## Testing
- CI=1 npm test -- --runTestsByPath src/state/__tests__/utils.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d1889ae7e0832ba9653748199ea118