### PR TITLE
Add age and experience filters across client views

### DIFF
--- a/src/components/AttendanceTab.tsx
+++ b/src/components/AttendanceTab.tsx
@@ -20,6 +20,7 @@ import type {
   Group,
 } from "../types";
 import { usePersistentTableSettings } from "../utils/tableSettings";
+import { matchesClientAgeExperience, parseAgeExperienceFilter } from "../utils/clientFilters";
 
 const DEFAULT_VISIBLE_COLUMNS = ["name", "area", "group", "mark"];
 const TABLE_SETTINGS_KEY = "attendance";
@@ -58,6 +59,20 @@ export default function AttendanceTab({
   const [editing, setEditing] = useState<Client | null>(null);
   const [month, setMonth] = useState(() => todayISO().slice(0, 7));
   const [selectedDate, setSelectedDate] = useState(() => todayISO().slice(0, 10));
+  const [ageMin, setAgeMin] = useState("");
+  const [ageMax, setAgeMax] = useState("");
+  const [experienceMin, setExperienceMin] = useState("");
+  const [experienceMax, setExperienceMax] = useState("");
+  const ageExperienceFilter = useMemo(
+    () =>
+      parseAgeExperienceFilter({
+        minAgeText: ageMin,
+        maxAgeText: ageMax,
+        minExperienceYearsText: experienceMin,
+        maxExperienceYearsText: experienceMax,
+      }),
+    [ageMin, ageMax, experienceMin, experienceMax],
+  );
 
   const groupsByArea = useMemo(() => buildGroupsByArea(db.schedule), [db.schedule]);
   const areaOptions = useMemo(() => Array.from(groupsByArea.keys()), [groupsByArea]);
@@ -112,8 +127,10 @@ export default function AttendanceTab({
     if (!area || !group) {
       return [];
     }
-    return db.clients.filter(client => client.area === area && client.group === group);
-  }, [area, group, db.clients]);
+    return db.clients
+      .filter(client => client.area === area && client.group === group)
+      .filter(client => matchesClientAgeExperience(client, ageExperienceFilter));
+  }, [ageExperienceFilter, area, db.clients, group]);
 
   type ColumnConfig = {
     id: string;
@@ -430,6 +447,42 @@ export default function AttendanceTab({
           options={columns.map(column => ({ id: column.id, label: column.label }))}
           value={visibleColumns}
           onChange={setVisibleColumns}
+        />
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="number"
+          min={0}
+          placeholder="Возраст от"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={ageMin}
+          onChange={event => setAgeMin(event.target.value)}
+        />
+        <input
+          type="number"
+          min={0}
+          placeholder="Возраст до"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={ageMax}
+          onChange={event => setAgeMax(event.target.value)}
+        />
+        <input
+          type="number"
+          min={0}
+          step="0.1"
+          placeholder="Опыт от (лет)"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={experienceMin}
+          onChange={event => setExperienceMin(event.target.value)}
+        />
+        <input
+          type="number"
+          min={0}
+          step="0.1"
+          placeholder="Опыт до (лет)"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={experienceMax}
+          onChange={event => setExperienceMax(event.target.value)}
         />
       </div>
       {area && group && (

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -29,6 +29,7 @@ import {
   type PeriodFilter,
 } from "../state/period";
 import { usePersistentTableSettings } from "../utils/tableSettings";
+import { matchesClientAgeExperience, parseAgeExperienceFilter } from "../utils/clientFilters";
 
 const DEFAULT_VISIBLE_COLUMNS = ["name", "area", "group", "mark"];
 const TABLE_SETTINGS_KEY = "performance";
@@ -61,6 +62,20 @@ export default function PerformanceTab({
     if (!area) return [];
     return groupsByArea.get(area) ?? [];
   }, [area, groupsByArea]);
+  const [ageMin, setAgeMin] = useState("");
+  const [ageMax, setAgeMax] = useState("");
+  const [experienceMin, setExperienceMin] = useState("");
+  const [experienceMax, setExperienceMax] = useState("");
+  const ageExperienceFilter = useMemo(
+    () =>
+      parseAgeExperienceFilter({
+        minAgeText: ageMin,
+        maxAgeText: ageMax,
+        minExperienceYearsText: experienceMin,
+        maxExperienceYearsText: experienceMax,
+      }),
+    [ageMin, ageMax, experienceMin, experienceMax],
+  );
 
   useEffect(() => {
     if (area && group && !availableGroups.includes(group)) {
@@ -78,8 +93,10 @@ export default function PerformanceTab({
     if (!area || !group) {
       return [];
     }
-    return db.clients.filter(client => client.area === area && client.group === group);
-  }, [area, group, db.clients]);
+    return db.clients
+      .filter(client => client.area === area && client.group === group)
+      .filter(client => matchesClientAgeExperience(client, ageExperienceFilter));
+  }, [ageExperienceFilter, area, db.clients, group]);
 
   type ColumnConfig = {
     id: string;
@@ -324,6 +341,42 @@ export default function PerformanceTab({
           options={columns.map(column => ({ id: column.id, label: column.label }))}
           value={visibleColumns}
           onChange={setVisibleColumns}
+        />
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="number"
+          min={0}
+          placeholder="Возраст от"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={ageMin}
+          onChange={event => setAgeMin(event.target.value)}
+        />
+        <input
+          type="number"
+          min={0}
+          placeholder="Возраст до"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={ageMax}
+          onChange={event => setAgeMax(event.target.value)}
+        />
+        <input
+          type="number"
+          min={0}
+          step="0.1"
+          placeholder="Опыт от (лет)"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={experienceMin}
+          onChange={event => setExperienceMin(event.target.value)}
+        />
+        <input
+          type="number"
+          min={0}
+          step="0.1"
+          placeholder="Опыт до (лет)"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={experienceMax}
+          onChange={event => setExperienceMax(event.target.value)}
         />
       </div>
       <div className="text-xs text-slate-500">

--- a/src/components/__tests__/ClientsTab.test.tsx
+++ b/src/components/__tests__/ClientsTab.test.tsx
@@ -24,11 +24,12 @@ jest.mock('../../state/utils', () => ({
   parseDateInput: jest.fn(),
   calcAgeYears: jest.fn(),
   calcExperience: jest.fn(),
+  calcExperienceMonths: jest.fn(),
 }));
 
 import ClientsTab from '../ClientsTab';
 import { commitDBUpdate } from '../../state/appState';
-import { uid, todayISO, fmtMoney, fmtDate, parseDateInput, calcAgeYears, calcExperience } from '../../state/utils';
+import { uid, todayISO, fmtMoney, fmtDate, parseDateInput, calcAgeYears, calcExperience, calcExperienceMonths } from '../../state/utils';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -44,6 +45,7 @@ beforeEach(() => {
   parseDateInput.mockImplementation(value => (value ? `${value}T00:00:00.000Z` : ''));
   calcAgeYears.mockReturnValue(10);
   calcExperience.mockReturnValue('1 год');
+  calcExperienceMonths.mockReturnValue(12);
   window.alert = jest.fn();
   global.confirm = jest.fn(() => true);
 });

--- a/src/components/__tests__/GroupsTab.test.tsx
+++ b/src/components/__tests__/GroupsTab.test.tsx
@@ -32,11 +32,12 @@ jest.mock('../../state/utils', () => ({
   fmtDate: jest.fn(),
   calcAgeYears: jest.fn(),
   calcExperience: jest.fn(),
+  calcExperienceMonths: jest.fn(),
 }));
 
 import GroupsTab from '../GroupsTab';
 import { commitDBUpdate } from '../../state/appState';
-import { uid, todayISO, parseDateInput, fmtMoney, fmtDate, calcAgeYears, calcExperience } from '../../state/utils';
+import { uid, todayISO, parseDateInput, fmtMoney, fmtDate, calcAgeYears, calcExperience, calcExperienceMonths } from '../../state/utils';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -52,6 +53,7 @@ beforeEach(() => {
   fmtDate.mockImplementation((iso) => iso);
   calcAgeYears.mockReturnValue(10);
   calcExperience.mockReturnValue('1 год');
+  calcExperienceMonths.mockReturnValue(12);
   global.confirm = jest.fn(() => true);
   window.alert = jest.fn();
 });

--- a/src/components/__tests__/LeadsTab.test.tsx
+++ b/src/components/__tests__/LeadsTab.test.tsx
@@ -20,6 +20,7 @@ jest.mock('../../state/utils', () => ({
   todayISO: jest.fn(() => '2024-01-01T00:00:00.000Z'),
   uid: jest.fn(() => 'uid-123'),
   fmtDate: (iso: string) => iso,
+  calcExperienceMonths: () => 0,
 }));
 
 import LeadsTab from '../LeadsTab';

--- a/src/components/__tests__/ScheduleTab.groups.test.tsx
+++ b/src/components/__tests__/ScheduleTab.groups.test.tsx
@@ -17,6 +17,7 @@ jest.mock("../../state/utils", () => ({
   fmtMoney: (v: number) => String(v),
   calcAgeYears: () => 0,
   calcExperience: () => 0,
+  calcExperienceMonths: () => 0,
 }));
 
 jest.mock("../VirtualizedTable", () => (props) => <table>{props.children}</table>);

--- a/src/components/__tests__/ScheduleTab.test.tsx
+++ b/src/components/__tests__/ScheduleTab.test.tsx
@@ -17,6 +17,7 @@ jest.mock('../../state/utils', () => ({
   fmtMoney: (v: number) => String(v),
   calcAgeYears: () => 0,
   calcExperience: () => 0,
+  calcExperienceMonths: () => 0,
 }));
 
 jest.mock('../VirtualizedTable', () => (props) => <table>{props.children}</table>);

--- a/src/components/__tests__/TasksTab.test.tsx
+++ b/src/components/__tests__/TasksTab.test.tsx
@@ -12,7 +12,8 @@ jest.mock('../../state/utils', () => ({
   __esModule: true,
   fmtDate: (iso: string) => new Intl.DateTimeFormat('ru-RU').format(new Date(iso)),
   uid: () => 'uid',
-  todayISO: () => '2025-01-01T00:00:00.000Z'
+  todayISO: () => '2025-01-01T00:00:00.000Z',
+  calcExperienceMonths: () => 0,
 }));
 import TasksTab from '../TasksTab';
 import { commitDBUpdate } from '../../state/appState';

--- a/src/components/clients/ClientFilters.tsx
+++ b/src/components/clients/ClientFilters.tsx
@@ -18,6 +18,14 @@ type Props = {
   year: number,
   onYearChange: (value: number) => void,
   yearOptions: number[],
+  ageMin: string,
+  onAgeMinChange: (value: string) => void,
+  ageMax: string,
+  onAgeMaxChange: (value: string) => void,
+  experienceMin: string,
+  onExperienceMinChange: (value: string) => void,
+  experienceMax: string,
+  onExperienceMaxChange: (value: string) => void,
 };
 
 function Chip({ active, onClick, children }: { active?: boolean; onClick?: () => void; children: React.ReactNode }) {
@@ -51,6 +59,14 @@ export default function ClientFilters({
   year,
   onYearChange,
   yearOptions,
+  ageMin,
+  onAgeMinChange,
+  ageMax,
+  onAgeMaxChange,
+  experienceMin,
+  onExperienceMinChange,
+  experienceMax,
+  onExperienceMaxChange,
 }: Props) {
   return (
     <>
@@ -123,6 +139,42 @@ export default function ClientFilters({
         <div className="text-xs text-slate-500">
           {area && group ? `Найдено: ${listLength}` : "Выберите район и группу"}
         </div>
+      </div>
+      <div className="flex flex-wrap gap-2 items-center">
+        <input
+          type="number"
+          min={0}
+          placeholder="Возраст от"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={ageMin}
+          onChange={event => onAgeMinChange(event.target.value)}
+        />
+        <input
+          type="number"
+          min={0}
+          placeholder="Возраст до"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={ageMax}
+          onChange={event => onAgeMaxChange(event.target.value)}
+        />
+        <input
+          type="number"
+          min={0}
+          step="0.1"
+          placeholder="Опыт от (лет)"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={experienceMin}
+          onChange={event => onExperienceMinChange(event.target.value)}
+        />
+        <input
+          type="number"
+          min={0}
+          step="0.1"
+          placeholder="Опыт до (лет)"
+          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          value={experienceMax}
+          onChange={event => onExperienceMaxChange(event.target.value)}
+        />
       </div>
     </>
   );

--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -3,7 +3,7 @@ import VirtualizedTable from "../VirtualizedTable";
 import ClientDetailsModal from "./ClientDetailsModal";
 import ColumnSettings from "../ColumnSettings";
 import { compareValues, toggleSort } from "../tableUtils";
-import { fmtMoney, fmtDate } from "../../state/utils";
+import { calcAgeYears, calcExperience, calcExperienceMonths, fmtDate, fmtMoney } from "../../state/utils";
 import { getClientRecurringPayDate, type PeriodFilter } from "../../state/period";
 import { getEffectiveRemainingLessons } from "../../state/lessons";
 import type { AttendanceEntry, Client, Currency, PerformanceEntry, ScheduleSlot } from "../../types";
@@ -40,6 +40,8 @@ const DEFAULT_VISIBLE_COLUMNS = [
   "instagram",
   "area",
   "group",
+  "age",
+  "experience",
   "status",
   "payStatus",
   "remainingLessons",
@@ -123,6 +125,28 @@ export default function ClientTable({
       width: "minmax(120px, max-content)",
       renderCell: client => client.group,
       sortValue: client => client.group,
+    },
+    {
+      id: "age",
+      label: "Возраст",
+      width: "minmax(110px, max-content)",
+      headerAlign: "center",
+      cellClassName: "text-center",
+      renderCell: client => {
+        const age = calcAgeYears(client.birthDate);
+        return Number.isNaN(age) ? "—" : `${age} лет`;
+      },
+      sortValue: client => {
+        const age = calcAgeYears(client.birthDate);
+        return Number.isNaN(age) ? -1 : age;
+      },
+    },
+    {
+      id: "experience",
+      label: "Опыт",
+      width: "minmax(140px, max-content)",
+      renderCell: client => calcExperience(client.startDate),
+      sortValue: client => calcExperienceMonths(client.startDate),
     },
     {
       id: "status",

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -33,12 +33,22 @@ export const calcAgeYears = (iso: string) => {
   return age;
 };
 
-export const calcExperience = (iso: string) => {
+const calcMonthDifference = (start: Date, end: Date) => {
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return 0;
+  }
+  const base = (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());
+  return base < 0 ? 0 : base;
+};
+
+export const calcExperienceMonths = (iso: string) => {
   const start = new Date(iso);
   const now = new Date();
-  const months =
-    (now.getFullYear() - start.getFullYear()) * 12 +
-    now.getMonth() - start.getMonth();
+  return calcMonthDifference(start, now);
+};
+
+export const calcExperience = (iso: string) => {
+  const months = calcExperienceMonths(iso);
   if (months < 12) return `${months} мес.`;
   const years = Math.floor(months / 12);
   const rest = months % 12;

--- a/src/utils/clientFilters.ts
+++ b/src/utils/clientFilters.ts
@@ -1,0 +1,70 @@
+import type { Client } from "../types";
+import { calcAgeYears, calcExperienceMonths } from "../state/utils";
+
+export type AgeExperienceFilter = {
+  minAge: number | null;
+  maxAge: number | null;
+  minExperienceYears: number | null;
+  maxExperienceYears: number | null;
+};
+
+export type AgeExperienceFilterInput = {
+  minAgeText: string;
+  maxAgeText: string;
+  minExperienceYearsText: string;
+  maxExperienceYearsText: string;
+};
+
+const parsePositiveInt = (value: string): number | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.max(0, parsed);
+};
+
+const parsePositiveNumber = (value: string): number | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number.parseFloat(trimmed);
+  if (!Number.isFinite(parsed)) return null;
+  return parsed < 0 ? 0 : parsed;
+};
+
+export const parseAgeExperienceFilter = ({
+  minAgeText,
+  maxAgeText,
+  minExperienceYearsText,
+  maxExperienceYearsText,
+}: AgeExperienceFilterInput): AgeExperienceFilter => ({
+  minAge: parsePositiveInt(minAgeText),
+  maxAge: parsePositiveInt(maxAgeText),
+  minExperienceYears: parsePositiveNumber(minExperienceYearsText),
+  maxExperienceYears: parsePositiveNumber(maxExperienceYearsText),
+});
+
+export const isAgeExperienceFilterActive = (filter: AgeExperienceFilter): boolean =>
+  filter.minAge != null ||
+  filter.maxAge != null ||
+  filter.minExperienceYears != null ||
+  filter.maxExperienceYears != null;
+
+export const matchesClientAgeExperience = (client: Client, filter: AgeExperienceFilter): boolean => {
+  const age = calcAgeYears(client.birthDate);
+  if (filter.minAge != null && age < filter.minAge) {
+    return false;
+  }
+  if (filter.maxAge != null && age > filter.maxAge) {
+    return false;
+  }
+
+  const experienceYears = calcExperienceMonths(client.startDate) / 12;
+  if (filter.minExperienceYears != null && experienceYears < filter.minExperienceYears) {
+    return false;
+  }
+  if (filter.maxExperienceYears != null && experienceYears > filter.maxExperienceYears) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
## Summary
- add shared helpers to parse age and experience filters and expose experience in months
- show age and experience columns in the reusable client table and hook up filtering logic in clients and groups tabs
- surface the same age and experience filters in attendance and performance views for consistent client filtering

## Testing
- CI=true npm test -- --runTestsByPath src/components/__tests__/ClientsTab.test.tsx
- CI=true npm test -- --runTestsByPath src/components/__tests__/GroupsTab.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dec1bafb40832bb6aa690acd8542e4