### PR TITLE
Preserve group filter selection when changing area

### DIFF
--- a/src/components/clients/ClientFilters.tsx
+++ b/src/components/clients/ClientFilters.tsx
@@ -57,7 +57,7 @@ export default function ClientFilters({
       <div className="flex flex-wrap gap-2 items-center">
         <Chip active={area === null} onClick={() => { setArea(null); setGroup(null); }}>Сбросить район</Chip>
         {db.settings.areas.map(a => (
-          <Chip key={a} active={area === a} onClick={() => { setArea(a); setGroup(null); }}>{a}</Chip>
+          <Chip key={a} active={area === a} onClick={() => setArea(a)}>{a}</Chip>
         ))}
         <div className="flex-1" />
         <button


### PR DESCRIPTION
## Summary
- keep the current group filter selection when switching between area chips

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68de85f1eec8832b87ab8f450eddca73