### PR TITLE
Fix reserve area helper imports

### DIFF
--- a/src/components/AttendanceTab.tsx
+++ b/src/components/AttendanceTab.tsx
@@ -6,7 +6,7 @@ import ClientDetailsModal from "./clients/ClientDetailsModal";
 import ClientForm from "./clients/ClientForm";
 import ColumnSettings from "./ColumnSettings";
 import { compareValues, toggleSort } from "./tableUtils";
-import { fmtDate, todayISO, uid } from "../state/utils";
+import { fmtDate, isReserveArea, todayISO, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
 import { buildGroupsByArea, clientRequiresManualRemainingLessons } from "../state/lessons";
 import { transformClientFormValues } from "./clients/clientMutations";
@@ -112,7 +112,7 @@ export default function AttendanceTab({
     if (!area || !group) {
       return [];
     }
-    return db.clients.filter(client => client.area === area && client.group === group);
+    return db.clients.filter(client => client.area === area && client.group === group && !isReserveArea(client.area));
   }, [area, group, db.clients]);
 
   type ColumnConfig = {

--- a/src/components/GroupsTab.tsx
+++ b/src/components/GroupsTab.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "./Breadcrumbs";
 import ClientFilters from "./clients/ClientFilters";
 import ClientTable from "./clients/ClientTable";
 import ClientForm from "./clients/ClientForm";
-import { uid, todayISO, fmtMoney } from "../state/utils";
+import { fmtMoney, isReserveArea, todayISO, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
 import {
   applyPaymentStatusRules,
@@ -93,6 +93,7 @@ export default function GroupsTab({
     return db.clients.filter(c =>
       c.area === area &&
       c.group === group &&
+      !isReserveArea(c.area) &&
       (pay === "all" || c.payStatus === pay) &&
       (isClientInPeriod(c, period) || isClientActiveInPeriod(c, period)) &&
       (!ui.search || `${c.firstName} ${c.lastName ?? ""} ${c.phone ?? ""}`.toLowerCase().includes(search))

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -6,7 +6,7 @@ import ClientDetailsModal from "./clients/ClientDetailsModal";
 import ClientForm from "./clients/ClientForm";
 import ColumnSettings from "./ColumnSettings";
 import { compareValues, toggleSort } from "./tableUtils";
-import { fmtDate, todayISO, uid } from "../state/utils";
+import { fmtDate, isReserveArea, todayISO, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
 import { buildGroupsByArea } from "../state/lessons";
 import { transformClientFormValues } from "./clients/clientMutations";
@@ -78,7 +78,7 @@ export default function PerformanceTab({
     if (!area || !group) {
       return [];
     }
-    return db.clients.filter(client => client.area === area && client.group === group);
+    return db.clients.filter(client => client.area === area && client.group === group && !isReserveArea(client.area));
   }, [area, group, db.clients]);
 
   type ColumnConfig = {

--- a/src/components/__tests__/ClientsTab.test.tsx
+++ b/src/components/__tests__/ClientsTab.test.tsx
@@ -24,6 +24,9 @@ jest.mock('../../state/utils', () => ({
   parseDateInput: jest.fn(),
   calcAgeYears: jest.fn(),
   calcExperience: jest.fn(),
+  isReserveArea: jest.fn(() => false),
+  ensureReserveAreaIncluded: jest.fn(v => v),
+  RESERVE_AREA_NAME: 'резерв',
 }));
 
 import ClientsTab from '../ClientsTab';

--- a/src/components/__tests__/GroupsTab.test.tsx
+++ b/src/components/__tests__/GroupsTab.test.tsx
@@ -32,11 +32,23 @@ jest.mock('../../state/utils', () => ({
   fmtDate: jest.fn(),
   calcAgeYears: jest.fn(),
   calcExperience: jest.fn(),
+  isReserveArea: jest.fn(() => false),
+  ensureReserveAreaIncluded: jest.fn(v => v),
+  RESERVE_AREA_NAME: 'резерв',
 }));
 
 import GroupsTab from '../GroupsTab';
 import { commitDBUpdate } from '../../state/appState';
-import { uid, todayISO, parseDateInput, fmtMoney, fmtDate, calcAgeYears, calcExperience } from '../../state/utils';
+import {
+  uid,
+  todayISO,
+  parseDateInput,
+  fmtMoney,
+  fmtDate,
+  calcAgeYears,
+  calcExperience,
+  isReserveArea,
+} from '../../state/utils';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -52,6 +64,7 @@ beforeEach(() => {
   fmtDate.mockImplementation((iso) => iso);
   calcAgeYears.mockReturnValue(10);
   calcExperience.mockReturnValue('1 год');
+  isReserveArea.mockImplementation(area => area?.trim().toLowerCase() === 'резерв');
   global.confirm = jest.fn(() => true);
   window.alert = jest.fn();
 });
@@ -209,6 +222,22 @@ test('filters clients by selected month', async () => {
     expect(screen.getByRole('row', { name: /Февраль/ })).toBeInTheDocument();
     expect(screen.queryByRole('row', { name: /Март/ })).not.toBeInTheDocument();
   });
+});
+
+test('hides clients assigned to reserve area', () => {
+  const db = makeDB();
+  db.settings.areas = [...db.settings.areas, 'резерв'];
+  db.settings.groups = [...db.settings.groups, 'ReserveGroup'];
+  db.schedule.push({ id: 'slot-res', area: 'резерв', group: 'ReserveGroup', coachId: 's1', weekday: 4, time: '15:00', location: '' });
+  db.clients = [
+    makeClient({ id: 'regular', firstName: 'Обычный', area: 'Area1', group: 'Group1' }),
+    makeClient({ id: 'reserve', firstName: 'Резерв', area: 'резерв', group: 'ReserveGroup' }),
+  ];
+
+  renderGroups(db, makeUI(), { initialArea: 'резерв', initialGroup: 'ReserveGroup' });
+
+  expect(screen.queryByText('Резерв')).not.toBeInTheDocument();
+  expect(screen.getByText('Найдено: 0')).toBeInTheDocument();
 });
 
 test('update: edits client name', async () => {

--- a/src/components/__tests__/LeadsTab.test.tsx
+++ b/src/components/__tests__/LeadsTab.test.tsx
@@ -20,6 +20,9 @@ jest.mock('../../state/utils', () => ({
   todayISO: jest.fn(() => '2024-01-01T00:00:00.000Z'),
   uid: jest.fn(() => 'uid-123'),
   fmtDate: (iso: string) => iso,
+  isReserveArea: () => false,
+  ensureReserveAreaIncluded: (areas: string[]) => areas,
+  RESERVE_AREA_NAME: 'резерв',
 }));
 
 import LeadsTab from '../LeadsTab';

--- a/src/components/__tests__/ScheduleTab.test.tsx
+++ b/src/components/__tests__/ScheduleTab.test.tsx
@@ -17,6 +17,9 @@ jest.mock('../../state/utils', () => ({
   fmtMoney: (v: number) => String(v),
   calcAgeYears: () => 0,
   calcExperience: () => 0,
+  isReserveArea: () => false,
+  ensureReserveAreaIncluded: (areas: string[]) => areas,
+  RESERVE_AREA_NAME: 'резерв',
 }));
 
 jest.mock('../VirtualizedTable', () => (props) => <table>{props.children}</table>);

--- a/src/components/__tests__/TasksTab.test.tsx
+++ b/src/components/__tests__/TasksTab.test.tsx
@@ -12,7 +12,10 @@ jest.mock('../../state/utils', () => ({
   __esModule: true,
   fmtDate: (iso: string) => new Intl.DateTimeFormat('ru-RU').format(new Date(iso)),
   uid: () => 'uid',
-  todayISO: () => '2025-01-01T00:00:00.000Z'
+  todayISO: () => '2025-01-01T00:00:00.000Z',
+  isReserveArea: () => false,
+  ensureReserveAreaIncluded: (areas: string[]) => areas,
+  RESERVE_AREA_NAME: 'резерв',
 }));
 import TasksTab from '../TasksTab';
 import { commitDBUpdate } from '../../state/appState';

--- a/src/state/__tests__/useAppState.test.tsx
+++ b/src/state/__tests__/useAppState.test.tsx
@@ -25,6 +25,8 @@ jest.mock('../../firebase', () => ({
 }));
 
 import { commitDBUpdate, LS_KEYS, LOCAL_ONLY_MESSAGE, useAppState } from '../appState';
+import { RESERVE_AREA_NAME } from '../utils';
+import { makeSeedDB } from '../seed';
 
 describe('useAppState with local persistence', () => {
   beforeEach(() => {
@@ -81,5 +83,16 @@ describe('useAppState with local persistence', () => {
     expect(loginResult).toEqual({ ok: true });
     expect(result.current.currentUser).not.toBeNull();
     expect(result.current.currentUser?.login).toBe('admin1');
+  });
+
+  it('ensures the reserve area is available even if missing from stored settings', async () => {
+    const legacy = makeSeedDB();
+    legacy.settings.areas = legacy.settings.areas.filter(area => area !== RESERVE_AREA_NAME);
+    localStorage.setItem(LS_KEYS.db, JSON.stringify(legacy));
+
+    const { result } = renderHook(() => useAppState());
+    await act(async () => {});
+
+    expect(result.current.db.settings.areas).toContain(RESERVE_AREA_NAME);
   });
 });

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -6,10 +6,11 @@ import { useToasts } from "../components/Toasts";
 import { doc, onSnapshot, setDoc } from "firebase/firestore";
 import { db as firestore, ensureSignedIn } from "../firebase";
 import { makeSeedDB } from "./seed";
-import { todayISO, uid } from "./utils";
+import { ensureReserveAreaIncluded, todayISO, uid } from "./utils";
 import { DEFAULT_SUBSCRIPTION_PLAN, getSubscriptionPlanMeta } from "./payments";
 import type {
   AttendanceEntry,
+  Area,
   AuthState,
   AuthUser,
   Client,
@@ -39,11 +40,13 @@ export const LOCAL_ONLY_EVENT = "judo-crm/local-only";
 export const LOCAL_ONLY_MESSAGE =
   "Данные сейчас сохраняются только в этом браузере — синхронизация с Firebase отключена, поэтому содержимое может отличаться в других окнах.";
 
+const DEFAULT_AREAS: Area[] = ["Махмутлар", "Центр", "Джикджилли"];
+
 const DEFAULT_SETTINGS: Settings = {
-  areas: ["Махмутлар", "Центр", "Джикджилли"],
+  areas: DEFAULT_AREAS,
   groups: ["4–6", "6–9", "7–14", "9–14", "взрослые", "индивидуальные", "доп. группа"],
   limits: Object.fromEntries(
-    ["Махмутлар", "Центр", "Джикджилли"].flatMap(area =>
+    DEFAULT_AREAS.flatMap(area =>
       ["4–6", "6–9", "7–14", "9–14", "взрослые", "индивидуальные", "доп. группа"].map(group => [`${area}|${group}`, 20]),
     ),
   ) as Settings["limits"],
@@ -81,15 +84,21 @@ function ensureObjectArray<T>(value: unknown): T[] {
 
 function normalizeSettings(value: unknown): Settings {
   if (!value || typeof value !== "object") {
-    return DEFAULT_SETTINGS;
+    return {
+      ...DEFAULT_SETTINGS,
+      areas: ensureReserveAreaIncluded(DEFAULT_SETTINGS.areas) as Settings["areas"],
+    };
   }
 
   const raw = value as Partial<Settings>;
   const areas = ensureArray<string>(raw.areas);
   const groups = ensureArray<string>(raw.groups);
+  const normalizedAreas = ensureReserveAreaIncluded(
+    areas.length ? (areas as Settings["areas"]) : DEFAULT_SETTINGS.areas,
+  ) as Settings["areas"];
 
   return {
-    areas: areas.length ? (areas as Settings["areas"]) : DEFAULT_SETTINGS.areas,
+    areas: normalizedAreas,
     groups: groups.length ? (groups as Settings["groups"]) : DEFAULT_SETTINGS.groups,
     limits: raw.limits && typeof raw.limits === "object" ? (raw.limits as Settings["limits"]) : DEFAULT_SETTINGS.limits,
     rentByAreaEUR:

--- a/src/state/seed.ts
+++ b/src/state/seed.ts
@@ -1,4 +1,4 @@
-import { rnd, uid, todayISO } from "./utils";
+import { RESERVE_AREA_NAME, rnd, uid, todayISO } from "./utils";
 import type {
   Area,
   Client,
@@ -17,7 +17,8 @@ import { clientRequiresManualRemainingLessons } from "./lessons";
 import { SUBSCRIPTION_PLANS } from "./payments";
 
 export function makeSeedDB(): DB {
-  const areas: Area[] = ["Махмутлар", "Центр", "Джикджилли"];
+  const activeAreas: Area[] = ["Махмутлар", "Центр", "Джикджилли"];
+  const areas: Area[] = [...activeAreas, RESERVE_AREA_NAME];
   const groups: Group[] = [
     "4–6",
     "6–9",
@@ -28,9 +29,9 @@ export function makeSeedDB(): DB {
     "доп. группа",
   ];
   const staff: StaffMember[] = [
-    { id: uid(), role: "Администратор", name: "Админ", areas, groups },
-    { id: uid(), role: "Менеджер", name: "Марина", areas, groups },
-    { id: uid(), role: "Менеджер", name: "Илья", areas, groups },
+    { id: uid(), role: "Администратор", name: "Админ", areas: activeAreas, groups },
+    { id: uid(), role: "Менеджер", name: "Марина", areas: activeAreas, groups },
+    { id: uid(), role: "Менеджер", name: "Илья", areas: activeAreas, groups },
     {
       id: uid(),
       role: "Тренер",
@@ -97,7 +98,7 @@ export function makeSeedDB(): DB {
     const fn = firstNames[rnd(0, firstNames.length - 1)];
     const ln = lastNames[rnd(0, lastNames.length - 1)];
     const gender: Gender = Math.random() < 0.5 ? "м" : "ж";
-    const area = areas[rnd(0, areas.length - 1)];
+    const area = activeAreas[rnd(0, activeAreas.length - 1)];
     const group = groups[rnd(0, groups.length - 1)];
     const subscriptionPlan = SUBSCRIPTION_PLANS[rnd(0, SUBSCRIPTION_PLANS.length - 1)].value;
     const planMeta = SUBSCRIPTION_PLANS.find(option => option.value === subscriptionPlan);

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -1,4 +1,4 @@
-import type { Currency } from "../types";
+import type { Area, Currency } from "../types";
 
 export const rnd = (min: number, max: number) =>
   Math.floor(Math.random() * (max - min + 1)) + min;
@@ -44,3 +44,19 @@ export const calcExperience = (iso: string) => {
   const rest = months % 12;
   return `${years} г.${rest ? ` ${rest} мес.` : ""}`;
 };
+
+export const RESERVE_AREA_NAME = "резерв";
+
+export function isReserveArea(area?: Area | null): boolean {
+  if (!area) {
+    return false;
+  }
+  return area.trim().toLowerCase() === RESERVE_AREA_NAME;
+}
+
+export function ensureReserveAreaIncluded(areas: readonly Area[]): Area[] {
+  if (areas.some(isReserveArea)) {
+    return [...areas];
+  }
+  return [...areas, RESERVE_AREA_NAME];
+}


### PR DESCRIPTION
## Summary
- move the reserve area helpers into `state/utils` and remove the standalone module that failed to resolve in the app build
- point the attendance, groups, and performance tabs at the shared helper so reserve clients remain hidden outside the clients list
- refresh the unit tests to mock the new utilities and keep the reserve-area coverage in place

## Testing
- CI=1 npm test -- GroupsTab.test.tsx
- CI=1 npm test -- useAppState.test.tsx
- CI=1 npm test -- ClientsTab.test.tsx
- CI=1 npm test -- LeadsTab.test.tsx
- CI=1 npm test -- ScheduleTab.test.tsx
- CI=1 npm test -- TasksTab.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dec1430728832b862415a9761e7bee