### PR TITLE
Set new client defaults when converting leads

### DIFF
--- a/src/components/LeadsTab.tsx
+++ b/src/components/LeadsTab.tsx
@@ -131,8 +131,8 @@ function convertLeadToClient(lead: Lead, db: DB): Client {
     coachId: coach?.id,
     startDate: lead.startDate ?? fallbackDate,
     payMethod: "перевод",
-    payStatus: "действует",
-    status: "действующий",
+    payStatus: "ожидание",
+    status: "новый",
     payDate: fallbackDate,
   };
 

--- a/src/components/__tests__/LeadsTab.test.tsx
+++ b/src/components/__tests__/LeadsTab.test.tsx
@@ -203,5 +203,6 @@ test('move: converts paid lead into client', async () => {
   const created = getDB().clients[0];
   expect(created.firstName).toBe('Иван');
   expect(created.group).toBe('Group1');
-  expect(created.payStatus).toBe('действует');
+  expect(created.status).toBe('новый');
+  expect(created.payStatus).toBe('ожидание');
 });


### PR DESCRIPTION
## Summary
- ensure converted clients are created with the "новый" status and pending payment
- adjust lead conversion test to expect the updated client defaults

## Testing
- CI=1 npm test -- LeadsTab

------
https://chatgpt.com/codex/tasks/task_e_68d268c64860832bbe2f4ca2f2e63a6a