### PR TITLE
Enable editing parent field in client form

### DIFF
--- a/src/components/clients/ClientForm.tsx
+++ b/src/components/clients/ClientForm.tsx
@@ -206,6 +206,10 @@ export default function ClientForm({ db, editing, onSave, onClose }: Props) {
             <input className={fieldClass} {...register("lastName")} />
           </div>
           <div className="flex flex-col gap-1">
+            <label className={labelClass}>Родитель</label>
+            <input className={fieldClass} {...register("parentName")} />
+          </div>
+          <div className="flex flex-col gap-1">
             <label className={labelClass}>Телефон</label>
             <input className={fieldClass} {...register("phone")} />
             {errors.phone && <span className="text-xs text-rose-600">{errors.phone.message}</span>}


### PR DESCRIPTION
## Summary
- allow the client edit modal to edit the parent field just like the create form

## Testing
- npm test -- --runTestsByPath src/components/__tests__/ClientsTab.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d934d52a80832bae3a0d3a1cca1013