### PR TITLE
Add CSV import/export for clients

### DIFF
--- a/src/components/ClientsTab.tsx
+++ b/src/components/ClientsTab.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useState } from "react";
-import type { Dispatch, SetStateAction } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import type { Dispatch, SetStateAction, ChangeEvent } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import ClientTable from "./clients/ClientTable";
 import ClientForm from "./clients/ClientForm";
@@ -7,6 +7,11 @@ import { fmtMoney, todayISO, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
 import { applyPaymentStatusRules } from "../state/payments";
 import { transformClientFormValues } from "./clients/clientMutations";
+import {
+  appendImportedClients,
+  exportClientsToCsv,
+  parseClientsCsv,
+} from "./clients/clientCsv";
 import type { Client, ClientFormValues, DB, TaskItem, UIState } from "../types";
 
 type ClientsTabProps = {
@@ -19,6 +24,7 @@ export default function ClientsTab({ db, setDB, ui }: ClientsTabProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<Client | null>(null);
   const [query, setQuery] = useState(ui.search);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     setQuery(ui.search);
@@ -140,6 +146,65 @@ export default function ClientsTab({ db, setDB, ui }: ClientsTabProps) {
     }
   };
 
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImportFile = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) {
+      return;
+    }
+
+    try {
+      const text = await file.text();
+      const result = parseClientsCsv(text, db);
+
+      const messages: string[] = [];
+
+      if (result.processed) {
+        messages.push(`Обработано строк: ${result.processed}`);
+      }
+
+      if (result.clients.length) {
+        const { next } = appendImportedClients(db, result.clients);
+        const ok = await commitDBUpdate(next, setDB);
+        if (!ok) {
+          window.alert(
+            "Не удалось синхронизировать импорт. Данные сохранены локально, проверьте доступ к базе данных.",
+          );
+          setDB(next);
+        }
+        messages.push(`Импортировано клиентов: ${result.clients.length}`);
+        if (result.skipped) {
+          messages.push(`Пропущено строк: ${result.skipped}`);
+        }
+      } else if (!result.errors.length) {
+        messages.push("Подходящих строк не найдено");
+      }
+
+      if (result.errors.length) {
+        messages.push("Ошибки:");
+        messages.push(...result.errors);
+      }
+
+      if (messages.length) {
+        window.alert(messages.join("\n"));
+      }
+    } catch (error) {
+      window.alert(`Не удалось прочитать файл: ${(error as Error).message}`);
+    }
+  };
+
+  const handleExport = () => {
+    if (!db.clients.length) {
+      window.alert("Список клиентов пуст — экспортировать нечего.");
+      return;
+    }
+    exportClientsToCsv(db.clients);
+  };
+
   const total = db.clients.length;
   const visibleCount = list.length;
   const counterText = search
@@ -159,12 +224,33 @@ export default function ClientsTab({ db, setDB, ui }: ClientsTabProps) {
           />
           <div className="text-xs text-slate-500">{counterText}</div>
         </div>
-        <button
-          onClick={openAddModal}
-          className="px-3 py-2 rounded-lg bg-sky-600 text-white text-sm hover:bg-sky-700"
-        >
-          + Добавить клиента
-        </button>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            onClick={openAddModal}
+            className="px-3 py-2 rounded-lg bg-sky-600 text-white text-sm hover:bg-sky-700"
+          >
+            + Добавить клиента
+          </button>
+          <button
+            onClick={handleExport}
+            className="px-3 py-2 rounded-lg border border-sky-600 text-sky-600 text-sm hover:bg-sky-50 dark:border-sky-500 dark:text-sky-300 dark:hover:bg-slate-800"
+          >
+            Экспорт CSV
+          </button>
+          <button
+            onClick={handleImportClick}
+            className="px-3 py-2 rounded-lg border border-emerald-600 text-emerald-600 text-sm hover:bg-emerald-50 dark:border-emerald-500 dark:text-emerald-300 dark:hover:bg-slate-800"
+          >
+            Импорт CSV
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            className="hidden"
+            onChange={handleImportFile}
+          />
+        </div>
       </div>
       <ClientTable
         list={list}

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useMemo } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import { commitDBUpdate } from "../state/appState";
 import type { DB } from "../types";
+import { downloadClientCsvTemplate } from "./clients/clientCsv";
 
 const formatRate = (value?: number) => (value != null ? value.toFixed(2) : "");
 const parseRateInputValue = (raw: string): number | undefined => {
@@ -261,6 +262,22 @@ export default function SettingsTab({
   return (
     <div className="space-y-3">
       <Breadcrumbs items={["Настройки"]} />
+      <div className="p-4 rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 space-y-3">
+        <div className="font-semibold">Импорт клиентов</div>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Скачайте шаблон CSV, заполните его данными и загрузите файл в разделе «Клиенты», чтобы добавить несколько учеников
+          за один раз. Строки, начинающиеся с символа «#», игнорируются при импорте.
+        </p>
+        <div>
+          <button
+            type="button"
+            onClick={() => downloadClientCsvTemplate()}
+            className="rounded-md border border-emerald-600 px-4 py-2 text-sm font-semibold text-emerald-600 hover:bg-emerald-50 dark:border-emerald-500 dark:text-emerald-300 dark:hover:bg-slate-800"
+          >
+            Скачать шаблон CSV
+          </button>
+        </div>
+      </div>
       <div className="p-4 rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 space-y-3">
         <div className="font-semibold">Курсы валют</div>
         <div className="grid sm:grid-cols-3 gap-2">

--- a/src/components/clients/clientCsv.ts
+++ b/src/components/clients/clientCsv.ts
@@ -1,0 +1,525 @@
+import { parseCsv, stringifyCsv } from "../../utils/csv";
+import { downloadTextFile } from "../../utils/download";
+import { transformClientFormValues } from "./clientMutations";
+import { todayISO, uid } from "../../state/utils";
+import type {
+  Area,
+  Client,
+  ClientFormValues,
+  ClientStatus,
+  ContactChannel,
+  DB,
+  Gender,
+  Group,
+  PaymentMethod,
+  PaymentStatus,
+} from "../../types";
+
+export const CLIENT_CSV_HEADERS = [
+  "firstName",
+  "lastName",
+  "parentName",
+  "phone",
+  "whatsApp",
+  "telegram",
+  "instagram",
+  "channel",
+  "birthDate",
+  "gender",
+  "area",
+  "group",
+  "startDate",
+  "payMethod",
+  "payStatus",
+  "status",
+  "payDate",
+  "payAmount",
+  "remainingLessons",
+] as const;
+
+type ClientCsvColumn = (typeof CLIENT_CSV_HEADERS)[number];
+
+type HeaderAliasMap = Record<string, ClientCsvColumn>;
+
+const HEADER_ALIASES: HeaderAliasMap = {
+  firstname: "firstName",
+  "имя": "firstName",
+  "first_name": "firstName",
+  lastname: "lastName",
+  "фамилия": "lastName",
+  "last_name": "lastName",
+  parentname: "parentName",
+  "родитель": "parentName",
+  "parent_name": "parentName",
+  phone: "phone",
+  "телефон": "phone",
+  whatsapp: "whatsApp",
+  "whats_app": "whatsApp",
+  "ватсап": "whatsApp",
+  telegram: "telegram",
+  "телеграм": "telegram",
+  instagram: "instagram",
+  "инстаграм": "instagram",
+  channel: "channel",
+  "канал": "channel",
+  "канал_связи": "channel",
+  birthdate: "birthDate",
+  "дата_рождения": "birthDate",
+  gender: "gender",
+  "пол": "gender",
+  area: "area",
+  "район": "area",
+  group: "group",
+  "группа": "group",
+  startdate: "startDate",
+  "дата_старта": "startDate",
+  paymethod: "payMethod",
+  "метод_оплаты": "payMethod",
+  paystatus: "payStatus",
+  "статус_оплаты": "payStatus",
+  status: "status",
+  "статус": "status",
+  paydate: "payDate",
+  "дата_оплаты": "payDate",
+  payamount: "payAmount",
+  "сумма": "payAmount",
+  remaininglessons: "remainingLessons",
+  "оставшиеся_занятия": "remainingLessons",
+};
+
+const REQUIRED_COLUMNS: ClientCsvColumn[] = [
+  "firstName",
+  "channel",
+  "birthDate",
+  "gender",
+  "area",
+  "group",
+  "startDate",
+  "payMethod",
+  "payStatus",
+  "status",
+];
+
+const CONTACT_CHANNEL_ALIASES: Record<string, ContactChannel> = {
+  telegram: "Telegram",
+  телеграм: "Telegram",
+  tg: "Telegram",
+  whatsap: "WhatsApp",
+  whatsapp: "WhatsApp",
+  ватсап: "WhatsApp",
+  wa: "WhatsApp",
+  instagram: "Instagram",
+  инстаграм: "Instagram",
+  insta: "Instagram",
+};
+
+const PAYMENT_METHOD_ALIASES: Record<string, PaymentMethod> = {
+  "наличные": "наличные",
+  "наличка": "наличные",
+  cash: "наличные",
+  "перевод": "перевод",
+  transfer: "перевод",
+  "безнал": "перевод",
+  "перевод на карту": "перевод",
+};
+
+const PAYMENT_STATUS_ALIASES: Record<string, PaymentStatus> = {
+  "ожидание": "ожидание",
+  "ожидание оплаты": "ожидание",
+  pending: "ожидание",
+  "действует": "действует",
+  active: "действует",
+  "оплачено": "действует",
+  "задолженность": "задолженность",
+  overdue: "задолженность",
+  debt: "задолженность",
+};
+
+const CLIENT_STATUS_ALIASES: Record<string, ClientStatus> = {
+  "действующий": "действующий",
+  "активный": "действующий",
+  active: "действующий",
+  "отмена": "отмена",
+  "отменен": "отмена",
+  cancelled: "отмена",
+  "новый": "новый",
+  new: "новый",
+  "вернувшийся": "вернувшийся",
+  returned: "вернувшийся",
+  "продлившийся": "продлившийся",
+  renewed: "продлившийся",
+};
+
+const GENDER_ALIASES: Record<string, Gender> = {
+  м: "м",
+  "m": "м",
+  male: "м",
+  муж: "м",
+  "ж": "ж",
+  "f": "ж",
+  female: "ж",
+  жен: "ж",
+};
+
+type ClientCsvImportResult = {
+  clients: Omit<Client, "id">[];
+  errors: string[];
+  processed: number;
+  skipped: number;
+};
+
+const COMMENT_PREFIX = "#";
+
+const sanitizeKey = (value: string) => value.trim().toLowerCase().replace(/[\s_-]+/g, "");
+
+function normalizeEnumValue<T extends string>(value: string, map: Record<string, T>): T | null {
+  if (!value) {
+    return null;
+  }
+  const normalized = sanitizeKey(value);
+  if (normalized in map) {
+    return map[normalized];
+  }
+  return null;
+}
+
+function normalizeDate(value: string, allowEmpty = false): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return allowEmpty ? "" : null;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  const replaced = trimmed.replace(/[./]/g, "-");
+  const parts = replaced.split("-").map(part => part.trim());
+  if (parts.length === 3) {
+    if (parts[0].length === 4) {
+      const candidate = `${parts[0].padStart(4, "0")}-${parts[1].padStart(2, "0")}-${parts[2].padStart(2, "0")}`;
+      if (!Number.isNaN(new Date(candidate).getTime())) {
+        return candidate;
+      }
+    }
+    if (parts[2].length === 4) {
+      const candidate = `${parts[2].padStart(4, "0")}-${parts[1].padStart(2, "0")}-${parts[0].padStart(2, "0")}`;
+      if (!Number.isNaN(new Date(candidate).getTime())) {
+        return candidate;
+      }
+    }
+  }
+
+  const parsed = new Date(trimmed);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toISOString().slice(0, 10);
+  }
+
+  return null;
+}
+
+function normalizeNumberString(value: string): string {
+  return value.trim().replace(/\s+/g, "").replace(",", ".");
+}
+
+function normalizeIntString(value: string): string {
+  return value.trim().replace(/\s+/g, "");
+}
+
+function rowToRecord(headerMap: Map<ClientCsvColumn, number>, row: string[]): Record<ClientCsvColumn, string> {
+  return CLIENT_CSV_HEADERS.reduce<Record<ClientCsvColumn, string>>((acc, column) => {
+    const index = headerMap.get(column);
+    acc[column] = index != null && index < row.length ? row[index].trim() : "";
+    return acc;
+  }, {} as Record<ClientCsvColumn, string>);
+}
+
+function clientToRow(client: Client): (string | number | null | undefined)[] {
+  return [
+    client.firstName,
+    client.lastName ?? "",
+    client.parentName ?? "",
+    client.phone ?? "",
+    client.whatsApp ?? "",
+    client.telegram ?? "",
+    client.instagram ?? "",
+    client.channel,
+    client.birthDate ? client.birthDate.slice(0, 10) : "",
+    client.gender,
+    client.area,
+    client.group,
+    client.startDate ? client.startDate.slice(0, 10) : "",
+    client.payMethod,
+    client.payStatus,
+    client.status ?? "",
+    client.payDate ? client.payDate.slice(0, 10) : "",
+    client.payAmount != null ? client.payAmount : "",
+    client.remainingLessons != null ? client.remainingLessons : "",
+  ];
+}
+
+export function exportClientsToCsv(clients: Client[], filename?: string) {
+  const content = stringifyCsv([
+    [...CLIENT_CSV_HEADERS],
+    ...clients.map(clientToRow),
+  ]);
+  const targetName = filename ?? `clients-${todayISO().slice(0, 10)}.csv`;
+  downloadTextFile(targetName, content, "text/csv;charset=utf-8");
+}
+
+export function buildClientCsvTemplate(): string {
+  const commentRow = [
+    `${COMMENT_PREFIX} пример: заполните данные ниже, затем удалите эту строку`,
+    "Иванов",
+    "Мария Иванова",
+    "+7 999 123-45-67",
+    "",
+    "",
+    "",
+    "Telegram",
+    "2015-05-12",
+    "м",
+    "Центр",
+    "Младшая группа",
+    "2024-09-01",
+    "перевод",
+    "ожидание",
+    "новый",
+    "2024-09-10",
+    "12000",
+    "",
+  ];
+
+  return stringifyCsv([[...CLIENT_CSV_HEADERS], commentRow]);
+}
+
+export function downloadClientCsvTemplate(filename = "clients-template.csv") {
+  const content = buildClientCsvTemplate();
+  downloadTextFile(filename, content, "text/csv;charset=utf-8");
+}
+
+export function parseClientsCsv(text: string, db: DB): ClientCsvImportResult {
+  const rows = parseCsv(text);
+  if (!rows.length) {
+    return { clients: [], errors: ["Файл CSV пустой"], processed: 0, skipped: 0 };
+  }
+
+  const headerRow = rows[0];
+  const headerMap = new Map<ClientCsvColumn, number>();
+
+  headerRow.forEach((rawTitle, index) => {
+    const key = sanitizeKey(rawTitle);
+    const column = HEADER_ALIASES[key] ?? (CLIENT_CSV_HEADERS as readonly string[]).find(
+      header => sanitizeKey(header) === key,
+    );
+    if (column) {
+      if (!headerMap.has(column)) {
+        headerMap.set(column as ClientCsvColumn, index);
+      }
+    }
+  });
+
+  const missing = REQUIRED_COLUMNS.filter(column => !headerMap.has(column));
+  if (missing.length) {
+    return {
+      clients: [],
+      errors: [
+        `Отсутствуют обязательные колонки: ${missing
+          .map(column => `"${column}"`)
+          .join(", ")}. Используйте шаблон из настроек.`,
+      ],
+      processed: 0,
+      skipped: 0,
+    };
+  }
+
+  const errors: string[] = [];
+  const created: Omit<Client, "id">[] = [];
+  let processed = 0;
+
+  const areas = new Set<string>(db.settings.areas);
+  const groups = new Set<string>(db.settings.groups);
+  const defaultCoachId = db.staff.find(member => member.role === "Тренер")?.id;
+
+  for (let rowIndex = 1; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex];
+    const cells = headerRow.map((_, index) => (index < row.length ? row[index] : ""));
+    const trimmedCells = cells.map(cell => cell.trim());
+    const firstMeaningful = trimmedCells.find(cell => cell.length > 0);
+
+    if (!firstMeaningful) {
+      continue;
+    }
+
+    if (firstMeaningful.startsWith(COMMENT_PREFIX)) {
+      continue;
+    }
+
+    processed += 1;
+
+    const record = rowToRecord(headerMap, row);
+    const lineNumber = rowIndex + 1;
+    let hasError = false;
+
+    const firstName = record.firstName.trim();
+    if (!firstName) {
+      errors.push(`Строка ${lineNumber}: укажите firstName`);
+      hasError = true;
+    }
+
+    const channel = normalizeEnumValue(record.channel, CONTACT_CHANNEL_ALIASES);
+    if (!channel) {
+      errors.push(`Строка ${lineNumber}: неизвестный канал связи "${record.channel}"`);
+      hasError = true;
+    }
+
+    const gender = normalizeEnumValue(record.gender, GENDER_ALIASES);
+    if (!gender) {
+      errors.push(`Строка ${lineNumber}: некорректный пол "${record.gender}" (используйте м/ж)`);
+      hasError = true;
+    }
+
+    const area = record.area as Area;
+    if (!area) {
+      errors.push(`Строка ${lineNumber}: укажите area`);
+      hasError = true;
+    } else if (!areas.has(area)) {
+      errors.push(`Строка ${lineNumber}: неизвестная площадка "${area}"`);
+      hasError = true;
+    }
+
+    const group = record.group as Group;
+    if (!group) {
+      errors.push(`Строка ${lineNumber}: укажите group`);
+      hasError = true;
+    } else if (!groups.has(group)) {
+      errors.push(`Строка ${lineNumber}: неизвестная группа "${group}"`);
+      hasError = true;
+    }
+
+    const payMethod = normalizeEnumValue(record.payMethod, PAYMENT_METHOD_ALIASES);
+    if (!payMethod) {
+      errors.push(`Строка ${lineNumber}: неизвестный метод оплаты "${record.payMethod}"`);
+      hasError = true;
+    }
+
+    const payStatus = normalizeEnumValue(record.payStatus, PAYMENT_STATUS_ALIASES);
+    if (!payStatus) {
+      errors.push(`Строка ${lineNumber}: неизвестный статус оплаты "${record.payStatus}"`);
+      hasError = true;
+    }
+
+    const status = normalizeEnumValue(record.status, CLIENT_STATUS_ALIASES);
+    if (!status) {
+      errors.push(`Строка ${lineNumber}: неизвестный статус клиента "${record.status}"`);
+      hasError = true;
+    }
+
+    const birthDate = normalizeDate(record.birthDate);
+    if (!birthDate) {
+      errors.push(`Строка ${lineNumber}: неверный формат birthDate (ожидается ГГГГ-ММ-ДД)`);
+      hasError = true;
+    }
+
+    const startDate = normalizeDate(record.startDate);
+    if (!startDate) {
+      errors.push(`Строка ${lineNumber}: неверный формат startDate (ожидается ГГГГ-ММ-ДД)`);
+      hasError = true;
+    }
+
+    const payDate = normalizeDate(record.payDate, true);
+    if (record.payDate.trim() && !payDate) {
+      errors.push(`Строка ${lineNumber}: неверный формат payDate (ожидается ГГГГ-ММ-ДД)`);
+      hasError = true;
+    }
+
+    const payAmountRaw = normalizeNumberString(record.payAmount);
+    if (payAmountRaw) {
+      const parsedAmount = Number.parseFloat(payAmountRaw);
+      if (Number.isNaN(parsedAmount) || !Number.isFinite(parsedAmount)) {
+        errors.push(`Строка ${lineNumber}: неверное значение payAmount "${record.payAmount}"`);
+        hasError = true;
+      }
+    }
+
+    const remainingRaw = normalizeIntString(record.remainingLessons);
+    if (remainingRaw) {
+      const parsedRemaining = Number.parseInt(remainingRaw, 10);
+      if (Number.isNaN(parsedRemaining)) {
+        errors.push(
+          `Строка ${lineNumber}: неверное значение remainingLessons "${record.remainingLessons}"`,
+        );
+        hasError = true;
+      }
+    }
+
+    const contacts = [record.phone, record.whatsApp, record.telegram, record.instagram]
+      .map(contact => contact.trim())
+      .filter(Boolean);
+    if (contacts.length === 0) {
+      errors.push(`Строка ${lineNumber}: укажите хотя бы один контакт`);
+      hasError = true;
+    }
+
+    if (hasError) {
+      continue;
+    }
+
+    const formValues: ClientFormValues = {
+      firstName,
+      lastName: record.lastName,
+      parentName: record.parentName,
+      phone: record.phone,
+      whatsApp: record.whatsApp,
+      telegram: record.telegram,
+      instagram: record.instagram,
+      channel: channel!,
+      birthDate: birthDate!,
+      gender: gender!,
+      area,
+      group,
+      startDate: startDate!,
+      payMethod: payMethod!,
+      payStatus: payStatus!,
+      status: status!,
+      payDate: payDate ?? "",
+      payAmount: payAmountRaw,
+      remainingLessons: remainingRaw,
+    };
+
+    const prepared = transformClientFormValues(formValues, null);
+    const client: Omit<Client, "id"> = {
+      ...prepared,
+      coachId: prepared.coachId ?? defaultCoachId,
+    };
+    created.push(client);
+  }
+
+  return {
+    clients: created,
+    errors,
+    processed,
+    skipped: processed - created.length,
+  };
+}
+
+export function appendImportedClients(
+  db: DB,
+  imported: Omit<Client, "id">[],
+): { next: DB; changelogMessage: string } {
+  const newClients: Client[] = imported.map(client => ({ ...client, id: uid() }));
+  const next: DB = {
+    ...db,
+    clients: [...newClients, ...db.clients],
+    changelog: [
+      ...db.changelog,
+      {
+        id: uid(),
+        who: "UI",
+        what: `Импортировано клиентов из CSV: ${newClients.length}`,
+        when: todayISO(),
+      },
+    ],
+  };
+  return { next, changelogMessage: `Добавлено клиентов: ${newClients.length}` };
+}

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,84 @@
+export function stringifyCsv(rows: (string | number | null | undefined)[][]): string {
+  return rows
+    .map(row =>
+      row
+        .map(value => {
+          if (value == null) {
+            return "";
+          }
+          const text = String(value);
+          const needsQuotes = /[",\n\r]/.test(text);
+          const escaped = text.replace(/"/g, '""');
+          return needsQuotes ? `"${escaped}"` : escaped;
+        })
+        .join(","),
+    )
+    .join("\r\n");
+}
+
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentCell = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+
+    if (inQuotes) {
+      if (char === "\"") {
+        if (text[i + 1] === "\"") {
+          currentCell += "\"";
+          i += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        currentCell += char;
+      }
+      continue;
+    }
+
+    if (char === "\"") {
+      inQuotes = true;
+      continue;
+    }
+
+    if (char === ",") {
+      currentRow.push(currentCell);
+      currentCell = "";
+      continue;
+    }
+
+    if (char === "\n") {
+      currentRow.push(currentCell);
+      rows.push(currentRow);
+      currentRow = [];
+      currentCell = "";
+      continue;
+    }
+
+    if (char === "\r") {
+      if (text[i + 1] === "\n") {
+        currentRow.push(currentCell);
+        rows.push(currentRow);
+        currentRow = [];
+        currentCell = "";
+        i += 1;
+        continue;
+      }
+      currentRow.push(currentCell);
+      rows.push(currentRow);
+      currentRow = [];
+      currentCell = "";
+      continue;
+    }
+
+    currentCell += char;
+  }
+
+  currentRow.push(currentCell);
+  rows.push(currentRow);
+
+  return rows;
+}

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,0 +1,11 @@
+export function downloadTextFile(filename: string, content: string, mimeType = "text/plain;charset=utf-8") {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add CSV export and import controls to the Clients tab with validation and bulk creation
- provide CSV parsing/stringifying utilities and a download helper for reuse
- expose a downloadable CSV template in settings to guide bulk uploads

## Testing
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8fafd23e4832ba90dc7e8be95c668