### PR TITLE
Adjust client table layout for long names

### DIFF
--- a/src/components/VirtualizedTable.tsx
+++ b/src/components/VirtualizedTable.tsx
@@ -193,7 +193,7 @@ export default function VirtualizedTable<T>({
             ref={node => {
               tableRef.current = node;
             }}
-            className="w-full text-sm"
+            className="w-full min-w-[1200px] text-sm"
           >
             {header}
             {children}
@@ -252,7 +252,7 @@ export default function VirtualizedTable<T>({
               ref={node => {
                 tableRef.current = node;
               }}
-              className="w-full text-sm"
+              className="w-full min-w-[1200px] text-sm"
             >
               {header}
               <tbody>{items.map(item => renderRow(item, {}))}</tbody>

--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -71,9 +71,9 @@ export default function ClientTable({
     {
       id: "name",
       label: "Имя",
-      width: "minmax(160px, max-content)",
+      width: "minmax(220px, 2fr)",
       renderCell: client => (
-        <span className="font-medium text-slate-800 transition-colors duration-150 group-hover:text-sky-600 dark:text-slate-100 dark:group-hover:text-sky-300">
+        <span className="block max-w-full break-words font-medium text-slate-800 transition-colors duration-150 group-hover:text-sky-600 dark:text-slate-100 dark:group-hover:text-sky-300">
           {client.firstName} {client.lastName}
         </span>
       ),


### PR DESCRIPTION
## Summary
- widen the client name column and allow long names to wrap without shifting the layout
- give the virtualized table a minimum width so the listing stays wide by default

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68de7c06eeec832b840d4f22a86f0929