### PR TITLE
Fix duplicate reserve helper imports

### DIFF
--- a/src/components/AttendanceTab.tsx
+++ b/src/components/AttendanceTab.tsx
@@ -7,7 +7,6 @@ import ClientForm from "./clients/ClientForm";
 import ColumnSettings from "./ColumnSettings";
 import { compareValues, toggleSort } from "./tableUtils";
 import { fmtDate, todayISO, uid } from "../state/utils";
-import { isReserveArea } from "../state/reserve";
 import { commitDBUpdate } from "../state/appState";
 import { buildGroupsByArea, clientRequiresManualRemainingLessons } from "../state/lessons";
 import { transformClientFormValues } from "./clients/clientMutations";

--- a/src/components/GroupsTab.tsx
+++ b/src/components/GroupsTab.tsx
@@ -5,7 +5,6 @@ import ClientFilters from "./clients/ClientFilters";
 import ClientTable from "./clients/ClientTable";
 import ClientForm from "./clients/ClientForm";
 import { fmtMoney, todayISO, uid } from "../state/utils";
-import { isReserveArea } from "../state/reserve";
 import { commitDBUpdate } from "../state/appState";
 import {
   applyPaymentStatusRules,
@@ -26,6 +25,7 @@ import {
 } from "../state/period";
 
 import { isReserveArea } from "../state/areas";
+import { parseAgeExperienceFilter } from "../utils/clientFilters";
 
 export default function GroupsTab({
   db,

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -7,7 +7,6 @@ import ClientForm from "./clients/ClientForm";
 import ColumnSettings from "./ColumnSettings";
 import { compareValues, toggleSort } from "./tableUtils";
 import { fmtDate, todayISO, uid } from "../state/utils";
-import { isReserveArea } from "../state/reserve";
 import { commitDBUpdate } from "../state/appState";
 import { buildGroupsByArea } from "../state/lessons";
 import { transformClientFormValues } from "./clients/clientMutations";

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -7,7 +7,6 @@ import { doc, onSnapshot, setDoc } from "firebase/firestore";
 import { db as firestore, ensureSignedIn } from "../firebase";
 import { makeSeedDB } from "./seed";
 import { todayISO, uid } from "./utils";
-import { ensureReserveAreaIncluded } from "./reserve";
 import { DEFAULT_SUBSCRIPTION_PLAN, getSubscriptionPlanMeta } from "./payments";
 import { ensureReserveAreaIncluded } from "./areas";
 import type {

--- a/src/state/reserve.ts
+++ b/src/state/reserve.ts
@@ -1,17 +1,1 @@
-import type { Area } from "../types";
-
-export const RESERVE_AREA_NAME = "резерв";
-
-export function isReserveArea(area?: Area | null): boolean {
-  if (!area) {
-    return false;
-  }
-  return area.trim().toLowerCase() === RESERVE_AREA_NAME;
-}
-
-export function ensureReserveAreaIncluded(areas: readonly Area[]): Area[] {
-  if (areas.some(isReserveArea)) {
-    return [...areas];
-  }
-  return [...areas, RESERVE_AREA_NAME];
-}
+export { RESERVE_AREA_NAME, ensureReserveAreaIncluded, isReserveArea } from "./areas";

--- a/src/state/seed.ts
+++ b/src/state/seed.ts
@@ -1,5 +1,4 @@
 import { rnd, uid, todayISO } from "./utils";
-import { RESERVE_AREA_NAME } from "./reserve";
 import type {
   Area,
   Client,


### PR DESCRIPTION
## Summary
- update attendance, groups, and performance tabs to use the reserve helpers from `state/areas`
- re-export reserve helpers from `state/areas` for legacy imports and update state modules accordingly
- add the missing `parseAgeExperienceFilter` import to `GroupsTab`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dede4a2470832bbdd700d387b68cb9