### PR TITLE
Improve tasks handling and client access

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -162,7 +162,7 @@ export default function App() {
               path="/tasks"
               element={
                 can(ui.role, "tasks") ? (
-                  <TasksTab db={db} setDB={setDB} />
+                  <TasksTab db={db} setDB={setDB} currency={ui.currency} />
                 ) : (
                   <Navigate to="/dashboard" replace />
                 )

--- a/src/components/ClientsTab.tsx
+++ b/src/components/ClientsTab.tsx
@@ -249,7 +249,7 @@ export default function ClientsTab({ db, setDB, ui }: ClientsTabProps) {
     };
 
     const nextTasks = [task, ...db.tasks];
-    const nextClients = applyPaymentStatusRules(db.clients, nextTasks);
+    const nextClients = applyPaymentStatusRules(db.clients, nextTasks, db.tasksArchive);
     const next = {
       ...db,
       tasks: nextTasks,

--- a/src/components/GroupsTab.tsx
+++ b/src/components/GroupsTab.tsx
@@ -213,7 +213,7 @@ export default function GroupsTab({
     };
 
     const nextTasks = [task, ...db.tasks];
-    const nextClients = applyPaymentStatusRules(db.clients, nextTasks);
+    const nextClients = applyPaymentStatusRules(db.clients, nextTasks, db.tasksArchive);
     const next = {
       ...db,
       tasks: nextTasks,

--- a/src/state/payments.ts
+++ b/src/state/payments.ts
@@ -57,8 +57,13 @@ export function getDefaultPayAmount(group: string): number | null {
   return 55;
 }
 
-export function derivePaymentStatus(client: Client, tasks: TaskItem[]): PaymentStatus {
-  const relatedTasks = tasks.filter(
+export function derivePaymentStatus(
+  client: Client,
+  tasks: TaskItem[],
+  archivedTasks: TaskItem[] = [],
+): PaymentStatus {
+  const relevantTasks = tasks.concat(archivedTasks.filter(task => task.status === "done"));
+  const relatedTasks = relevantTasks.filter(
     task =>
       task.topic === "оплата" &&
       task.assigneeType === "client" &&
@@ -76,9 +81,13 @@ export function derivePaymentStatus(client: Client, tasks: TaskItem[]): PaymentS
   return "действует";
 }
 
-export function applyPaymentStatusRules(clients: Client[], tasks: TaskItem[]): Client[] {
+export function applyPaymentStatusRules(
+  clients: Client[],
+  tasks: TaskItem[],
+  archivedTasks: TaskItem[] = [],
+): Client[] {
   return clients.map(client => {
-    const nextStatus = derivePaymentStatus(client, tasks);
+    const nextStatus = derivePaymentStatus(client, tasks, archivedTasks);
     const withPayStatus =
       client.payStatus === nextStatus ? client : { ...client, payStatus: nextStatus };
     return applyClientStatusAutoTransition(withPayStatus);


### PR DESCRIPTION
## Summary
- move completed tasks into the archive automatically and refresh payment status calculations
- make task cards clickable with an edit modal that links to the client details when available
- update tests for the new behaviour and pass the UI currency down to the tasks view

## Testing
- npm test -- TasksTab

------
https://chatgpt.com/codex/tasks/task_e_68debfb7a6b0832bb2e79e3d874b3ece