### PR TITLE
Import payment helpers in ClientsTab

### DIFF
--- a/src/components/ClientsTab.tsx
+++ b/src/components/ClientsTab.tsx
@@ -6,7 +6,11 @@ import ClientTable from "./clients/ClientTable";
 import ClientForm from "./clients/ClientForm";
 import { uid, todayISO, fmtMoney } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
-import { applyPaymentStatusRules } from "../state/payments";
+import {
+  applyPaymentStatusRules,
+  getDefaultPayAmount,
+  shouldAllowCustomPayAmount,
+} from "../state/payments";
 import { buildGroupsByArea } from "../state/lessons";
 import { readDailySelection, writeDailySelection, clearDailySelection } from "../state/filterPersistence";
 import { transformClientFormValues } from "./clients/clientMutations";


### PR DESCRIPTION
## Summary
- add the missing payment helper imports in ClientsTab to resolve TypeScript build errors

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d188b54770832b9c372861f8065500