### PR TITLE
Fix TypeScript typing for imported client merge helper

### DIFF
--- a/src/components/clients/__tests__/clientCsv.test.ts
+++ b/src/components/clients/__tests__/clientCsv.test.ts
@@ -1,0 +1,145 @@
+import type { Client, DB } from '../../../types';
+
+jest.mock('../../../state/utils', () => ({
+  __esModule: true,
+  uid: jest.fn(),
+  todayISO: jest.fn(),
+}));
+
+import { appendImportedClients } from '../clientCsv';
+import { uid, todayISO } from '../../../state/utils';
+
+const asMock = <T extends (...args: any[]) => any>(fn: T) => fn as unknown as jest.MockedFunction<T>;
+
+const makeDB = (overrides: Partial<DB> = {}): DB => ({
+  clients: [],
+  attendance: [],
+  performance: [],
+  schedule: [],
+  leads: [],
+  leadsArchive: [],
+  leadHistory: [],
+  tasks: [],
+  tasksArchive: [],
+  staff: [{ id: 's1', role: 'Тренер', name: 'Coach', areas: ['Area1'], groups: ['Group1'] }],
+  settings: {
+    areas: ['Area1'],
+    groups: ['Group1'],
+    limits: {},
+    rentByAreaEUR: {},
+    coachSalaryByAreaEUR: {},
+    currencyRates: { EUR: 1, TRY: 1, RUB: 1 },
+    coachPayFormula: '',
+  },
+  changelog: [],
+  ...overrides,
+});
+
+const baseCandidate = (): Omit<Client, 'id'> => ({
+  firstName: 'Импорт',
+  lastName: '',
+  parentName: '',
+  phone: '',
+  whatsApp: '',
+  telegram: '',
+  instagram: '',
+  channel: 'Telegram',
+  birthDate: '2010-01-01T00:00:00.000Z',
+  gender: 'м',
+  area: 'Area1',
+  group: 'Group1',
+  coachId: 's1',
+  startDate: '2024-01-01T00:00:00.000Z',
+  payMethod: 'перевод',
+  payStatus: 'ожидание',
+  status: 'новый',
+  subscriptionPlan: 'monthly',
+  payDate: '2024-01-10T00:00:00.000Z',
+  payAmount: 100,
+  remainingLessons: 5,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  let counter = 0;
+  asMock(uid).mockImplementation(() => `uid-${++counter}`);
+  asMock(todayISO).mockReturnValue('2024-01-01T00:00:00.000Z');
+});
+
+describe('appendImportedClients', () => {
+  test('skips existing duplicates and merges imported duplicates', () => {
+    const existing: Client = {
+      id: 'c-existing',
+      firstName: 'Иван',
+      lastName: 'Иванов',
+      parentName: '',
+      phone: '+7 (900) 123-45-67',
+      whatsApp: '',
+      telegram: '',
+      instagram: '',
+      channel: 'Telegram',
+      birthDate: '2010-01-01T00:00:00.000Z',
+      gender: 'м',
+      area: 'Area1',
+      group: 'Group1',
+      coachId: 's1',
+      startDate: '2024-01-01T00:00:00.000Z',
+      payMethod: 'перевод',
+      payStatus: 'ожидание',
+      status: 'новый',
+      subscriptionPlan: 'monthly',
+      payDate: '2024-01-10T00:00:00.000Z',
+      payAmount: 120,
+      remainingLessons: 8,
+    };
+
+    const db = makeDB({ clients: [existing] });
+
+    const imported: Omit<Client, 'id'>[] = [
+      {
+        ...baseCandidate(),
+        firstName: 'Иван',
+        lastName: 'Иванов',
+        phone: '8 (900) 1234567',
+      },
+      {
+        ...baseCandidate(),
+        firstName: 'Пётр',
+        lastName: 'Сидоров',
+        telegram: '@petr',
+        payAmount: 150,
+      },
+      {
+        ...baseCandidate(),
+        firstName: 'Petr',
+        lastName: 'Sidorov',
+        telegram: 'https://t.me/petr',
+        instagram: 'https://instagram.com/petr',
+        payAmount: 160,
+      },
+    ];
+
+    const result = appendImportedClients(db, imported);
+
+    expect(result.summary).toMatchObject({ added: 1, skipped: 1, merged: 1 });
+    expect(result.next.clients).toHaveLength(db.clients.length + 1);
+
+    const newClient = result.next.clients[0];
+    expect(newClient.id).toBe('uid-1');
+    expect(newClient.firstName).toBe('Пётр');
+    expect(newClient.telegram).toBe('@petr');
+    expect(newClient.instagram).toBe('https://instagram.com/petr');
+
+    const existingDuplicate = result.summary.duplicates.find(entry => entry.type === 'existing');
+    expect(existingDuplicate?.client.id).toBe('c-existing');
+    expect(existingDuplicate?.matches.map(match => match.field)).toContain('phone');
+
+    const mergedDuplicate = result.summary.duplicates.find(entry => entry.type === 'imported');
+    expect(mergedDuplicate?.client.id).toBe(newClient.id);
+    expect(mergedDuplicate?.matches.map(match => match.field)).toContain('telegram');
+
+    expect(result.changelogMessage).toBe('Добавлено клиентов: 1');
+    expect(result.next.changelog).toHaveLength(1);
+    expect(result.next.changelog[0]).toMatchObject({ what: 'Импортировано клиентов из CSV: 1' });
+  });
+});

--- a/src/components/clients/clientCsv.ts
+++ b/src/components/clients/clientCsv.ts
@@ -2,6 +2,7 @@ import { parseCsv, stringifyCsv } from "../../utils/csv";
 import { downloadTextFile } from "../../utils/download";
 import { transformClientFormValues } from "./clientMutations";
 import { todayISO, uid } from "../../state/utils";
+import { findClientDuplicates, type DuplicateMatchDetail } from "../../state/clients";
 import type {
   Area,
   Client,
@@ -173,6 +174,19 @@ type ClientCsvImportResult = {
   errors: string[];
   processed: number;
   skipped: number;
+};
+
+export type DuplicateSummaryEntry = {
+  type: "existing" | "imported";
+  client: Client;
+  matches: DuplicateMatchDetail[];
+};
+
+export type AppendImportedClientsSummary = {
+  added: number;
+  skipped: number;
+  merged: number;
+  duplicates: DuplicateSummaryEntry[];
 };
 
 const COMMENT_PREFIX = "#";
@@ -542,23 +556,86 @@ export function parseClientsCsv(text: string, db: DB): ClientCsvImportResult {
   };
 }
 
+const MERGEABLE_FIELDS = [
+  "lastName",
+  "parentName",
+  "phone",
+  "whatsApp",
+  "telegram",
+  "instagram",
+  "coachId",
+] as const satisfies ReadonlyArray<keyof Omit<Client, "id">>;
+
+type MergeableField = (typeof MERGEABLE_FIELDS)[number];
+
+function mergeClientData(target: Client, source: Omit<Client, "id">) {
+  for (const field of MERGEABLE_FIELDS) {
+    const current = target[field];
+    const incoming = source[field];
+    if ((current == null || current === "") && incoming) {
+      target[field] = incoming as Client[MergeableField];
+    }
+  }
+}
+
 export function appendImportedClients(
   db: DB,
   imported: Omit<Client, "id">[],
-): { next: DB; changelogMessage: string } {
-  const newClients: Client[] = imported.map(client => ({ ...client, id: uid() }));
-  const next: DB = {
-    ...db,
-    clients: [...newClients, ...db.clients],
-    changelog: [
+): { next: DB; changelogMessage: string; summary: AppendImportedClientsSummary } {
+  const accepted: Client[] = [];
+  const summary: AppendImportedClientsSummary = {
+    added: 0,
+    skipped: 0,
+    merged: 0,
+    duplicates: [],
+  };
+
+  for (const candidate of imported) {
+    const matches = findClientDuplicates({ ...db, clients: [...db.clients, ...accepted] }, candidate);
+
+    if (!matches.length) {
+      const client: Client = { ...candidate, id: uid() };
+      accepted.push(client);
+      continue;
+    }
+
+    const matchWithAccepted = matches.find(match => accepted.some(client => client.id === match.client.id));
+
+    if (matchWithAccepted) {
+      const target = accepted.find(client => client.id === matchWithAccepted.client.id);
+      if (target) {
+        mergeClientData(target, candidate);
+        summary.merged += 1;
+        summary.duplicates.push({ type: "imported", client: target, matches: matchWithAccepted.matches });
+      }
+      continue;
+    }
+
+    summary.skipped += 1;
+    const primaryMatch = matches[0];
+    summary.duplicates.push({ type: "existing", client: primaryMatch.client, matches: primaryMatch.matches });
+  }
+
+  summary.added = accepted.length;
+
+  let nextChangelog = db.changelog;
+  if (summary.added > 0) {
+    nextChangelog = [
       ...db.changelog,
       {
         id: uid(),
         who: "UI",
-        what: `Импортировано клиентов из CSV: ${newClients.length}`,
+        what: `Импортировано клиентов из CSV: ${summary.added}`,
         when: todayISO(),
       },
-    ],
+    ];
+  }
+
+  const next: DB = {
+    ...db,
+    clients: [...accepted, ...db.clients],
+    changelog: nextChangelog,
   };
-  return { next, changelogMessage: `Добавлено клиентов: ${newClients.length}` };
+
+  return { next, changelogMessage: `Добавлено клиентов: ${summary.added}`, summary };
 }

--- a/src/state/clients.ts
+++ b/src/state/clients.ts
@@ -1,0 +1,172 @@
+import type { Client, DB } from "../types";
+
+export type DuplicateField =
+  | "fullName"
+  | "parentName"
+  | "phone"
+  | "whatsApp"
+  | "telegram"
+  | "instagram";
+
+export type DuplicateMatchDetail = {
+  field: DuplicateField;
+  value: string;
+};
+
+export type ClientDuplicateMatch = {
+  client: Client;
+  matches: DuplicateMatchDetail[];
+};
+
+const CONTACT_FIELDS: Array<"phone" | "whatsApp" | "telegram" | "instagram"> = [
+  "phone",
+  "whatsApp",
+  "telegram",
+  "instagram",
+];
+
+type ComparableClient = Pick<
+  Client,
+  "firstName" | "lastName" | "parentName" | "phone" | "whatsApp" | "telegram" | "instagram"
+> &
+  Partial<Client>;
+
+type NormalizedClient = {
+  fullName: string;
+  parentName: string;
+  contacts: Record<(typeof CONTACT_FIELDS)[number], string>;
+};
+
+const normalizeWhitespace = (value: string): string => value.trim().replace(/\s+/g, " ").toLowerCase();
+
+const normalizeName = (value?: string): string => {
+  if (!value) return "";
+  return normalizeWhitespace(value);
+};
+
+const normalizeFullName = (client: ComparableClient): string => {
+  const first = normalizeName(client.firstName);
+  const last = normalizeName(client.lastName);
+  return `${first} ${last}`.trim();
+};
+
+const normalizeParentName = (client: ComparableClient): string => normalizeName(client.parentName);
+
+const normalizePhone = (value?: string): string => {
+  if (!value) return "";
+  const digits = value.replace(/\D+/g, "");
+  if (!digits) return "";
+  if (digits.length === 11 && digits.startsWith("8")) {
+    return `7${digits.slice(1)}`;
+  }
+  if (digits.length === 10) {
+    return `7${digits}`;
+  }
+  return digits;
+};
+
+const normalizeHandle = (value?: string): string => {
+  if (!value) return "";
+  let normalized = value.trim().toLowerCase();
+  normalized = normalized.replace(/^https?:\/\/(www\.)?t\.me\//, "");
+  normalized = normalized.replace(/^https?:\/\/(www\.)?telegram\.me\//, "");
+  normalized = normalized.replace(/^https?:\/\/(www\.)?instagram\.com\//, "");
+  normalized = normalized.replace(/^@+/, "");
+  normalized = normalized.replace(/\s+/g, "");
+  normalized = normalized.replace(/\/+$/, "");
+  return normalized;
+};
+
+const normalizeContacts = (client: ComparableClient): Record<(typeof CONTACT_FIELDS)[number], string> => ({
+  phone: normalizePhone(client.phone),
+  whatsApp: normalizePhone(client.whatsApp),
+  telegram: normalizeHandle(client.telegram),
+  instagram: normalizeHandle(client.instagram),
+});
+
+const getNormalizedClient = (client: ComparableClient): NormalizedClient => ({
+  fullName: normalizeFullName(client),
+  parentName: normalizeParentName(client),
+  contacts: normalizeContacts(client),
+});
+
+const formatClientName = (client: ComparableClient): string => {
+  const lastName = client.lastName?.trim();
+  return [client.firstName.trim(), lastName].filter(Boolean).join(" ");
+};
+
+const duplicateFieldValue = (client: ComparableClient, field: DuplicateField): string => {
+  switch (field) {
+    case "fullName":
+      return formatClientName(client);
+    case "parentName":
+      return client.parentName?.trim() ?? "";
+    case "phone":
+    case "whatsApp":
+    case "telegram":
+    case "instagram":
+      return client[field]?.trim() ?? "";
+    default:
+      return "";
+  }
+};
+
+export function findClientDuplicates(
+  db: DB,
+  candidate: ComparableClient,
+  options: { excludeId?: string | null } = {},
+): ClientDuplicateMatch[] {
+  const matches: ClientDuplicateMatch[] = [];
+  const normalizedCandidate = getNormalizedClient(candidate);
+  const seen = new Set<string>();
+
+  for (const client of db.clients) {
+    if (options.excludeId && client.id === options.excludeId) {
+      continue;
+    }
+
+    const normalizedExisting = getNormalizedClient(client);
+    const details: DuplicateMatchDetail[] = [];
+
+    if (
+      normalizedCandidate.fullName &&
+      normalizedCandidate.fullName === normalizedExisting.fullName
+    ) {
+      details.push({ field: "fullName", value: formatClientName(client) });
+    }
+
+    if (
+      normalizedCandidate.parentName &&
+      normalizedCandidate.parentName === normalizedExisting.parentName
+    ) {
+      details.push({ field: "parentName", value: duplicateFieldValue(client, "parentName") });
+    }
+
+    for (const candidateField of CONTACT_FIELDS) {
+      const candidateValue = normalizedCandidate.contacts[candidateField];
+      if (!candidateValue) continue;
+
+      for (const existingField of CONTACT_FIELDS) {
+        const existingValue = normalizedExisting.contacts[existingField];
+        if (!existingValue) continue;
+        if (candidateValue !== existingValue) continue;
+
+        const key = `${client.id}:${existingField}`;
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+
+        const value =
+          duplicateFieldValue(client, existingField) || duplicateFieldValue(candidate, candidateField);
+        details.push({ field: existingField, value });
+      }
+    }
+
+    if (details.length) {
+      matches.push({ client, matches: details });
+    }
+  }
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- preserve the literal field types for the mergeable client keys used during CSV imports
- adjust the merge helper assignment so TypeScript accepts the imported values when building the app

## Testing
- CI=1 npm test -- --runTestsByPath src/components/__tests__/ClientsTab.test.tsx src/components/clients/__tests__/clientCsv.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de5b592a58832b91d8dd6071a09e05