### PR TITLE
Detect duplicate clients during creation and CSV import

### DIFF
--- a/src/components/clients/__tests__/clientCsv.test.ts
+++ b/src/components/clients/__tests__/clientCsv.test.ts
@@ -1,0 +1,145 @@
+import type { Client, DB } from '../../../types';
+
+jest.mock('../../../state/utils', () => ({
+  __esModule: true,
+  uid: jest.fn(),
+  todayISO: jest.fn(),
+}));
+
+import { appendImportedClients } from '../clientCsv';
+import { uid, todayISO } from '../../../state/utils';
+
+const asMock = <T extends (...args: any[]) => any>(fn: T) => fn as unknown as jest.MockedFunction<T>;
+
+const makeDB = (overrides: Partial<DB> = {}): DB => ({
+  clients: [],
+  attendance: [],
+  performance: [],
+  schedule: [],
+  leads: [],
+  leadsArchive: [],
+  leadHistory: [],
+  tasks: [],
+  tasksArchive: [],
+  staff: [{ id: 's1', role: 'Тренер', name: 'Coach', areas: ['Area1'], groups: ['Group1'] }],
+  settings: {
+    areas: ['Area1'],
+    groups: ['Group1'],
+    limits: {},
+    rentByAreaEUR: {},
+    coachSalaryByAreaEUR: {},
+    currencyRates: { EUR: 1, TRY: 1, RUB: 1 },
+    coachPayFormula: '',
+  },
+  changelog: [],
+  ...overrides,
+});
+
+const baseCandidate = (): Omit<Client, 'id'> => ({
+  firstName: 'Импорт',
+  lastName: '',
+  parentName: '',
+  phone: '',
+  whatsApp: '',
+  telegram: '',
+  instagram: '',
+  channel: 'Telegram',
+  birthDate: '2010-01-01T00:00:00.000Z',
+  gender: 'м',
+  area: 'Area1',
+  group: 'Group1',
+  coachId: 's1',
+  startDate: '2024-01-01T00:00:00.000Z',
+  payMethod: 'перевод',
+  payStatus: 'ожидание',
+  status: 'новый',
+  subscriptionPlan: 'monthly',
+  payDate: '2024-01-10T00:00:00.000Z',
+  payAmount: 100,
+  remainingLessons: 5,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  let counter = 0;
+  asMock(uid).mockImplementation(() => `uid-${++counter}`);
+  asMock(todayISO).mockReturnValue('2024-01-01T00:00:00.000Z');
+});
+
+describe('appendImportedClients', () => {
+  test('skips existing duplicates and merges imported duplicates', () => {
+    const existing: Client = {
+      id: 'c-existing',
+      firstName: 'Иван',
+      lastName: 'Иванов',
+      parentName: '',
+      phone: '+7 (900) 123-45-67',
+      whatsApp: '',
+      telegram: '',
+      instagram: '',
+      channel: 'Telegram',
+      birthDate: '2010-01-01T00:00:00.000Z',
+      gender: 'м',
+      area: 'Area1',
+      group: 'Group1',
+      coachId: 's1',
+      startDate: '2024-01-01T00:00:00.000Z',
+      payMethod: 'перевод',
+      payStatus: 'ожидание',
+      status: 'новый',
+      subscriptionPlan: 'monthly',
+      payDate: '2024-01-10T00:00:00.000Z',
+      payAmount: 120,
+      remainingLessons: 8,
+    };
+
+    const db = makeDB({ clients: [existing] });
+
+    const imported: Omit<Client, 'id'>[] = [
+      {
+        ...baseCandidate(),
+        firstName: 'Иван',
+        lastName: 'Иванов',
+        phone: '8 (900) 1234567',
+      },
+      {
+        ...baseCandidate(),
+        firstName: 'Пётр',
+        lastName: 'Сидоров',
+        telegram: '@petr',
+        payAmount: 150,
+      },
+      {
+        ...baseCandidate(),
+        firstName: 'Petr',
+        lastName: 'Sidorov',
+        telegram: 'https://t.me/petr',
+        instagram: 'https://instagram.com/petr',
+        payAmount: 160,
+      },
+    ];
+
+    const result = appendImportedClients(db, imported);
+
+    expect(result.summary).toMatchObject({ added: 1, skipped: 1, merged: 1 });
+    expect(result.next.clients).toHaveLength(db.clients.length + 1);
+
+    const newClient = result.next.clients[0];
+    expect(newClient.id).toBe('uid-1');
+    expect(newClient.firstName).toBe('Пётр');
+    expect(newClient.telegram).toBe('@petr');
+    expect(newClient.instagram).toBe('https://instagram.com/petr');
+
+    const existingDuplicate = result.summary.duplicates.find(entry => entry.type === 'existing');
+    expect(existingDuplicate?.client.id).toBe('c-existing');
+    expect(existingDuplicate?.matches.map(match => match.field)).toContain('phone');
+
+    const mergedDuplicate = result.summary.duplicates.find(entry => entry.type === 'imported');
+    expect(mergedDuplicate?.client.id).toBe(newClient.id);
+    expect(mergedDuplicate?.matches.map(match => match.field)).toContain('telegram');
+
+    expect(result.changelogMessage).toBe('Добавлено клиентов: 1');
+    expect(result.next.changelog).toHaveLength(1);
+    expect(result.next.changelog[0]).toMatchObject({ what: 'Импортировано клиентов из CSV: 1' });
+  });
+});

--- a/src/state/clients.ts
+++ b/src/state/clients.ts
@@ -1,0 +1,172 @@
+import type { Client, DB } from "../types";
+
+export type DuplicateField =
+  | "fullName"
+  | "parentName"
+  | "phone"
+  | "whatsApp"
+  | "telegram"
+  | "instagram";
+
+export type DuplicateMatchDetail = {
+  field: DuplicateField;
+  value: string;
+};
+
+export type ClientDuplicateMatch = {
+  client: Client;
+  matches: DuplicateMatchDetail[];
+};
+
+const CONTACT_FIELDS: Array<"phone" | "whatsApp" | "telegram" | "instagram"> = [
+  "phone",
+  "whatsApp",
+  "telegram",
+  "instagram",
+];
+
+type ComparableClient = Pick<
+  Client,
+  "firstName" | "lastName" | "parentName" | "phone" | "whatsApp" | "telegram" | "instagram"
+> &
+  Partial<Client>;
+
+type NormalizedClient = {
+  fullName: string;
+  parentName: string;
+  contacts: Record<(typeof CONTACT_FIELDS)[number], string>;
+};
+
+const normalizeWhitespace = (value: string): string => value.trim().replace(/\s+/g, " ").toLowerCase();
+
+const normalizeName = (value?: string): string => {
+  if (!value) return "";
+  return normalizeWhitespace(value);
+};
+
+const normalizeFullName = (client: ComparableClient): string => {
+  const first = normalizeName(client.firstName);
+  const last = normalizeName(client.lastName);
+  return `${first} ${last}`.trim();
+};
+
+const normalizeParentName = (client: ComparableClient): string => normalizeName(client.parentName);
+
+const normalizePhone = (value?: string): string => {
+  if (!value) return "";
+  const digits = value.replace(/\D+/g, "");
+  if (!digits) return "";
+  if (digits.length === 11 && digits.startsWith("8")) {
+    return `7${digits.slice(1)}`;
+  }
+  if (digits.length === 10) {
+    return `7${digits}`;
+  }
+  return digits;
+};
+
+const normalizeHandle = (value?: string): string => {
+  if (!value) return "";
+  let normalized = value.trim().toLowerCase();
+  normalized = normalized.replace(/^https?:\/\/(www\.)?t\.me\//, "");
+  normalized = normalized.replace(/^https?:\/\/(www\.)?telegram\.me\//, "");
+  normalized = normalized.replace(/^https?:\/\/(www\.)?instagram\.com\//, "");
+  normalized = normalized.replace(/^@+/, "");
+  normalized = normalized.replace(/\s+/g, "");
+  normalized = normalized.replace(/\/+$/, "");
+  return normalized;
+};
+
+const normalizeContacts = (client: ComparableClient): Record<(typeof CONTACT_FIELDS)[number], string> => ({
+  phone: normalizePhone(client.phone),
+  whatsApp: normalizePhone(client.whatsApp),
+  telegram: normalizeHandle(client.telegram),
+  instagram: normalizeHandle(client.instagram),
+});
+
+const getNormalizedClient = (client: ComparableClient): NormalizedClient => ({
+  fullName: normalizeFullName(client),
+  parentName: normalizeParentName(client),
+  contacts: normalizeContacts(client),
+});
+
+const formatClientName = (client: ComparableClient): string => {
+  const lastName = client.lastName?.trim();
+  return [client.firstName.trim(), lastName].filter(Boolean).join(" ");
+};
+
+const duplicateFieldValue = (client: ComparableClient, field: DuplicateField): string => {
+  switch (field) {
+    case "fullName":
+      return formatClientName(client);
+    case "parentName":
+      return client.parentName?.trim() ?? "";
+    case "phone":
+    case "whatsApp":
+    case "telegram":
+    case "instagram":
+      return client[field]?.trim() ?? "";
+    default:
+      return "";
+  }
+};
+
+export function findClientDuplicates(
+  db: DB,
+  candidate: ComparableClient,
+  options: { excludeId?: string | null } = {},
+): ClientDuplicateMatch[] {
+  const matches: ClientDuplicateMatch[] = [];
+  const normalizedCandidate = getNormalizedClient(candidate);
+  const seen = new Set<string>();
+
+  for (const client of db.clients) {
+    if (options.excludeId && client.id === options.excludeId) {
+      continue;
+    }
+
+    const normalizedExisting = getNormalizedClient(client);
+    const details: DuplicateMatchDetail[] = [];
+
+    if (
+      normalizedCandidate.fullName &&
+      normalizedCandidate.fullName === normalizedExisting.fullName
+    ) {
+      details.push({ field: "fullName", value: formatClientName(client) });
+    }
+
+    if (
+      normalizedCandidate.parentName &&
+      normalizedCandidate.parentName === normalizedExisting.parentName
+    ) {
+      details.push({ field: "parentName", value: duplicateFieldValue(client, "parentName") });
+    }
+
+    for (const candidateField of CONTACT_FIELDS) {
+      const candidateValue = normalizedCandidate.contacts[candidateField];
+      if (!candidateValue) continue;
+
+      for (const existingField of CONTACT_FIELDS) {
+        const existingValue = normalizedExisting.contacts[existingField];
+        if (!existingValue) continue;
+        if (candidateValue !== existingValue) continue;
+
+        const key = `${client.id}:${existingField}`;
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+
+        const value =
+          duplicateFieldValue(client, existingField) || duplicateFieldValue(candidate, candidateField);
+        details.push({ field: existingField, value });
+      }
+    }
+
+    if (details.length) {
+      matches.push({ client, matches: details });
+    }
+  }
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- add a shared duplicate detection utility and use it when creating clients via the UI
- extend CSV import to reuse duplicate matching, merging duplicate rows and reporting statistics
- cover duplicate scenarios with ClientsTab and CSV import unit tests

## Testing
- CI=1 npm test -- --runTestsByPath src/components/__tests__/ClientsTab.test.tsx src/components/clients/__tests__/clientCsv.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de5b592a58832b91d8dd6071a09e05