### PR TITLE
Persist table column settings across tabs

### DIFF
--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import VirtualizedTable from "./VirtualizedTable";
 import ClientDetailsModal from "./clients/ClientDetailsModal";
 import ClientForm from "./clients/ClientForm";
 import ColumnSettings from "./ColumnSettings";
-import { compareValues, toggleSort, type SortState } from "./tableUtils";
+import { compareValues, toggleSort } from "./tableUtils";
 import { fmtDate, todayISO, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
 import { buildGroupsByArea } from "../state/lessons";
@@ -25,10 +25,13 @@ import {
   collectAvailableYears,
   formatMonthInput,
   getDefaultPeriod,
-  isClientInPeriod,
   isPerformanceInPeriod,
   type PeriodFilter,
 } from "../state/period";
+import { usePersistentTableSettings } from "../utils/tableSettings";
+
+const DEFAULT_VISIBLE_COLUMNS = ["name", "area", "group", "mark"];
+const TABLE_SETTINGS_KEY = "performance";
 
 export default function PerformanceTab({
   db,
@@ -43,8 +46,6 @@ export default function PerformanceTab({
   const [group, setGroup] = useState<Group | null>(null);
   const [selected, setSelected] = useState<Client | null>(null);
   const [editing, setEditing] = useState<Client | null>(null);
-  const [visibleColumns, setVisibleColumns] = useState<string[]>(["name", "area", "group", "mark"]);
-  const [sort, setSort] = useState<SortState | null>(null);
   const persistedPeriod = useMemo(() => readDailyPeriod("performance"), []);
   const [period, setPeriod] = useState<PeriodFilter>(() => {
     const fallback = getDefaultPeriod();
@@ -130,7 +131,7 @@ export default function PerformanceTab({
     setPeriod(prev => ({ year: nextYear, month: prev.month }));
   };
 
-  const toggle = async (clientId: string) => {
+  const toggle = useCallback(async (clientId: string) => {
     const mark = todayMarks.get(clientId);
     if (mark) {
       const updated = { ...mark, successful: !mark.successful };
@@ -155,7 +156,7 @@ export default function PerformanceTab({
         window.alert("Не удалось сохранить отметку успеваемости. Проверьте доступ к базе данных.");
       }
     }
-  };
+  }, [db, setDB, todayMarks]);
 
   const columns: ColumnConfig[] = useMemo(() => {
     return [
@@ -216,7 +217,14 @@ export default function PerformanceTab({
         },
       },
     ];
-  }, [todayMarks]);
+  }, [todayMarks, toggle]);
+
+  const columnIds = useMemo(() => columns.map(column => column.id), [columns]);
+  const { visibleColumns, setVisibleColumns, sort, setSort } = usePersistentTableSettings(
+    TABLE_SETTINGS_KEY,
+    columnIds,
+    DEFAULT_VISIBLE_COLUMNS,
+  );
 
   const activeColumns = useMemo(
     () => columns.filter(column => visibleColumns.includes(column.id)),

--- a/src/utils/tableSettings.ts
+++ b/src/utils/tableSettings.ts
@@ -1,0 +1,196 @@
+import { useEffect, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import type { SortState } from "../components/tableUtils";
+
+const STORAGE_PREFIX = "judo_crm_table_";
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage ?? null;
+  } catch (err) {
+    console.warn("Local storage is not available", err);
+    return null;
+  }
+}
+
+function buildColumnsKey(key: string): string {
+  return `${STORAGE_PREFIX}${key}_columns`;
+}
+
+function buildSortKey(key: string): string {
+  return `${STORAGE_PREFIX}${key}_sort`;
+}
+
+function sanitizeVisibleColumns(
+  value: unknown,
+  available: string[],
+  fallback: string[],
+): string[] {
+  const ensureFallback = () => {
+    const cleanedFallback: string[] = [];
+    for (const id of fallback) {
+      if (typeof id !== "string") continue;
+      if (!available.includes(id)) continue;
+      if (cleanedFallback.includes(id)) continue;
+      cleanedFallback.push(id);
+    }
+    if (cleanedFallback.length > 0) {
+      return cleanedFallback;
+    }
+    return [...available];
+  };
+
+  if (!Array.isArray(value)) {
+    return ensureFallback();
+  }
+  const cleaned: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    if (!available.includes(item)) continue;
+    if (cleaned.includes(item)) continue;
+    cleaned.push(item);
+  }
+  if (cleaned.length === 0) {
+    return ensureFallback();
+  }
+  return cleaned;
+}
+
+function sanitizeSort(value: unknown, available: string[]): SortState | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const raw = value as Partial<Record<keyof SortState, unknown>>;
+  const columnId = typeof raw.columnId === "string" ? raw.columnId : null;
+  const direction = raw.direction === "asc" || raw.direction === "desc" ? raw.direction : null;
+  if (!columnId || !direction) {
+    return null;
+  }
+  if (!available.includes(columnId)) {
+    return null;
+  }
+  return { columnId, direction };
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}
+
+function sortEqual(a: SortState | null, b: SortState | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.columnId === b.columnId && a.direction === b.direction;
+}
+
+function readVisibleColumns(key: string, available: string[], fallback: string[]): string[] {
+  const storage = getStorage();
+  const safeFallback = sanitizeVisibleColumns(fallback, available, fallback);
+  if (!storage) {
+    return safeFallback;
+  }
+  try {
+    const raw = storage.getItem(buildColumnsKey(key));
+    if (!raw) {
+      return safeFallback;
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    return sanitizeVisibleColumns(parsed, available, safeFallback);
+  } catch (err) {
+    console.warn("Failed to read persisted table columns", err);
+    return safeFallback;
+  }
+}
+
+function persistVisibleColumns(key: string, columns: string[]): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(buildColumnsKey(key), JSON.stringify(columns));
+  } catch (err) {
+    console.warn("Failed to persist table columns", err);
+  }
+}
+
+function readSortState(key: string, available: string[], fallback: SortState | null): SortState | null {
+  const storage = getStorage();
+  const safeFallback = fallback ? sanitizeSort(fallback, available) : null;
+  if (!storage) {
+    return safeFallback ?? null;
+  }
+  try {
+    const raw = storage.getItem(buildSortKey(key));
+    if (!raw) {
+      return safeFallback ?? null;
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    return sanitizeSort(parsed, available) ?? safeFallback ?? null;
+  } catch (err) {
+    console.warn("Failed to read persisted table sort", err);
+    return safeFallback ?? null;
+  }
+}
+
+function persistSortState(key: string, sort: SortState | null): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    if (!sort) {
+      storage.removeItem(buildSortKey(key));
+      return;
+    }
+    storage.setItem(buildSortKey(key), JSON.stringify(sort));
+  } catch (err) {
+    console.warn("Failed to persist table sort", err);
+  }
+}
+
+export function usePersistentTableSettings(
+  key: string,
+  availableColumns: string[],
+  defaultVisibleColumns: string[],
+  defaultSort: SortState | null = null,
+): {
+  visibleColumns: string[];
+  setVisibleColumns: Dispatch<SetStateAction<string[]>>;
+  sort: SortState | null;
+  setSort: Dispatch<SetStateAction<SortState | null>>;
+} {
+  const [visibleColumns, setVisibleColumns] = useState<string[]>(() =>
+    readVisibleColumns(key, availableColumns, defaultVisibleColumns),
+  );
+  const [sort, setSort] = useState<SortState | null>(() =>
+    readSortState(key, availableColumns, defaultSort),
+  );
+
+  useEffect(() => {
+    setVisibleColumns(prev => {
+      const next = sanitizeVisibleColumns(prev, availableColumns, defaultVisibleColumns);
+      return arraysEqual(prev, next) ? prev : next;
+    });
+  }, [availableColumns, defaultVisibleColumns]);
+
+  useEffect(() => {
+    setSort(prev => {
+      const next = sanitizeSort(prev, availableColumns);
+      if (sortEqual(prev, next ?? null)) {
+        return prev;
+      }
+      return next ?? (defaultSort ? sanitizeSort(defaultSort, availableColumns) : null);
+    });
+  }, [availableColumns, defaultSort]);
+
+  useEffect(() => {
+    persistVisibleColumns(key, visibleColumns);
+  }, [key, visibleColumns]);
+
+  useEffect(() => {
+    persistSortState(key, sort);
+  }, [key, sort]);
+
+  return { visibleColumns, setVisibleColumns, sort, setSort };
+}


### PR DESCRIPTION
## Summary
- add a reusable `usePersistentTableSettings` hook that stores column visibility and sort preferences in localStorage
- wire the attendance, performance, and client tables to load and persist their column/sort settings via the new hook
- stabilize table action handlers with `useCallback` so the persisted settings stay consistent across renders

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7f8d67f0832ba9b865e309ace011