### PR TITLE
Align lead workflow and UI updates

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -79,8 +79,6 @@ export default function Dashboard({ db, ui }: DashboardProps) {
     "Задержка",
     "Пробное",
     "Ожидание оплаты",
-    "Оплаченный абонемент",
-    "Отмена",
   ];
   const leads = useMemo(() => filterLeadsByPeriod(db.leads, period), [db.leads, period]);
   const leadsDistribution = useMemo(

--- a/src/components/__tests__/LeadsTab.test.tsx
+++ b/src/components/__tests__/LeadsTab.test.tsx
@@ -77,6 +77,7 @@ const makeDB = () => ({
       updatedAt: '2024-01-01T00:00:00.000Z',
     },
   ],
+  leadsArchive: [],
   tasks: [],
   tasksArchive: [],
   staff: [],
@@ -161,7 +162,7 @@ test('update: saves changes from modal', async () => {
   const { getDB } = renderLeads();
   await userEvent.click(screen.getByRole('button', { name: 'Лид1' }));
   await userEvent.click(screen.getByText('Редактировать'));
-  const nameInput = screen.getByPlaceholderText('Имя');
+  const nameInput = await screen.findByPlaceholderText('Имя');
   fireEvent.change(nameInput, { target: { value: 'Лид1 обнов' } });
   fireEvent.submit(nameInput.closest('form'));
   await waitFor(() => expect(getDB().leads.find(l => l.id === 'l1').name).toBe('Лид1 обнов'));
@@ -187,7 +188,7 @@ test('move: changes stage with arrows', async () => {
   expect(getDB().leads.find(l => l.id === 'l1').stage).toBe('Задержка');
 });
 
-test('move: converts paid lead into client', async () => {
+test('convert: transforms lead into client via action', async () => {
   const base = makeDB();
   const db = {
     ...base,
@@ -199,9 +200,8 @@ test('move: converts paid lead into client', async () => {
     ],
   };
   const { getDB } = renderLeads(db);
-  const waiting = screen.getByText('Ожидание оплаты').parentElement;
-  const leadItem = within(waiting).getByRole('button', { name: 'Лид1' }).closest('div');
-  await userEvent.click(within(leadItem).getByText('▶'));
+  await userEvent.click(screen.getByRole('button', { name: 'Лид1' }));
+  await userEvent.click(screen.getByText('Оплаченный лид'));
   await waitFor(() => expect(getDB().leads).toHaveLength(0));
   expect(getDB().clients).toHaveLength(1);
   const created = getDB().clients[0];
@@ -209,4 +209,13 @@ test('move: converts paid lead into client', async () => {
   expect(created.group).toBe('Group1');
   expect(created.status).toBe('новый');
   expect(created.payStatus).toBe('ожидание');
+});
+
+test('archive: moves lead to archive list', async () => {
+  const { getDB } = renderLeads();
+  await userEvent.click(screen.getByRole('button', { name: 'Лид1' }));
+  await userEvent.click(screen.getByText('Отмена'));
+  await waitFor(() => expect(getDB().leads.find(l => l.id === 'l1')).toBeUndefined());
+  expect(getDB().leadsArchive).toHaveLength(1);
+  expect(getDB().leadsArchive[0].id).toBe('l1');
 });

--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -61,7 +61,7 @@ export default function ClientTable({ list, currency, onEdit, onRemove, onCreate
       label: "Имя",
       width: "minmax(160px, max-content)",
       renderCell: client => (
-        <span className="font-medium text-slate-800 dark:text-slate-100">
+        <span className="font-medium text-slate-800 transition-colors duration-150 group-hover:text-sky-600 dark:text-slate-100 dark:group-hover:text-sky-300">
           {client.firstName} {client.lastName}
         </span>
       ),
@@ -274,7 +274,7 @@ export default function ClientTable({ list, currency, onEdit, onRemove, onCreate
               gridTemplateColumns: columnTemplate,
               alignItems: "center",
             }}
-            className="border-t border-slate-100 dark:border-slate-700"
+            className="group cursor-pointer border-t border-slate-100 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
             onClick={() => setSelected(c)}
           >
             {activeColumns.map(column => (

--- a/src/state/__tests__/analytics.period.test.ts
+++ b/src/state/__tests__/analytics.period.test.ts
@@ -51,6 +51,7 @@ describe("computeAnalyticsSnapshot with period", () => {
       { id: "s1", area: "Area1", group: "Group1", coachId: "coach-1", weekday: 1, time: "10:00", location: "" },
     ],
     leads: [],
+    leadsArchive: [],
     tasks: [],
     tasksArchive: [],
     staff: [],

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -102,6 +102,7 @@ function normalizeDB(value: unknown): DB | null {
     performance: ensureObjectArray<PerformanceEntry>(raw.performance),
     schedule: ensureObjectArray<ScheduleSlot>(raw.schedule),
     leads: ensureObjectArray<Lead>(raw.leads),
+    leadsArchive: ensureObjectArray<Lead>(raw.leadsArchive),
     tasks: ensureObjectArray<TaskItem>(raw.tasks),
     tasksArchive: ensureObjectArray<TaskItem>(raw.tasksArchive),
     staff: ensureObjectArray<StaffMember>(raw.staff),

--- a/src/state/seed.ts
+++ b/src/state/seed.ts
@@ -187,6 +187,7 @@ export function makeSeedDB(): DB {
     performance,
     schedule,
     leads,
+    leadsArchive: [],
     tasks,
     tasksArchive: [],
     staff,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export type PaymentStatus = "ожидание" | "действует" | "зад�
 
 export type ClientStatus = "действующий" | "отмена" | "новый" | "вернувшийся" | "продлившийся";
 
-export type LeadStage = "Очередь" | "Задержка" | "Пробное" | "Ожидание оплаты" | "Оплаченный абонемент" | "Отмена";
+export type LeadStage = "Очередь" | "Задержка" | "Пробное" | "Ожидание оплаты";
 
 export type Currency = "EUR" | "TRY" | "RUB";
 
@@ -168,6 +168,7 @@ export interface DB {
   performance: PerformanceEntry[];
   schedule: ScheduleSlot[];
   leads: Lead[];
+  leadsArchive: Lead[];
   tasks: TaskItem[];
   tasksArchive: TaskItem[];
   staff: StaffMember[];


### PR DESCRIPTION
## Summary
- align the lead detail modal and editing flow with the client form, adding explicit actions for converting and archiving leads
- introduce persistent lead archiving support and remove the obsolete pipeline stages across dashboard, seed data, and types
- add hover affordances to client names and expand unit tests to cover the new lead actions

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d8f574ad90832b84462707b84cc615