### PR TITLE
feat: extend analytics expenses and athlete stats

### DIFF
--- a/src/components/__tests__/ClientsTab.test.tsx
+++ b/src/components/__tests__/ClientsTab.test.tsx
@@ -74,6 +74,7 @@ const makeDB = () => ({
     groups: ['Group1', 'Group2'],
     limits: {},
     rentByAreaEUR: {},
+    coachSalaryByAreaEUR: {},
     currencyRates: { EUR: 1, TRY: 1, RUB: 1 },
     coachPayFormula: '',
   },

--- a/src/components/__tests__/LeadsTab.test.tsx
+++ b/src/components/__tests__/LeadsTab.test.tsx
@@ -84,6 +84,7 @@ const makeDB = () => ({
     groups: ['Group1'],
     limits: {},
     rentByAreaEUR: {},
+    coachSalaryByAreaEUR: {},
     currencyRates: { EUR: 1, TRY: 1, RUB: 1 },
     coachPayFormula: '',
   },

--- a/src/components/__tests__/ScheduleTab.groups.test.tsx
+++ b/src/components/__tests__/ScheduleTab.groups.test.tsx
@@ -53,6 +53,7 @@ function makeDb() {
       groups: [],
       limits: {},
       rentByAreaEUR: {},
+      coachSalaryByAreaEUR: {},
       currencyRates: { EUR: 1, TRY: 1, RUB: 1 },
       coachPayFormula: "",
     },

--- a/src/components/__tests__/ScheduleTab.test.tsx
+++ b/src/components/__tests__/ScheduleTab.test.tsx
@@ -52,6 +52,7 @@ function makeDb() {
       groups: ['G1'],
       limits: {},
       rentByAreaEUR: {},
+      coachSalaryByAreaEUR: {},
       currencyRates: { EUR: 1, TRY: 1, RUB: 1 },
       coachPayFormula: '',
     },

--- a/src/components/__tests__/SettingsTab.test.tsx
+++ b/src/components/__tests__/SettingsTab.test.tsx
@@ -23,6 +23,7 @@ const createDB = (): DB => ({
     groups: [],
     limits: {},
     rentByAreaEUR: {},
+    coachSalaryByAreaEUR: {},
     currencyRates: { EUR: 1, TRY: 35, RUB: 100 },
     coachPayFormula: "",
     analyticsFavorites: [],

--- a/src/state/analytics.ts
+++ b/src/state/analytics.ts
@@ -42,11 +42,23 @@ export type MetricSnapshot = {
   values: Record<ProjectionKey, number>;
 };
 
+export type AthleteStats = {
+  total: number;
+  new: number;
+  firstRenewals: number;
+  canceled: number;
+  returned: number;
+  dropIns: number;
+  attendanceRate: number;
+};
+
 export type AnalyticsSnapshot = {
   area: AreaScope;
   metrics: Record<MetricKey, MetricSnapshot>;
   capacity: number;
   rent: number;
+  coachSalary: number;
+  athleteStats: AthleteStats;
 };
 
 export function encodeFavorite(favorite: AnalyticsFavorite): string {
@@ -140,6 +152,10 @@ function rentForAreas(db: DB, areas: Area[]): number {
   return areas.reduce((sum, area) => sum + ensureNumber(db.settings.rentByAreaEUR?.[area] ?? 0), 0);
 }
 
+function coachSalaryForAreas(db: DB, areas: Area[]): number {
+  return areas.reduce((sum, area) => sum + ensureNumber(db.settings.coachSalaryByAreaEUR?.[area] ?? 0), 0);
+}
+
 export function getAnalyticsAreas(db: DB): AreaScope[] {
   const active = collectActiveAreas(db);
   const unique = new Set<Area>();
@@ -160,14 +176,17 @@ export function computeAnalyticsSnapshot(db: DB, area: AreaScope): AnalyticsSnap
 
   const capacity = relevantAreas.reduce((sum, item) => sum + capacityForArea(db, item), 0);
   const rent = rentForAreas(db, relevantAreas);
+  const coachSalary = coachSalaryForAreas(db, relevantAreas);
 
   const actualRevenue = actualClients.reduce((sum, client) => sum + getClientAmount(client), 0);
   const forecastRevenue = clients.reduce((sum, client) => sum + getClientAmount(client), 0);
   const maxRevenue = relevantAreas.reduce((sum, item) => sum + maxRevenueForArea(db, item), 0);
 
-  const actualProfit = actualRevenue - rent;
-  const forecastProfit = forecastRevenue - rent;
-  const maxProfit = maxRevenue - rent;
+  const totalExpenses = rent + coachSalary;
+
+  const actualProfit = actualRevenue - totalExpenses;
+  const forecastProfit = forecastRevenue - totalExpenses;
+  const maxProfit = maxRevenue - totalExpenses;
 
   const actualFill = capacity ? (actualClients.length / capacity) * 100 : 0;
   const forecastFill = capacity ? (clients.length / capacity) * 100 : 0;
@@ -211,7 +230,23 @@ export function computeAnalyticsSnapshot(db: DB, area: AreaScope): AnalyticsSnap
     },
   };
 
-  return { area, metrics, capacity, rent };
+  const clientIds = new Set(clients.map(client => client.id));
+  const attendanceEntries = db.attendance.filter(entry => clientIds.has(entry.clientId));
+  const attendanceTotal = attendanceEntries.length;
+  const attendanceCame = attendanceEntries.filter(entry => entry.came).length;
+  const attendanceRate = attendanceTotal ? (attendanceCame / attendanceTotal) * 100 : 0;
+
+  const athleteStats: AthleteStats = {
+    total: actualClients.length,
+    new: clients.filter(client => client.status === "новый").length,
+    firstRenewals: clients.filter(client => client.status === "продлившийся").length,
+    canceled: clients.filter(client => client.status === "отмена").length,
+    returned: clients.filter(client => client.status === "вернувшийся").length,
+    dropIns: clients.filter(client => (client.remainingLessons ?? 0) > 0).length,
+    attendanceRate: ensureNumber(attendanceRate),
+  };
+
+  return { area, metrics, capacity, rent, coachSalary, athleteStats };
 }
 
 export type FavoriteSummary = {

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -41,6 +41,7 @@ const DEFAULT_SETTINGS: Settings = {
     ),
   ) as Settings["limits"],
   rentByAreaEUR: { Махмутлар: 300, Центр: 400, Джикджилли: 250 },
+  coachSalaryByAreaEUR: { Махмутлар: 0, Центр: 0, Джикджилли: 0 },
   currencyRates: { EUR: 1, TRY: 36, RUB: 100 },
   coachPayFormula: "фикс 100€ + 5€ за ученика",
   analyticsFavorites: [],
@@ -73,6 +74,10 @@ function normalizeSettings(value: unknown): Settings {
       raw.rentByAreaEUR && typeof raw.rentByAreaEUR === "object"
         ? (raw.rentByAreaEUR as Settings["rentByAreaEUR"])
         : DEFAULT_SETTINGS.rentByAreaEUR,
+    coachSalaryByAreaEUR:
+      raw.coachSalaryByAreaEUR && typeof raw.coachSalaryByAreaEUR === "object"
+        ? (raw.coachSalaryByAreaEUR as Settings["coachSalaryByAreaEUR"])
+        : DEFAULT_SETTINGS.coachSalaryByAreaEUR,
     currencyRates: raw.currencyRates
       ? { ...DEFAULT_SETTINGS.currencyRates, ...raw.currencyRates }
       : DEFAULT_SETTINGS.currencyRates,

--- a/src/state/seed.ts
+++ b/src/state/seed.ts
@@ -175,6 +175,7 @@ export function makeSeedDB(): DB {
     groups,
     limits: Object.fromEntries(areas.flatMap(a => groups.map(g => [`${a}|${g}`, 20]))),
     rentByAreaEUR: { Махмутлар: 300, Центр: 400, Джикджилли: 250 },
+    coachSalaryByAreaEUR: { Махмутлар: 0, Центр: 0, Джикджилли: 0 },
     currencyRates: { EUR: 1, TRY: 36, RUB: 100 },
     coachPayFormula: "фикс 100€ + 5€ за ученика",
     analyticsFavorites: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,7 @@ export interface Settings {
   groups: Group[];
   limits: Record<string, number>; // key: `${area}|${group}` => лимит мест
   rentByAreaEUR: Partial<Record<Area, number>>; // аренда в евро для простоты
+  coachSalaryByAreaEUR: Partial<Record<Area, number>>; // выплаты тренерам в евро
   currencyRates: { EUR: number; TRY: number; RUB: number }; // к базовой валюте EUR (1.0)
   coachPayFormula: string; // просто строка, которая описывает формулу (демо)
   analyticsFavorites: string[];


### PR DESCRIPTION
## Summary
- allow per-area rent and coach salary adjustments directly in analytics and display totals alongside capacity
- include coach salary expenses in profit calculations and expose athlete statistics (new, canceled, returned, etc.) for each area
- extend default settings and tests with coach salary values to persist the new data

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d190347f14832b9c0e1ed62826f3bf