### PR TITLE
Fix client listing in performance tab

### DIFF
--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -76,10 +76,8 @@ export default function PerformanceTab({
     if (!area || !group) {
       return [];
     }
-    return db.clients.filter(
-      client => client.area === area && client.group === group && isClientInPeriod(client, period),
-    );
-  }, [area, group, db.clients, period]);
+    return db.clients.filter(client => client.area === area && client.group === group);
+  }, [area, group, db.clients]);
 
   type ColumnConfig = {
     id: string;


### PR DESCRIPTION
## Summary
- ensure the performance tab shows all clients for the selected area and group, matching the behaviour of groups and attendance

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d543cf642c832ba437e5a85bed0912