### PR TITLE
Hide reserve clients from groups, attendance, and performance

### DIFF
--- a/src/components/AttendanceTab.tsx
+++ b/src/components/AttendanceTab.tsx
@@ -10,6 +10,7 @@ import { fmtDate, todayISO, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
 import { buildGroupsByArea, clientRequiresManualRemainingLessons } from "../state/lessons";
 import { transformClientFormValues } from "./clients/clientMutations";
+import { isReserveArea } from "../state/areas";
 import type {
   Area,
   AttendanceEntry,
@@ -112,7 +113,7 @@ export default function AttendanceTab({
     if (!area || !group) {
       return [];
     }
-    return db.clients.filter(client => client.area === area && client.group === group);
+    return db.clients.filter(client => client.area === area && client.group === group && !isReserveArea(client.area));
   }, [area, group, db.clients]);
 
   type ColumnConfig = {

--- a/src/components/GroupsTab.tsx
+++ b/src/components/GroupsTab.tsx
@@ -23,6 +23,7 @@ import {
   isClientInPeriod,
   type PeriodFilter,
 } from "../state/period";
+import { isReserveArea } from "../state/areas";
 
 
 export default function GroupsTab({
@@ -93,6 +94,7 @@ export default function GroupsTab({
     return db.clients.filter(c =>
       c.area === area &&
       c.group === group &&
+      !isReserveArea(c.area) &&
       (pay === "all" || c.payStatus === pay) &&
       (isClientInPeriod(c, period) || isClientActiveInPeriod(c, period)) &&
       (!ui.search || `${c.firstName} ${c.lastName ?? ""} ${c.phone ?? ""}`.toLowerCase().includes(search))

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -10,6 +10,7 @@ import { fmtDate, todayISO, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
 import { buildGroupsByArea } from "../state/lessons";
 import { transformClientFormValues } from "./clients/clientMutations";
+import { isReserveArea } from "../state/areas";
 import type {
   Area,
   Client,
@@ -78,7 +79,7 @@ export default function PerformanceTab({
     if (!area || !group) {
       return [];
     }
-    return db.clients.filter(client => client.area === area && client.group === group);
+    return db.clients.filter(client => client.area === area && client.group === group && !isReserveArea(client.area));
   }, [area, group, db.clients]);
 
   type ColumnConfig = {

--- a/src/components/__tests__/GroupsTab.test.tsx
+++ b/src/components/__tests__/GroupsTab.test.tsx
@@ -211,6 +211,22 @@ test('filters clients by selected month', async () => {
   });
 });
 
+test('hides clients assigned to reserve area', () => {
+  const db = makeDB();
+  db.settings.areas = [...db.settings.areas, 'резерв'];
+  db.settings.groups = [...db.settings.groups, 'ReserveGroup'];
+  db.schedule.push({ id: 'slot-res', area: 'резерв', group: 'ReserveGroup', coachId: 's1', weekday: 4, time: '15:00', location: '' });
+  db.clients = [
+    makeClient({ id: 'regular', firstName: 'Обычный', area: 'Area1', group: 'Group1' }),
+    makeClient({ id: 'reserve', firstName: 'Резерв', area: 'резерв', group: 'ReserveGroup' }),
+  ];
+
+  renderGroups(db, makeUI(), { initialArea: 'резерв', initialGroup: 'ReserveGroup' });
+
+  expect(screen.queryByText('Резерв')).not.toBeInTheDocument();
+  expect(screen.getByText('Найдено: 0')).toBeInTheDocument();
+});
+
 test('update: edits client name', async () => {
   const db = makeDB();
   db.clients = [

--- a/src/state/areas.ts
+++ b/src/state/areas.ts
@@ -1,0 +1,10 @@
+import type { Area } from "../types";
+
+export const RESERVE_AREA_NAME = "резерв";
+
+export function isReserveArea(area?: Area | null): boolean {
+  if (!area) {
+    return false;
+  }
+  return area.trim().toLowerCase() === RESERVE_AREA_NAME;
+}


### PR DESCRIPTION
## Summary
- add a shared helper to detect the new "резерв" area
- filter reserve clients out of the groups, attendance, and performance tabs so they stay only in the clients section
- cover the reserve behavior with a unit test for the groups tab

## Testing
- CI=1 npm test -- GroupsTab.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dec1430728832b862415a9761e7bee