### PR TITLE
Add authentication flow with login and registration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import Topbar from "./components/Topbar";
 import Tabs from "./components/Tabs";
@@ -16,6 +16,7 @@ import AppealsTab from "./components/AppealsTab";
 import QuickAddModal from "./components/QuickAddModal";
 import Toasts from "./components/Toasts";
 import ErrorBoundary from "./components/ErrorBoundary";
+import AuthPage from "./components/AuthPage";
 import { useAppState, can, LOCAL_ONLY_MESSAGE } from "./state/appState";
 
 export default function App() {
@@ -28,6 +29,10 @@ export default function App() {
     ui,
     setUI,
     roles,
+    currentUser,
+    loginUser,
+    registerUser,
+    logoutUser,
     toasts,
     isLocalOnly,
     quickOpen,
@@ -40,15 +45,42 @@ export default function App() {
 
   const [hideLocalOnly, setHideLocalOnly] = useState(false);
 
+  const toggleTheme = useCallback(() => {
+    setUI(prev => ({ ...prev, theme: prev.theme === "light" ? "dark" : "light" }));
+  }, [setUI]);
+
   useEffect(() => {
     if (!isLocalOnly) {
       setHideLocalOnly(false);
     }
   }, [isLocalOnly]);
 
+  if (!currentUser) {
+    return (
+      <>
+        <Routes>
+          <Route
+            path="/auth"
+            element={
+              <AuthPage
+                roles={roles}
+                onLogin={loginUser}
+                onRegister={registerUser}
+                theme={ui.theme}
+                onToggleTheme={toggleTheme}
+              />
+            }
+          />
+          <Route path="*" element={<Navigate to="/auth" replace />} />
+        </Routes>
+        <Toasts toasts={toasts} />
+      </>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-slate-100/60 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_55%)] pb-16 text-slate-900 transition-colors duration-300 dark:bg-slate-950 dark:bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.22),_transparent_60%)] dark:text-slate-100">
-      <Topbar ui={ui} setUI={setUI} roleList={roles} onQuickAdd={onQuickAdd} />
+      <Topbar ui={ui} setUI={setUI} onQuickAdd={onQuickAdd} currentUser={currentUser} onLogout={logoutUser} />
       {isLocalOnly && !hideLocalOnly ? (
         <div className="bg-amber-100 border-y border-amber-200 text-amber-900 dark:bg-amber-900/70 dark:border-amber-800 dark:text-amber-100">
           <div className="max-w-7xl mx-auto flex items-start gap-3 px-3 py-2 text-sm font-medium" role="alert">

--- a/src/components/AuthPage.tsx
+++ b/src/components/AuthPage.tsx
@@ -1,0 +1,265 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import type { Role } from "../types";
+
+type AuthResult = { ok: true } | { ok: false; error: string };
+
+type RegisterPayload = { name: string; login: string; password: string; role: Role };
+
+type AuthPageProps = {
+  roles: Role[];
+  onLogin: (login: string, password: string) => Promise<AuthResult>;
+  onRegister: (payload: RegisterPayload) => Promise<AuthResult>;
+  theme: "light" | "dark";
+  onToggleTheme: () => void;
+};
+
+const CONTROL_CLASS =
+  "w-full rounded-xl border border-slate-200/70 bg-white/80 px-4 py-3 text-sm text-slate-800 shadow-sm transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-200/60 dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-100 dark:focus:border-sky-500/60 dark:focus:ring-sky-500/30";
+
+export default function AuthPage({ roles, onLogin, onRegister, theme, onToggleTheme }: AuthPageProps) {
+  const navigate = useNavigate();
+  const [mode, setMode] = useState<"login" | "register">("login");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loginForm, setLoginForm] = useState({ login: "", password: "" });
+  const defaultRole = roles.includes("Менеджер") ? "Менеджер" : roles[0];
+  const [registerForm, setRegisterForm] = useState({
+    name: "",
+    login: "",
+    password: "",
+    confirm: "",
+    role: defaultRole,
+  });
+
+  const handleLogin = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const result = await onLogin(loginForm.login, loginForm.password);
+      if (result.ok) {
+        navigate("/dashboard", { replace: true });
+      } else {
+        setError(result.error);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRegister = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    if (registerForm.password.trim() !== registerForm.confirm.trim()) {
+      setError("Пароли не совпадают");
+      return;
+    }
+    setLoading(true);
+    try {
+      const payload: RegisterPayload = {
+        name: registerForm.name,
+        login: registerForm.login,
+        password: registerForm.password,
+        role: registerForm.role,
+      };
+      const result = await onRegister(payload);
+      if (result.ok) {
+        navigate("/dashboard", { replace: true });
+      } else {
+        setError(result.error);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleMode = (nextMode: "login" | "register") => {
+    setMode(nextMode);
+    setError(null);
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-100/70 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_55%)] px-4 py-12 transition-colors dark:bg-slate-950 dark:bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.22),_transparent_60%)]">
+      <div className="mb-8 flex w-full max-w-md items-center justify-between text-slate-600 dark:text-slate-300">
+        <div>
+          <div className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Judo CRM</div>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Войдите, чтобы продолжить работу</p>
+        </div>
+        <button
+          type="button"
+          onClick={onToggleTheme}
+          className="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 shadow-sm transition hover:border-sky-400 hover:text-slate-900 dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-sky-500/60 dark:hover:text-white"
+        >
+          {theme === "light" ? "Ночь" : "День"}
+        </button>
+      </div>
+
+      <div className="w-full max-w-md rounded-3xl border border-slate-200/70 bg-white/80 p-8 shadow-xl shadow-sky-500/10 transition dark:border-slate-800/60 dark:bg-slate-950/80">
+        <div className="mb-6 flex rounded-2xl bg-slate-100/80 p-1 text-sm font-semibold text-slate-500 dark:bg-slate-900/60 dark:text-slate-400">
+          <button
+            type="button"
+            onClick={() => toggleMode("login")}
+            className={`flex-1 rounded-2xl px-4 py-2 transition ${
+              mode === "login"
+                ? "bg-white text-slate-900 shadow-sm dark:bg-slate-800 dark:text-slate-100"
+                : "hover:text-slate-700 dark:hover:text-slate-200"
+            }`}
+          >
+            Вход
+          </button>
+          <button
+            type="button"
+            onClick={() => toggleMode("register")}
+            className={`flex-1 rounded-2xl px-4 py-2 transition ${
+              mode === "register"
+                ? "bg-white text-slate-900 shadow-sm dark:bg-slate-800 dark:text-slate-100"
+                : "hover:text-slate-700 dark:hover:text-slate-200"
+            }`}
+          >
+            Регистрация
+          </button>
+        </div>
+
+        {error ? (
+          <div className="mb-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
+            {error}
+          </div>
+        ) : null}
+
+        {mode === "login" ? (
+          <form className="space-y-4" onSubmit={handleLogin}>
+            <div>
+              <label className="mb-1 block text-sm font-semibold text-slate-600 dark:text-slate-300" htmlFor="login">
+                Логин
+              </label>
+              <input
+                id="login"
+                type="text"
+                autoComplete="username"
+                className={CONTROL_CLASS}
+                value={loginForm.login}
+                onChange={event => setLoginForm(prev => ({ ...prev, login: event.target.value }))}
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-semibold text-slate-600 dark:text-slate-300" htmlFor="password">
+                Пароль
+              </label>
+              <input
+                id="password"
+                type="password"
+                autoComplete="current-password"
+                className={CONTROL_CLASS}
+                value={loginForm.password}
+                onChange={event => setLoginForm(prev => ({ ...prev, password: event.target.value }))}
+              />
+            </div>
+            <button
+              type="submit"
+              className="w-full rounded-xl bg-gradient-to-r from-sky-500 via-blue-500 to-indigo-500 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-500/30 transition hover:-translate-y-[1px] hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-sky-300/60 disabled:cursor-not-allowed disabled:opacity-60 dark:focus:ring-sky-500/40"
+              disabled={loading}
+            >
+              {loading ? "Вход..." : "Войти"}
+            </button>
+            <div className="rounded-xl border border-slate-200/60 bg-slate-50/80 px-4 py-3 text-xs text-slate-500 dark:border-slate-800/60 dark:bg-slate-900/70 dark:text-slate-400">
+              <p className="font-semibold text-slate-600 dark:text-slate-200">Доступы администратора:</p>
+              <ul className="mt-2 space-y-1">
+                <li>
+                  <span className="font-medium text-slate-700 dark:text-slate-300">admin1</span> / admin1
+                </li>
+                <li>
+                  <span className="font-medium text-slate-700 dark:text-slate-300">admin2</span> / admin2
+                </li>
+                <li>
+                  <span className="font-medium text-slate-700 dark:text-slate-300">admin3</span> / admin3
+                </li>
+              </ul>
+            </div>
+          </form>
+        ) : (
+          <form className="space-y-4" onSubmit={handleRegister}>
+            <div>
+              <label className="mb-1 block text-sm font-semibold text-slate-600 dark:text-slate-300" htmlFor="register-name">
+                Имя пользователя
+              </label>
+              <input
+                id="register-name"
+                type="text"
+                autoComplete="name"
+                className={CONTROL_CLASS}
+                value={registerForm.name}
+                onChange={event => setRegisterForm(prev => ({ ...prev, name: event.target.value }))}
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-semibold text-slate-600 dark:text-slate-300" htmlFor="register-login">
+                Логин
+              </label>
+              <input
+                id="register-login"
+                type="text"
+                autoComplete="username"
+                className={CONTROL_CLASS}
+                value={registerForm.login}
+                onChange={event => setRegisterForm(prev => ({ ...prev, login: event.target.value }))}
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-semibold text-slate-600 dark:text-slate-300" htmlFor="register-role">
+                Роль
+              </label>
+              <select
+                id="register-role"
+                className={CONTROL_CLASS}
+                value={registerForm.role}
+                onChange={event => setRegisterForm(prev => ({ ...prev, role: event.target.value as Role }))}
+              >
+                {roles.map(role => (
+                  <option key={role} value={role}>
+                    {role}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-600 dark:text-slate-300" htmlFor="register-password">
+                  Пароль
+                </label>
+                <input
+                  id="register-password"
+                  type="password"
+                  autoComplete="new-password"
+                  className={CONTROL_CLASS}
+                  value={registerForm.password}
+                  onChange={event => setRegisterForm(prev => ({ ...prev, password: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-600 dark:text-slate-300" htmlFor="register-confirm">
+                  Повторите пароль
+                </label>
+                <input
+                  id="register-confirm"
+                  type="password"
+                  autoComplete="new-password"
+                  className={CONTROL_CLASS}
+                  value={registerForm.confirm}
+                  onChange={event => setRegisterForm(prev => ({ ...prev, confirm: event.target.value }))}
+                />
+              </div>
+            </div>
+            <button
+              type="submit"
+              className="w-full rounded-xl bg-gradient-to-r from-emerald-500 via-green-500 to-teal-500 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:-translate-y-[1px] hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-emerald-300/60 disabled:cursor-not-allowed disabled:opacity-60 dark:focus:ring-emerald-500/40"
+              disabled={loading}
+            >
+              {loading ? "Создание..." : "Зарегистрироваться"}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -5,6 +5,7 @@ import { buildFavoriteSummaries } from "../state/analytics";
 import type { Currency, DB, LeadStage, TaskItem, UIState } from "../types";
 import { readDailyPeriod, writeDailyPeriod } from "../state/filterPersistence";
 import {
+  MONTH_OPTIONS,
   collectAvailableYears,
   filterLeadsByPeriod,
   formatMonthInput,
@@ -79,8 +80,6 @@ export default function Dashboard({ db, ui }: DashboardProps) {
     "Задержка",
     "Пробное",
     "Ожидание оплаты",
-    "Оплаченный абонемент",
-    "Отмена",
   ];
   const leads = useMemo(() => filterLeadsByPeriod(db.leads, period), [db.leads, period]);
   const leadsDistribution = useMemo(
@@ -110,13 +109,11 @@ export default function Dashboard({ db, ui }: DashboardProps) {
       setPeriod(prev => ({ ...prev, month: null }));
       return;
     }
-    const [yearPart, monthPart] = value.split("-");
-    const nextYear = Number.parseInt(yearPart, 10);
-    const nextMonth = Number.parseInt(monthPart, 10);
-    if (!Number.isFinite(nextYear) || !Number.isFinite(nextMonth)) {
+    const nextMonth = Number.parseInt(value, 10);
+    if (!Number.isFinite(nextMonth)) {
       return;
     }
-    setPeriod({ year: nextYear, month: nextMonth });
+    setPeriod(prev => ({ ...prev, month: nextMonth }));
   };
 
   const handleYearChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -134,13 +131,19 @@ export default function Dashboard({ db, ui }: DashboardProps) {
         <label htmlFor="dashboard-month" className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
           Месяц
         </label>
-        <input
+        <select
           id="dashboard-month"
-          type="month"
           className={FIELD_CLASS}
           value={monthValue}
           onChange={event => handleMonthChange(event.target.value)}
-        />
+        >
+          <option value="">Все месяцы</option>
+          {MONTH_OPTIONS.map(option => (
+            <option key={option.value} value={String(option.value)}>
+              {option.label}
+            </option>
+          ))}
+        </select>
         <label htmlFor="dashboard-year" className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
           Год
         </label>

--- a/src/components/GroupsTab.tsx
+++ b/src/components/GroupsTab.tsx
@@ -112,13 +112,11 @@ export default function GroupsTab({
       setPeriod(prev => ({ ...prev, month: null }));
       return;
     }
-    const [yearPart, monthPart] = value.split("-");
-    const nextYear = Number.parseInt(yearPart, 10);
-    const nextMonth = Number.parseInt(monthPart, 10);
-    if (!Number.isFinite(nextYear) || !Number.isFinite(nextMonth)) {
+    const nextMonth = Number.parseInt(value, 10);
+    if (!Number.isFinite(nextMonth)) {
       return;
     }
-    setPeriod({ year: nextYear, month: nextMonth });
+    setPeriod(prev => ({ ...prev, month: nextMonth }));
   };
 
   const handleYearChange = (value: number) => {

--- a/src/components/LeadsTab.tsx
+++ b/src/components/LeadsTab.tsx
@@ -9,7 +9,16 @@ import Modal from "./Modal";
 import { FixedSizeList, ListChildComponentProps } from "react-window";
 import { todayISO, uid, fmtDate } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
-import type { ContactChannel, DB, Lead, LeadStage, LeadFormValues, Client } from "../types";
+import type {
+  ContactChannel,
+  DB,
+  Lead,
+  LeadStage,
+  LeadFormValues,
+  Client,
+  LeadLifecycleEvent,
+  LeadLifecycleOutcome,
+} from "../types";
 
 export default function LeadsTab({
   db,
@@ -18,8 +27,9 @@ export default function LeadsTab({
   db: DB;
   setDB: Dispatch<SetStateAction<DB>>;
 }) {
-  const stages: LeadStage[] = ["Очередь", "Задержка", "Пробное", "Ожидание оплаты", "Оплаченный абонемент", "Отмена"];
+  const stages: LeadStage[] = ["Очередь", "Задержка", "Пробное", "Ожидание оплаты"];
   const [open, setOpen] = useState<Lead | null>(null);
+  const [editing, setEditing] = useState<Lead | null>(null);
   const groupedLeads = useMemo((): Record<LeadStage, Lead[]> =>
     db.leads.reduce((acc, l) => {
       if (acc[l.stage]) acc[l.stage].push(l); else acc[l.stage] = [l];
@@ -32,25 +42,6 @@ export default function LeadsTab({
     const nextStage = stages[Math.min(stages.length - 1, Math.max(0, idx + dir))];
     const updatedLead: Lead = { ...current, stage: nextStage, updatedAt: todayISO() };
 
-    if (isPaidStage(nextStage)) {
-      const newClient = convertLeadToClient(updatedLead, db);
-      const next = {
-        ...db,
-        leads: db.leads.filter(lead => lead.id !== id),
-        clients: [newClient, ...db.clients],
-        changelog: [
-          ...db.changelog,
-          { id: uid(), who: "UI", what: `Лид ${current.name} конвертирован в клиента ${newClient.firstName}`, when: todayISO() },
-        ],
-      };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
-        window.alert("Не удалось обновить статус лида. Изменение сохранено локально, проверьте доступ к базе данных.");
-        setDB(next);
-      }
-      return;
-    }
-
     const next = { ...db, leads: db.leads.map(x => (x.id === id ? updatedLead : x)) };
     const ok = await commitDBUpdate(next, setDB);
     if (!ok) {
@@ -58,10 +49,102 @@ export default function LeadsTab({
       setDB(next);
     }
   };
+
+  const saveLead = async (lead: Lead, data: LeadFormValues) => {
+    const toISODate = (value: string): string | undefined => {
+      const trimmed = value?.trim();
+      return trimmed ? `${trimmed}T00:00:00.000Z` : undefined;
+    };
+
+    const fallbackArea = db.settings.areas[0] ?? "";
+    const fallbackGroup = db.settings.groups[0] ?? "";
+
+    const nextLead: Lead = {
+      ...lead,
+      name: data.name.trim(),
+      firstName: data.firstName?.trim() || undefined,
+      lastName: data.lastName?.trim() || undefined,
+      parentName: data.parentName?.trim() || undefined,
+      phone: data.phone?.trim() || undefined,
+      whatsApp: data.whatsApp?.trim() || undefined,
+      telegram: data.telegram?.trim() || undefined,
+      instagram: data.instagram?.trim() || undefined,
+      source: data.source as ContactChannel,
+      area: data.area || fallbackArea,
+      group: data.group || fallbackGroup,
+      stage: data.stage as LeadStage,
+      birthDate: toISODate(data.birthDate) ?? undefined,
+      startDate: toISODate(data.startDate) ?? undefined,
+      notes: data.notes?.trim() || undefined,
+      updatedAt: todayISO(),
+    };
+
+    const next = {
+      ...db,
+      leads: db.leads.map(l => (l.id === lead.id ? nextLead : l)),
+      changelog: [...db.changelog, { id: uid(), who: "UI", what: `Обновлён лид ${nextLead.name}`, when: todayISO() }],
+    };
+
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось синхронизировать изменения лида. Они сохранены локально, проверьте доступ к базе данных.");
+      setDB(next);
+    }
+  };
+
+  const convertLead = async (lead: Lead) => {
+    const newClient = convertLeadToClient(lead, db);
+    const resolution = makeLeadHistoryEntry(lead, "converted");
+    const next = {
+      ...db,
+      leads: db.leads.filter(l => l.id !== lead.id),
+      clients: [newClient, ...db.clients],
+      leadHistory: [resolution, ...db.leadHistory.filter(entry => entry.leadId !== lead.id)],
+      changelog: [
+        ...db.changelog,
+        { id: uid(), who: "UI", what: `Лид ${lead.name} конвертирован в клиента ${newClient.firstName}`, when: todayISO() },
+      ],
+    };
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось обновить лида. Изменение сохранено локально, проверьте доступ к базе данных.");
+      setDB(next);
+    }
+  };
+
+  const archiveLead = async (lead: Lead) => {
+    const archivedLead: Lead = { ...lead, updatedAt: todayISO() };
+    const resolution = makeLeadHistoryEntry(archivedLead, "canceled");
+    const next = {
+      ...db,
+      leads: db.leads.filter(l => l.id !== lead.id),
+      leadsArchive: [archivedLead, ...db.leadsArchive],
+      leadHistory: [resolution, ...db.leadHistory.filter(entry => entry.leadId !== lead.id)],
+      changelog: [...db.changelog, { id: uid(), who: "UI", what: `Лид ${lead.name} перенесён в архив`, when: todayISO() }],
+    };
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось переместить лида в архив. Изменение сохранено локально, проверьте доступ к базе данных.");
+      setDB(next);
+    }
+  };
+
+  const removeLead = async (lead: Lead) => {
+    if (!window.confirm("Удалить лид?")) return;
+    const next = {
+      ...db,
+      leads: db.leads.filter(l => l.id !== lead.id),
+      changelog: [...db.changelog, { id: uid(), who: "UI", what: `Удалён лид ${lead.id}`, when: todayISO() }],
+    };
+    const ok = await commitDBUpdate(next, setDB);
+    if (!ok) {
+      window.alert("Не удалось удалить лида. Проверьте доступ к базе данных.");
+    }
+  };
   return (
     <div className="space-y-3">
       <Breadcrumbs items={["Лиды"]} />
-      <div className="grid md:grid-cols-3 lg:grid-cols-6 gap-3">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
         {stages.map(s => {
 
           const leads: Lead[] = groupedLeads[s] ?? [];
@@ -79,7 +162,12 @@ export default function LeadsTab({
                   const l = leads[index];
                   return (
                     <div key={l.id} style={style} className="p-2 rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800">
-                      <button onClick={() => setOpen(l)} className="text-sm font-medium text-left hover:underline w-full">{l.name}</button>
+                      <button
+                        onClick={() => setOpen(l)}
+                        className="w-full text-left text-sm font-medium transition-colors duration-150 hover:text-sky-600 hover:underline dark:hover:text-sky-300"
+                      >
+                        {l.name}
+                      </button>
                       <div className="text-xs text-slate-500">{l.source}{formatLeadContactSummary(l)}</div>
                       <div className="flex gap-1 mt-2">
                         <button onClick={() => move(l.id, -1)} className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">◀</button>
@@ -97,16 +185,39 @@ export default function LeadsTab({
         <LeadModal
           lead={open}
           onClose={() => setOpen(null)}
+          onEdit={() => {
+            setEditing(open);
+            setOpen(null);
+          }}
+          onConvert={() => {
+            setOpen(null);
+            void convertLead(open);
+          }}
+          onArchive={() => {
+            setOpen(null);
+            void archiveLead(open);
+          }}
+          onRemove={() => {
+            setOpen(null);
+            void removeLead(open);
+          }}
+        />
+      )}
+      {editing && (
+        <LeadFormModal
+          lead={editing}
           db={db}
-          setDB={setDB}
           stages={stages}
+          onSave={async values => {
+            await saveLead(editing, values);
+            setEditing(null);
+          }}
+          onClose={() => setEditing(null)}
         />
       )}
     </div>
   );
 }
-
-const isPaidStage = (stage: LeadStage): boolean => stage.toLowerCase().includes("оплач");
 
 const CONTACT_CHANNELS: ContactChannel[] = ["Telegram", "WhatsApp", "Instagram"];
 
@@ -153,6 +264,20 @@ function formatLeadContactSummary(lead: Lead): string {
   return contact ? ` · ${contact}` : "";
 }
 
+function makeLeadHistoryEntry(lead: Lead, outcome: LeadLifecycleOutcome): LeadLifecycleEvent {
+  return {
+    id: uid(),
+    leadId: lead.id,
+    name: lead.name,
+    source: lead.source,
+    area: lead.area,
+    group: lead.group,
+    createdAt: lead.createdAt ?? lead.updatedAt,
+    resolvedAt: todayISO(),
+    outcome,
+  };
+}
+
 const toLeadFormValues = (
   current: Lead,
   defaults: { area: string; group: string },
@@ -177,23 +302,104 @@ const toLeadFormValues = (
   };
 };
 
-function LeadModal(
-  {
-    lead,
-    onClose,
-    db,
-    setDB,
-    stages,
-  }: {
-    lead: Lead;
-    onClose: () => void;
-    db: DB;
-    setDB: Dispatch<SetStateAction<DB>>;
-    stages: LeadStage[];
-  },
-) {
-  const [edit, setEdit] = useState(false);
 
+function LeadModal({
+  lead,
+  onClose,
+  onEdit,
+  onConvert,
+  onArchive,
+  onRemove,
+}: {
+  lead: Lead;
+  onClose: () => void;
+  onEdit: () => void;
+  onConvert: () => void;
+  onArchive: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <Modal size="lg" onClose={onClose}>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <div className="text-lg font-semibold text-slate-800 dark:text-slate-100">{lead.name}</div>
+            <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{lead.stage}</div>
+          </div>
+          <button
+            onClick={onClose}
+            className="px-3 py-2 rounded-md border border-slate-300 text-sm hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+          >
+            Закрыть
+          </button>
+        </div>
+
+        <div className="grid gap-2 text-sm sm:grid-cols-2">
+          <InfoRow label="Имя ребёнка" value={lead.firstName ?? "—"} />
+          <InfoRow label="Фамилия" value={lead.lastName ?? "—"} />
+          <InfoRow label="Родитель" value={lead.parentName || "—"} />
+          <InfoRow label="Источник" value={lead.source} />
+          <InfoRow label="Телефон" value={lead.phone || "—"} />
+          <InfoRow label="WhatsApp" value={lead.whatsApp || "—"} />
+          <InfoRow label="Telegram" value={lead.telegram || "—"} />
+          <InfoRow label="Instagram" value={lead.instagram || "—"} />
+          <InfoRow label="Район" value={lead.area ?? "—"} />
+          <InfoRow label="Группа" value={lead.group ?? "—"} />
+          <InfoRow label="Дата рождения" value={lead.birthDate ? fmtDate(lead.birthDate) : "—"} />
+          <InfoRow label="Старт" value={lead.startDate ? fmtDate(lead.startDate) : "—"} />
+          <InfoRow label="Создан" value={fmtDate(lead.createdAt)} />
+          <InfoRow label="Обновлён" value={fmtDate(lead.updatedAt)} />
+        </div>
+
+        <InfoRow
+          label="Заметки"
+          value={lead.notes ? <span className="whitespace-pre-line">{lead.notes}</span> : "—"}
+        />
+
+        <div className="flex flex-wrap justify-end gap-2 border-t border-slate-200 pt-3 dark:border-slate-700">
+          <button
+            onClick={onEdit}
+            className="px-3 py-2 rounded-md border border-slate-300 text-sm hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+          >
+            Редактировать
+          </button>
+          <button
+            onClick={onConvert}
+            className="px-3 py-2 rounded-md bg-emerald-600 text-sm font-medium text-white hover:bg-emerald-700 dark:bg-emerald-600 dark:hover:bg-emerald-500"
+          >
+            Оплаченный лид
+          </button>
+          <button
+            onClick={onArchive}
+            className="px-3 py-2 rounded-md border border-amber-300 text-sm text-amber-700 hover:bg-amber-50 dark:border-amber-600 dark:bg-amber-900/20 dark:text-amber-200 dark:hover:bg-amber-900/30"
+          >
+            Отмена
+          </button>
+          <button
+            onClick={onRemove}
+            className="px-3 py-2 rounded-md border border-rose-200 text-sm text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:text-rose-300 dark:hover:bg-rose-900/30"
+          >
+            Удалить
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function LeadFormModal({
+  lead,
+  db,
+  stages,
+  onSave,
+  onClose,
+}: {
+  lead: Lead;
+  db: DB;
+  stages: LeadStage[];
+  onSave: (values: LeadFormValues) => Promise<void> | void;
+  onClose: () => void;
+}) {
   const schema = yup
     .object({
       name: yup.string().trim().required("Имя обязательно"),
@@ -228,11 +434,15 @@ function LeadModal(
     });
 
   const resolver = yupResolver(schema) as unknown as Resolver<LeadFormValues>;
-
   const defaultArea = db.settings.areas[0] ?? "";
   const defaultGroup = db.settings.groups[0] ?? "";
 
-  const { register, handleSubmit, reset, formState: { errors, isValid } } = useForm<LeadFormValues>({
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isValid },
+  } = useForm<LeadFormValues>({
     resolver,
     mode: "onChange",
     defaultValues: toLeadFormValues(lead, { area: defaultArea, group: defaultGroup }),
@@ -242,344 +452,137 @@ function LeadModal(
     reset(toLeadFormValues(lead, { area: defaultArea, group: defaultGroup }));
   }, [lead, reset, defaultArea, defaultGroup]);
 
-  const save = async (data: LeadFormValues) => {
-    const toISODate = (value: string): string | undefined => {
-      const trimmed = value?.trim();
-      return trimmed ? `${trimmed}T00:00:00.000Z` : undefined;
-    };
-    const nextLead: Lead = {
-      ...lead,
-      name: data.name.trim(),
-      firstName: data.firstName?.trim() || undefined,
-      lastName: data.lastName?.trim() || undefined,
-      parentName: data.parentName?.trim() || undefined,
-      phone: data.phone?.trim() || undefined,
-      whatsApp: data.whatsApp?.trim() || undefined,
-      telegram: data.telegram?.trim() || undefined,
-      instagram: data.instagram?.trim() || undefined,
-      source: data.source as ContactChannel,
+  const submit = async (data: LeadFormValues) => {
+    await onSave({
+      ...data,
       area: data.area || defaultArea,
       group: data.group || defaultGroup,
-      stage: data.stage as LeadStage,
-      birthDate: toISODate(data.birthDate) ?? undefined,
-      startDate: toISODate(data.startDate) ?? undefined,
-      notes: data.notes?.trim() || undefined,
-      updatedAt: todayISO(),
-    };
-
-    if (isPaidStage(nextLead.stage)) {
-      const newClient = convertLeadToClient(nextLead, db);
-      const next = {
-        ...db,
-        leads: db.leads.filter(l => l.id !== lead.id),
-        clients: [newClient, ...db.clients],
-        changelog: [
-          ...db.changelog,
-          { id: uid(), who: "UI", what: `Лид ${nextLead.name} конвертирован в клиента ${newClient.firstName}`, when: todayISO() },
-        ],
-      };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
-        window.alert(
-          "Не удалось синхронизировать изменения лида. Они сохранены локально, проверьте доступ к базе данных.",
-        );
-        setDB(next);
-      }
-      setEdit(false);
-      onClose();
-      return;
-    }
-
-    const next = {
-      ...db,
-      leads: db.leads.map(l => (l.id === lead.id ? nextLead : l)),
-      changelog: [...db.changelog, { id: uid(), who: "UI", what: `Обновлён лид ${nextLead.name}`, when: todayISO() }],
-    };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert("Не удалось синхронизировать изменения лида. Они сохранены локально, проверьте доступ к базе данных.");
-      setDB(next);
-    }
-    setEdit(false);
+    });
     onClose();
   };
 
-  const remove = async () => {
-    if (!window.confirm("Удалить лид?")) return;
-    const next = {
-      ...db,
-      leads: db.leads.filter(l => l.id !== lead.id),
-      changelog: [...db.changelog, { id: uid(), who: "UI", what: `Удалён лид ${lead.id}`, when: todayISO() }],
-    };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert("Не удалось удалить лида. Проверьте доступ к базе данных.");
-      return;
-    }
-    onClose();
-  };
+  const labelClass = "text-xs text-slate-500 dark:text-slate-400";
+  const fieldClass =
+    "px-3 py-2 rounded-md border border-slate-300 bg-white placeholder:text-slate-400 " +
+    "dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 dark:placeholder:text-slate-500";
+  const selectClass = `${fieldClass} appearance-none`;
 
   return (
-    <Modal size="lg" onClose={onClose}>
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="space-y-1">
-            <div className="text-lg font-semibold text-slate-800 dark:text-slate-100">{lead.name}</div>
-            <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{lead.stage}</div>
+    <Modal size="xl" onClose={onClose}>
+      <div className="font-semibold text-slate-800 dark:text-slate-100">Редактирование лида</div>
+      <form onSubmit={handleSubmit(submit)} className="space-y-3">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="sm:col-span-2 flex flex-col gap-1">
+            <label className={labelClass}>Название карточки</label>
+            <input className={fieldClass} {...register("name")} placeholder="Имя" />
+            {errors.name && <span className="text-xs text-rose-600">{errors.name.message}</span>}
           </div>
-          <div className="flex flex-wrap justify-end gap-2">
-            {!edit && (
-              <button
-                onClick={() => setEdit(true)}
-                className="px-3 py-2 rounded-md border border-slate-300 text-sm hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
-              >
-                Редактировать
-              </button>
-            )}
-            <button
-              onClick={remove}
-              className="px-3 py-2 rounded-md border border-rose-200 text-sm text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:text-rose-300 dark:hover:bg-rose-900/30"
-            >
-              Удалить
-            </button>
-            <button
-              onClick={onClose}
-              className="px-3 py-2 rounded-md border border-slate-300 text-sm hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
-            >
-              Закрыть
-            </button>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Имя ребёнка</label>
+            <input className={fieldClass} {...register("firstName")} placeholder="Имя ребёнка" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Фамилия</label>
+            <input className={fieldClass} {...register("lastName")} placeholder="Фамилия" />
+          </div>
+          <div className="sm:col-span-2 flex flex-col gap-1">
+            <label className={labelClass}>Родитель</label>
+            <input className={fieldClass} {...register("parentName")} placeholder="Родитель" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Статус лида</label>
+            <select className={selectClass} {...register("stage")}>
+              {stages.map(stage => (
+                <option key={stage} value={stage}>
+                  {stage}
+                </option>
+              ))}
+            </select>
+            {errors.stage && <span className="text-xs text-rose-600">{errors.stage.message}</span>}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Источник</label>
+            <select className={selectClass} {...register("source")}>
+              {CONTACT_CHANNELS.map(channel => (
+                <option key={channel} value={channel}>
+                  {channel}
+                </option>
+              ))}
+            </select>
+            {errors.source && <span className="text-xs text-rose-600">{errors.source.message}</span>}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Район</label>
+            <select className={selectClass} {...register("area")}>
+              {db.settings.areas.map(area => (
+                <option key={area} value={area}>
+                  {area}
+                </option>
+              ))}
+            </select>
+            {errors.area && <span className="text-xs text-rose-600">{errors.area.message}</span>}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Группа</label>
+            <select className={selectClass} {...register("group")}>
+              {db.settings.groups.map(group => (
+                <option key={group} value={group}>
+                  {group}
+                </option>
+              ))}
+            </select>
+            {errors.group && <span className="text-xs text-rose-600">{errors.group.message}</span>}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Дата рождения</label>
+            <input type="date" className={fieldClass} {...register("birthDate")} />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Дата старта</label>
+            <input type="date" className={fieldClass} {...register("startDate")} />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Телефон</label>
+            <input className={fieldClass} {...register("phone")} placeholder="Телефон" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>WhatsApp</label>
+            <input className={fieldClass} {...register("whatsApp")} placeholder="WhatsApp" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Telegram</label>
+            <input className={fieldClass} {...register("telegram")} placeholder="Telegram" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Instagram</label>
+            <input className={fieldClass} {...register("instagram")} placeholder="Instagram" />
+          </div>
+          <div className="sm:col-span-2 flex flex-col gap-1">
+            <label className={labelClass}>Заметки</label>
+            <textarea rows={4} className={fieldClass} {...register("notes")} placeholder="Заметки" />
           </div>
         </div>
-
-        <div className="grid gap-2 text-sm sm:grid-cols-2">
-          <InfoRow label="Имя ребёнка" value={lead.firstName ?? "—"} />
-          <InfoRow label="Фамилия" value={lead.lastName ?? "—"} />
-          <InfoRow label="Родитель" value={lead.parentName || "—"} />
-          <InfoRow label="Источник" value={lead.source} />
-          <InfoRow label="Телефон" value={lead.phone || "—"} />
-          <InfoRow label="WhatsApp" value={lead.whatsApp || "—"} />
-          <InfoRow label="Telegram" value={lead.telegram || "—"} />
-          <InfoRow label="Instagram" value={lead.instagram || "—"} />
-          <InfoRow label="Район" value={lead.area ?? "—"} />
-          <InfoRow label="Группа" value={lead.group ?? "—"} />
-          <InfoRow label="Дата рождения" value={lead.birthDate ? fmtDate(lead.birthDate) : "—"} />
-          <InfoRow label="Старт" value={lead.startDate ? fmtDate(lead.startDate) : "—"} />
-          <InfoRow label="Создан" value={fmtDate(lead.createdAt)} />
-          <InfoRow label="Обновлён" value={fmtDate(lead.updatedAt)} />
-        </div>
-
-        <InfoRow
-          label="Заметки"
-          value={lead.notes ? <span className="whitespace-pre-line">{lead.notes}</span> : "—"}
-        />
-
-        {edit && (
-          <form
-            onSubmit={handleSubmit(save)}
-            className="space-y-3 rounded-2xl border border-slate-200 p-3 dark:border-slate-700"
+        {errors.phone && <span className="text-xs text-rose-600">{errors.phone.message}</span>}
+        <div className="flex justify-end gap-2">
+          <button
+            type="submit"
+            disabled={!isValid}
+            className="rounded-md bg-sky-600 px-3 py-2 text-sm text-white disabled:bg-slate-400"
           >
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="sm:col-span-2 space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Название карточки
-                </label>
-                <input
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("name")}
-                  placeholder="Имя"
-                />
-                {errors.name && <span className="text-xs text-rose-600">{errors.name.message}</span>}
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Имя ребёнка
-                </label>
-                <input
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("firstName")}
-                  placeholder="Имя ребёнка"
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Фамилия
-                </label>
-                <input
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("lastName")}
-                  placeholder="Фамилия"
-                />
-              </div>
-              <div className="sm:col-span-2 space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Родитель
-                </label>
-                <input
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("parentName")}
-                  placeholder="Родитель"
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Статус лида
-                </label>
-                <select
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("stage")}
-                >
-                  {stages.map(stage => (
-                    <option key={stage} value={stage}>
-                      {stage}
-                    </option>
-                  ))}
-                </select>
-                {errors.stage && <span className="text-xs text-rose-600">{errors.stage.message}</span>}
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Источник
-                </label>
-                <select
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("source")}
-                >
-                  {CONTACT_CHANNELS.map(channel => (
-                    <option key={channel} value={channel}>
-                      {channel}
-                    </option>
-                  ))}
-                </select>
-                {errors.source && <span className="text-xs text-rose-600">{errors.source.message}</span>}
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Район
-                </label>
-                <select
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("area")}
-                >
-                  {db.settings.areas.map(area => (
-                    <option key={area} value={area}>
-                      {area}
-                    </option>
-                  ))}
-                </select>
-                {errors.area && <span className="text-xs text-rose-600">{errors.area.message}</span>}
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Группа
-                </label>
-                <select
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("group")}
-                >
-                  {db.settings.groups.map(group => (
-                    <option key={group} value={group}>
-                      {group}
-                    </option>
-                  ))}
-                </select>
-                {errors.group && <span className="text-xs text-rose-600">{errors.group.message}</span>}
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Дата рождения
-                </label>
-                <input
-                  type="date"
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("birthDate")}
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Дата старта
-                </label>
-                <input
-                  type="date"
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("startDate")}
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Телефон
-                </label>
-                <input
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("phone")}
-                  placeholder="Телефон"
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  WhatsApp
-                </label>
-                <input
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("whatsApp")}
-                  placeholder="WhatsApp"
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Telegram
-                </label>
-                <input
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("telegram")}
-                  placeholder="Telegram"
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Instagram
-                </label>
-                <input
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("instagram")}
-                  placeholder="Instagram"
-                />
-              </div>
-              <div className="sm:col-span-2 space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Заметки
-                </label>
-                <textarea
-                  rows={4}
-                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-                  {...register("notes")}
-                  placeholder="Заметки"
-                />
-              </div>
-            </div>
-            {errors.phone && <span className="text-xs text-rose-600">{errors.phone.message}</span>}
-            <div className="flex justify-end gap-2">
-              <button
-                type="submit"
-                disabled={!isValid}
-                className="rounded-md bg-sky-600 px-3 py-2 text-sm text-white disabled:bg-slate-400"
-              >
-                Сохранить
-              </button>
-              <button
-                type="button"
-                onClick={() => setEdit(false)}
-                className="rounded-md border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
-              >
-                Отмена
-              </button>
-            </div>
-          </form>
-        )}
-      </div>
+            Сохранить
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+          >
+            Отмена
+          </button>
+        </div>
+      </form>
     </Modal>
   );
 }
-
 function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-1 rounded-xl border border-slate-200 bg-white p-3 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-800">

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -21,6 +21,7 @@ import type {
 } from "../types";
 import { readDailyPeriod, writeDailyPeriod } from "../state/filterPersistence";
 import {
+  MONTH_OPTIONS,
   collectAvailableYears,
   formatMonthInput,
   getDefaultPeriod,
@@ -114,13 +115,11 @@ export default function PerformanceTab({
       setPeriod(prev => ({ ...prev, month: null }));
       return;
     }
-    const [yearPart, monthPart] = value.split("-");
-    const nextYear = Number.parseInt(yearPart, 10);
-    const nextMonth = Number.parseInt(monthPart, 10);
-    if (!Number.isFinite(nextYear) || !Number.isFinite(nextMonth)) {
+    const nextMonth = Number.parseInt(value, 10);
+    if (!Number.isFinite(nextMonth)) {
       return;
     }
-    setPeriod({ year: nextYear, month: nextMonth });
+    setPeriod(prev => ({ ...prev, month: nextMonth }));
   };
 
   const handleYearChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -288,12 +287,18 @@ export default function PerformanceTab({
             </option>
           ))}
         </select>
-        <input
-          type="month"
+        <select
           className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
           value={monthValue}
           onChange={event => handleMonthChange(event.target.value)}
-        />
+        >
+          <option value="">Все месяцы</option>
+          {MONTH_OPTIONS.map(option => (
+            <option key={option.value} value={String(option.value)}>
+              {option.label}
+            </option>
+          ))}
+        </select>
         <select
           className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
           value={period.year}

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,17 +1,18 @@
 import React, { useCallback, useRef } from "react";
-import type { Currency, Role, UIState } from "../types";
+import type { AuthUser, Currency, UIState } from "../types";
 
 type TopbarProps = {
   ui: UIState;
   setUI: React.Dispatch<React.SetStateAction<UIState>>;
-  roleList: Role[];
   onQuickAdd: () => void;
+  currentUser: AuthUser;
+  onLogout: () => void;
 };
 
 const CONTROL_CLASS =
   "rounded-xl border border-slate-200/60 bg-white/70 px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-200/60 dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200 dark:focus:border-sky-500/60 dark:focus:ring-sky-500/30";
 
-export default function Topbar({ ui, setUI, roleList, onQuickAdd }: TopbarProps) {
+export default function Topbar({ ui, setUI, onQuickAdd, currentUser, onLogout }: TopbarProps) {
   const searchTimeout = useRef<number | null>(null);
 
   const handleSearch = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -80,21 +81,22 @@ export default function Topbar({ ui, setUI, roleList, onQuickAdd }: TopbarProps)
           >
             <span aria-hidden="true">＋</span> Быстро добавить
           </button>
-          <select
-            className={`${CONTROL_CLASS} w-auto`}
-            value={ui.role}
-            onChange={e => {
-              const u = { ...ui, role: e.target.value as Role };
-              setUI(u);
-            }}
-            title="Войти как"
-          >
-            {roleList.map(r => (
-              <option key={r} value={r}>
-                {r}
-              </option>
-            ))}
-          </select>
+          <div className="flex items-center gap-3 rounded-xl border border-slate-200/60 bg-white/70 px-3 py-2 text-left shadow-sm transition dark:border-slate-700/60 dark:bg-slate-900/70">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-500/20 text-base font-semibold text-sky-600 dark:bg-sky-500/10 dark:text-sky-300">
+              {(currentUser.name || currentUser.login).slice(0, 2).toUpperCase()}
+            </div>
+            <div>
+              <div className="text-sm font-semibold text-slate-800 dark:text-slate-100">{currentUser.name}</div>
+              <div className="text-xs text-slate-500 dark:text-slate-400">{currentUser.role}</div>
+            </div>
+            <button
+              type="button"
+              onClick={onLogout}
+              className="ml-3 inline-flex items-center rounded-lg border border-slate-300/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+            >
+              Выйти
+            </button>
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/__tests__/ClientsTab.test.tsx
+++ b/src/components/__tests__/ClientsTab.test.tsx
@@ -56,6 +56,8 @@ const makeDB = () => ({
     { id: 'slot-1', area: 'Area1', group: 'Group1', coachId: 's1', weekday: 1, time: '10:00', location: '' },
   ],
   leads: [],
+  leadsArchive: [],
+  leadHistory: [],
   tasks: [],
   tasksArchive: [],
   staff: [{ id: 's1', role: 'Тренер', name: 'Coach1', areas: ['Area1'], groups: ['Group1'] }],

--- a/src/components/__tests__/GroupsTab.test.tsx
+++ b/src/components/__tests__/GroupsTab.test.tsx
@@ -66,6 +66,8 @@ const makeDB = () => ({
     { id: 'slot-3', area: 'Area2', group: 'Group1', coachId: 's1', weekday: 3, time: '12:00', location: '' },
   ],
   leads: [],
+  leadsArchive: [],
+  leadHistory: [],
   tasks: [],
   tasksArchive: [],
   staff: [{ id: 's1', role: 'Тренер', name: 'Coach1' }],
@@ -190,14 +192,20 @@ test('filters clients by selected month', async () => {
 
   renderGroups(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
 
-  await waitFor(() => expect(screen.getByText('Январь')).toBeInTheDocument());
-  expect(screen.queryByText('Февраль')).not.toBeInTheDocument();
+  await waitFor(() => {
+    const rows = screen.getAllByRole('row');
+    expect(rows.length).toBe(2);
+    expect(rows[1]).toHaveTextContent('Январь');
+  });
 
   const monthInput = screen.getByLabelText('Фильтр по месяцу');
-  fireEvent.change(monthInput, { target: { value: '2024-02' } });
+  fireEvent.change(monthInput, { target: { value: '2' } });
 
-  await waitFor(() => expect(screen.getByText('Февраль')).toBeInTheDocument());
-  expect(screen.queryByText('Январь')).not.toBeInTheDocument();
+  await waitFor(() => {
+    const rows = screen.getAllByRole('row');
+    expect(rows.length).toBe(2);
+    expect(rows[1]).toHaveTextContent('Февраль');
+  });
 });
 
 test('update: edits client name', async () => {
@@ -301,7 +309,7 @@ test('creates payment task with client info', async () => {
   ];
 
   const { getDB } = renderGroups(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
-  fireEvent.change(screen.getByLabelText('Фильтр по месяцу'), { target: { value: '2024-02' } });
+  fireEvent.change(screen.getByLabelText('Фильтр по месяцу'), { target: { value: '2' } });
   const row = await screen.findByText('Ivan Petrov');
   const createTaskBtn = within(row.closest('tr')).getByRole('button', { name: 'Создать задачу' });
 

--- a/src/components/__tests__/ScheduleTab.groups.test.tsx
+++ b/src/components/__tests__/ScheduleTab.groups.test.tsx
@@ -45,6 +45,8 @@ function makeDb() {
     attendance: [],
     schedule: [],
   leads: [],
+  leadsArchive: [],
+  leadHistory: [],
   tasks: [],
   tasksArchive: [],
     staff: [],

--- a/src/components/__tests__/ScheduleTab.test.tsx
+++ b/src/components/__tests__/ScheduleTab.test.tsx
@@ -42,8 +42,10 @@ function makeDb() {
   return {
     clients: [],
     attendance: [],
-    schedule: [],
+  schedule: [],
   leads: [],
+  leadsArchive: [],
+  leadHistory: [],
   tasks: [],
   tasksArchive: [],
     staff: [],

--- a/src/components/__tests__/SettingsTab.test.tsx
+++ b/src/components/__tests__/SettingsTab.test.tsx
@@ -16,6 +16,8 @@ const createDB = (): DB => ({
   performance: [],
   schedule: [],
   leads: [],
+  leadsArchive: [],
+  leadHistory: [],
   tasks: [],
   tasksArchive: [],
   staff: [],

--- a/src/components/clients/ClientDetailsModal.tsx
+++ b/src/components/clients/ClientDetailsModal.tsx
@@ -57,32 +57,13 @@ export default function ClientDetailsModal({
               {client.area} · {client.group}
             </div>
           </div>
-          <div className="flex gap-2">
-            {onEdit && (
-              <button
-                type="button"
-                onClick={() => {
-                  onEdit(client);
-                  onClose();
-                }}
-                className="px-3 py-2 rounded-md border border-slate-300 text-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:hover:bg-slate-700"
-              >
-                Редактировать
-              </button>
-            )}
-            {onRemove && (
-              <button
-                type="button"
-                onClick={() => {
-                  onRemove(client.id);
-                  onClose();
-                }}
-                className="px-3 py-2 rounded-md border border-rose-200 text-sm text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:text-rose-300 dark:hover:bg-rose-900/30"
-              >
-                Удалить
-              </button>
-            )}
-          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-2 rounded-md border border-slate-300 text-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+          >
+            Закрыть
+          </button>
         </div>
 
         <div className="flex flex-wrap gap-2">
@@ -169,15 +150,34 @@ export default function ClientDetailsModal({
           </div>
         )}
 
-        <div className="flex justify-end">
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-4 py-2 rounded-md border border-slate-300 text-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-          >
-            Закрыть
-          </button>
-        </div>
+        {(onEdit || onRemove) && (
+          <div className="flex flex-wrap justify-end gap-2 border-t border-slate-200 pt-3 dark:border-slate-700">
+            {onEdit && (
+              <button
+                type="button"
+                onClick={() => {
+                  onEdit(client);
+                  onClose();
+                }}
+                className="px-3 py-2 rounded-md border border-slate-300 text-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:hover:bg-slate-700"
+              >
+                Редактировать
+              </button>
+            )}
+            {onRemove && (
+              <button
+                type="button"
+                onClick={() => {
+                  onRemove(client.id);
+                  onClose();
+                }}
+                className="px-3 py-2 rounded-md border border-rose-200 text-sm text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:text-rose-300 dark:hover:bg-rose-900/30"
+              >
+                Удалить
+              </button>
+            )}
+          </div>
+        )}
       </div>
     </Modal>
   );

--- a/src/components/clients/ClientFilters.tsx
+++ b/src/components/clients/ClientFilters.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { DB, Area, Group, PaymentStatus } from "../../types";
+import { MONTH_OPTIONS } from "../../state/period";
 
 type Props = {
   db: DB,
@@ -68,13 +69,19 @@ export default function ClientFilters({
       </div>
 
       <div className="flex flex-wrap gap-2 items-center">
-        <input
-          type="month"
+        <select
           className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
           value={monthValue}
           onChange={event => onMonthChange(event.target.value)}
           aria-label="Фильтр по месяцу"
-        />
+        >
+          <option value="">Все месяцы</option>
+          {MONTH_OPTIONS.map(option => (
+            <option key={option.value} value={String(option.value)}>
+              {option.label}
+            </option>
+          ))}
+        </select>
         <select
           className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
           value={year}

--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -61,7 +61,7 @@ export default function ClientTable({ list, currency, onEdit, onRemove, onCreate
       label: "Имя",
       width: "minmax(160px, max-content)",
       renderCell: client => (
-        <span className="font-medium text-slate-800 dark:text-slate-100">
+        <span className="font-medium text-slate-800 transition-colors duration-150 group-hover:text-sky-600 dark:text-slate-100 dark:group-hover:text-sky-300">
           {client.firstName} {client.lastName}
         </span>
       ),
@@ -274,7 +274,7 @@ export default function ClientTable({ list, currency, onEdit, onRemove, onCreate
               gridTemplateColumns: columnTemplate,
               alignItems: "center",
             }}
-            className="border-t border-slate-100 dark:border-slate-700"
+            className="group cursor-pointer border-t border-slate-100 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
             onClick={() => setSelected(c)}
           >
             {activeColumns.map(column => (

--- a/src/state/__tests__/analytics.period.test.ts
+++ b/src/state/__tests__/analytics.period.test.ts
@@ -51,6 +51,8 @@ describe("computeAnalyticsSnapshot with period", () => {
       { id: "s1", area: "Area1", group: "Group1", coachId: "coach-1", weekday: 1, time: "10:00", location: "" },
     ],
     leads: [],
+    leadsArchive: [],
+    leadHistory: [],
     tasks: [],
     tasksArchive: [],
     staff: [],

--- a/src/state/__tests__/useAppState.test.tsx
+++ b/src/state/__tests__/useAppState.test.tsx
@@ -69,4 +69,17 @@ describe('useAppState with local persistence', () => {
     warnSpy.mockRestore();
     errorSpy.mockRestore();
   });
+
+  it('allows logging in with predefined admin credentials', async () => {
+    const { result } = renderHook(() => useAppState());
+
+    let loginResult;
+    await act(async () => {
+      loginResult = await result.current.loginUser('admin1', 'admin1');
+    });
+
+    expect(loginResult).toEqual({ ok: true });
+    expect(result.current.currentUser).not.toBeNull();
+    expect(result.current.currentUser?.login).toBe('admin1');
+  });
 });

--- a/src/state/period.ts
+++ b/src/state/period.ts
@@ -6,7 +6,25 @@ export type PeriodFilter = {
   month: number | null;
 };
 
-const MONTH_PAD = new Intl.NumberFormat("ru-RU", { minimumIntegerDigits: 2 });
+const MONTH_NAMES = [
+  "Январь",
+  "Февраль",
+  "Март",
+  "Апрель",
+  "Май",
+  "Июнь",
+  "Июль",
+  "Август",
+  "Сентябрь",
+  "Октябрь",
+  "Ноябрь",
+  "Декабрь",
+];
+
+export const MONTH_OPTIONS = MONTH_NAMES.map((label, index) => ({
+  value: index + 1,
+  label,
+}));
 
 function parseYearPart(value?: string | null): number | null {
   if (!value) {
@@ -89,7 +107,7 @@ export function formatMonthInput(period: PeriodFilter): string {
   if (period.month == null) {
     return "";
   }
-  return `${period.year}-${MONTH_PAD.format(period.month)}`;
+  return String(period.month);
 }
 
 export function collectAvailableYears(db: DB): number[] {

--- a/src/state/seed.ts
+++ b/src/state/seed.ts
@@ -187,6 +187,8 @@ export function makeSeedDB(): DB {
     performance,
     schedule,
     leads,
+    leadsArchive: [],
+    leadHistory: [],
     tasks,
     tasksArchive: [],
     staff,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,9 +14,22 @@ export type PaymentStatus = "ожидание" | "действует" | "зад�
 
 export type ClientStatus = "действующий" | "отмена" | "новый" | "вернувшийся" | "продлившийся";
 
-export type LeadStage = "Очередь" | "Задержка" | "Пробное" | "Ожидание оплаты" | "Оплаченный абонемент" | "Отмена";
+export type LeadStage = "Очередь" | "Задержка" | "Пробное" | "Ожидание оплаты";
 
 export type Currency = "EUR" | "TRY" | "RUB";
+
+export interface AuthUser {
+  id: string;
+  login: string;
+  password: string;
+  name: string;
+  role: Role;
+}
+
+export interface AuthState {
+  users: AuthUser[];
+  currentUserId: string | null;
+}
 
 export interface Client {
   id: string;
@@ -113,6 +126,20 @@ export interface Lead {
   updatedAt: string;
 }
 
+export type LeadLifecycleOutcome = "converted" | "canceled";
+
+export interface LeadLifecycleEvent {
+  id: string;
+  leadId: string;
+  name: string;
+  source?: ContactChannel;
+  area?: Area;
+  group?: Group;
+  createdAt: string;
+  resolvedAt: string;
+  outcome: LeadLifecycleOutcome;
+}
+
 export interface LeadFormValues {
   name: string;
   firstName: string;
@@ -168,6 +195,8 @@ export interface DB {
   performance: PerformanceEntry[];
   schedule: ScheduleSlot[];
   leads: Lead[];
+  leadsArchive: Lead[];
+  leadHistory: LeadLifecycleEvent[];
   tasks: TaskItem[];
   tasksArchive: TaskItem[];
   staff: StaffMember[];


### PR DESCRIPTION
## Summary
- add a dedicated authentication page with login and registration flows and gate the app behind it
- persist user accounts with seeded administrators plus login, registration, and logout helpers in the shared app state and surface the current user in the top bar
- extend unit coverage to verify that default admin credentials successfully sign in

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d8f574ad90832b84462707b84cc615