### PR TITLE
Add automatic status promotions for paying clients

### DIFF
--- a/src/components/clients/clientMutations.ts
+++ b/src/components/clients/clientMutations.ts
@@ -5,7 +5,7 @@ import {
   subscriptionPlanAllowsCustomAmount,
   subscriptionPlanRequiresManualRemainingLessons,
 } from "../../state/payments";
-import { parseDateInput } from "../../state/utils";
+import { parseDateInput, todayISO } from "../../state/utils";
 import { requiresManualRemainingLessons } from "../../state/lessons";
 import type { Client, ClientFormValues, Group, SubscriptionPlan } from "../../types";
 
@@ -68,6 +68,9 @@ export function transformClientFormValues(
     }
   }
 
+  const statusChanged = !editing || editing.status !== base.status;
+  const statusUpdatedAt = statusChanged ? todayISO() : editing?.statusUpdatedAt;
+
   return {
     ...base,
     subscriptionPlan,
@@ -79,6 +82,7 @@ export function transformClientFormValues(
     ...(instagram.trim() ? { instagram: instagram.trim() } : {}),
     ...(resolvedPayAmount != null ? { payAmount: resolvedPayAmount } : {}),
     ...(resolvedRemaining != null ? { remainingLessons: resolvedRemaining } : {}),
+    ...(statusUpdatedAt ? { statusUpdatedAt } : {}),
     birthDate: parseDateInput(data.birthDate),
     startDate: parseDateInput(data.startDate),
     payDate: parseDateInput(data.payDate),

--- a/src/state/clientLifecycle.ts
+++ b/src/state/clientLifecycle.ts
@@ -1,0 +1,78 @@
+import type { Client, ClientStatus } from "../types";
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+function parseISODate(value?: string | null): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date;
+}
+
+function getStatusAnchor(client: Client): Date | null {
+  const candidates: Array<string | undefined> = [];
+  if (client.statusUpdatedAt) {
+    candidates.push(client.statusUpdatedAt);
+  }
+  if (!client.statusUpdatedAt && client.startDate) {
+    candidates.push(client.startDate);
+  }
+  for (const candidate of candidates) {
+    const parsed = parseISODate(candidate);
+    if (parsed) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+const PROMOTION_RULES: Array<{ statuses: ClientStatus[]; next: ClientStatus }> = [
+  { statuses: ["новый"], next: "продлившийся" },
+  { statuses: ["продлившийся", "вернувшийся"], next: "действующий" },
+];
+
+export function applyClientStatusAutoTransition(client: Client): Client {
+  if (client.payStatus !== "действует") {
+    return client;
+  }
+
+  const rule = PROMOTION_RULES.find(entry => entry.statuses.includes(client.status));
+  if (!rule) {
+    return client;
+  }
+
+  const payDate = parseISODate(client.payDate);
+  if (!payDate) {
+    return client;
+  }
+
+  const statusSince = getStatusAnchor(client);
+  if (!statusSince) {
+    return client;
+  }
+
+  if (payDate.getTime() <= statusSince.getTime()) {
+    return client;
+  }
+
+  const daysBetween = Math.floor((payDate.getTime() - statusSince.getTime()) / DAY_IN_MS);
+  if (daysBetween <= 30) {
+    return client;
+  }
+
+  if (client.status === rule.next) {
+    return client;
+  }
+
+  return {
+    ...client,
+    status: rule.next,
+    statusUpdatedAt: payDate.toISOString(),
+  };
+}
+
+export function applyClientStatusAutoTransitions(clients: Client[]): Client[] {
+  return clients.map(applyClientStatusAutoTransition);
+}

--- a/src/state/payments.ts
+++ b/src/state/payments.ts
@@ -1,4 +1,5 @@
 import type { Client, PaymentStatus, SubscriptionPlan, TaskItem } from "../types";
+import { applyClientStatusAutoTransition } from "./clientLifecycle";
 
 export const SUBSCRIPTION_PLANS: { value: SubscriptionPlan; label: string; amount: number | null }[] = [
   { value: "monthly", label: "Месячный абонемент", amount: 55 },
@@ -78,9 +79,8 @@ export function derivePaymentStatus(client: Client, tasks: TaskItem[]): PaymentS
 export function applyPaymentStatusRules(clients: Client[], tasks: TaskItem[]): Client[] {
   return clients.map(client => {
     const nextStatus = derivePaymentStatus(client, tasks);
-    if (client.payStatus === nextStatus) {
-      return client;
-    }
-    return { ...client, payStatus: nextStatus };
+    const withPayStatus =
+      client.payStatus === nextStatus ? client : { ...client, payStatus: nextStatus };
+    return applyClientStatusAutoTransition(withPayStatus);
   });
 }

--- a/src/state/seed.ts
+++ b/src/state/seed.ts
@@ -119,6 +119,7 @@ export function makeSeedDB(): DB {
       payMethod: "перевод",
       payStatus: "действует",
       status: "действующий",
+      statusUpdatedAt: start.toISOString(),
       subscriptionPlan,
       payDate: start.toISOString(),
       payAmount: planMeta?.amount ?? rnd(50, 100),

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface Client {
   payMethod: PaymentMethod;
   payStatus: PaymentStatus;
   status: ClientStatus;
+  statusUpdatedAt?: string; // ISO
   subscriptionPlan?: SubscriptionPlan;
   payDate?: string; // ISO
   payAmount?: number;


### PR DESCRIPTION
## Summary
- add lifecycle helper that promotes clients from "новый" to "продлившийся" and then to "действующий" after timely payments
- capture and persist status change timestamps when editing, exporting, or importing clients
- trigger automatic promotions when saving client cards and when recalculating payment statuses

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68de7e83a130832b999ede2e2ce984c2