### PR TITLE
Remove age and experience filters from CRM tabs

### DIFF
--- a/src/components/AttendanceTab.tsx
+++ b/src/components/AttendanceTab.tsx
@@ -22,7 +22,6 @@ import type {
 } from "../types";
 import { readDailySelection, writeDailySelection, clearDailySelection } from "../state/filterPersistence";
 import { usePersistentTableSettings } from "../utils/tableSettings";
-import { matchesClientAgeExperience, parseAgeExperienceFilter } from "../utils/clientFilters";
 
 const DEFAULT_VISIBLE_COLUMNS = ["name", "area", "group", "mark"];
 const TABLE_SETTINGS_KEY = "attendance";
@@ -62,21 +61,6 @@ export default function AttendanceTab({
   const [editing, setEditing] = useState<Client | null>(null);
   const [month, setMonth] = useState(() => todayISO().slice(0, 7));
   const [selectedDate, setSelectedDate] = useState(() => todayISO().slice(0, 10));
-  const [ageMin, setAgeMin] = useState("");
-  const [ageMax, setAgeMax] = useState("");
-  const [experienceMin, setExperienceMin] = useState("");
-  const [experienceMax, setExperienceMax] = useState("");
-  const ageExperienceFilter = useMemo(
-    () =>
-      parseAgeExperienceFilter({
-        minAgeText: ageMin,
-        maxAgeText: ageMax,
-        minExperienceYearsText: experienceMin,
-        maxExperienceYearsText: experienceMax,
-      }),
-    [ageMin, ageMax, experienceMin, experienceMax],
-  );
-
   const groupsByArea = useMemo(() => buildGroupsByArea(db.schedule), [db.schedule]);
   const areaOptions = useMemo(() => Array.from(groupsByArea.keys()), [groupsByArea]);
   const availableGroups = useMemo(() => {
@@ -457,42 +441,6 @@ export default function AttendanceTab({
           options={columns.map(column => ({ id: column.id, label: column.label }))}
           value={visibleColumns}
           onChange={setVisibleColumns}
-        />
-      </div>
-      <div className="flex flex-wrap items-center gap-2">
-        <input
-          type="number"
-          min={0}
-          placeholder="Возраст от"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={ageMin}
-          onChange={event => setAgeMin(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          placeholder="Возраст до"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={ageMax}
-          onChange={event => setAgeMax(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          step="0.1"
-          placeholder="Опыт от (лет)"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={experienceMin}
-          onChange={event => setExperienceMin(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          step="0.1"
-          placeholder="Опыт до (лет)"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={experienceMax}
-          onChange={event => setExperienceMax(event.target.value)}
         />
       </div>
       {area && group && (

--- a/src/components/ClientsTab.tsx
+++ b/src/components/ClientsTab.tsx
@@ -22,11 +22,6 @@ import {
   type DuplicateMatchDetail,
 } from "../state/clients";
 import type { Client, ClientFormValues, DB, TaskItem, UIState } from "../types";
-import {
-  isAgeExperienceFilterActive,
-  matchesClientAgeExperience,
-  parseAgeExperienceFilter,
-} from "../utils/clientFilters";
 
 type ClientsTabProps = {
   db: DB;
@@ -72,10 +67,6 @@ export default function ClientsTab({ db, setDB, ui }: ClientsTabProps) {
   const [duplicatePrompt, setDuplicatePrompt] = useState<DuplicatePromptState | null>(null);
   const [duplicatesOpen, setDuplicatesOpen] = useState(false);
   const [query, setQuery] = useState(ui.search);
-  const [ageMin, setAgeMin] = useState("");
-  const [ageMax, setAgeMax] = useState("");
-  const [experienceMin, setExperienceMin] = useState("");
-  const [experienceMax, setExperienceMax] = useState("");
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -83,17 +74,6 @@ export default function ClientsTab({ db, setDB, ui }: ClientsTabProps) {
   }, [ui.search]);
 
   const search = query.trim().toLowerCase();
-  const ageExperienceFilter = useMemo(
-    () =>
-      parseAgeExperienceFilter({
-        minAgeText: ageMin,
-        maxAgeText: ageMax,
-        minExperienceYearsText: experienceMin,
-        maxExperienceYearsText: experienceMax,
-      }),
-    [ageMin, ageMax, experienceMin, experienceMax],
-  );
-  const isAgeExperienceActive = isAgeExperienceFilterActive(ageExperienceFilter);
   const list = useMemo(() => {
     const base = !search
       ? db.clients
@@ -106,8 +86,8 @@ export default function ClientsTab({ db, setDB, ui }: ClientsTabProps) {
             .toLowerCase();
           return contacts.includes(search);
         });
-    return base.filter(client => matchesClientAgeExperience(client, ageExperienceFilter));
-  }, [ageExperienceFilter, db.clients, search]);
+    return base;
+  }, [db.clients, search]);
 
   const duplicatePairs = useMemo(() => {
     const map = new Map<
@@ -415,9 +395,7 @@ export default function ClientsTab({ db, setDB, ui }: ClientsTabProps) {
 
   const total = db.clients.length;
   const visibleCount = list.length;
-  const counterText = search || isAgeExperienceActive
-    ? `Найдено: ${visibleCount} из ${total}`
-    : `Всего клиентов: ${total}`;
+  const counterText = search ? `Найдено: ${visibleCount} из ${total}` : `Всего клиентов: ${total}`;
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3">
@@ -465,42 +443,6 @@ export default function ClientsTab({ db, setDB, ui }: ClientsTabProps) {
             onChange={handleImportFile}
           />
         </div>
-      </div>
-      <div className="flex flex-wrap items-center gap-2">
-        <input
-          type="number"
-          min={0}
-          placeholder="Возраст от"
-          className="px-3 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-          value={ageMin}
-          onChange={event => setAgeMin(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          placeholder="Возраст до"
-          className="px-3 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-          value={ageMax}
-          onChange={event => setAgeMax(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          step="0.1"
-          placeholder="Опыт от (лет)"
-          className="px-3 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-          value={experienceMin}
-          onChange={event => setExperienceMin(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          step="0.1"
-          placeholder="Опыт до (лет)"
-          className="px-3 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100"
-          value={experienceMax}
-          onChange={event => setExperienceMax(event.target.value)}
-        />
       </div>
       <div>
         <ClientTable

--- a/src/components/GroupsTab.tsx
+++ b/src/components/GroupsTab.tsx
@@ -25,7 +25,6 @@ import {
 } from "../state/period";
 
 import { isReserveArea } from "../state/areas";
-import { parseAgeExperienceFilter } from "../utils/clientFilters";
 
 export default function GroupsTab({
   db,
@@ -63,21 +62,6 @@ export default function GroupsTab({
     if (!area) return [];
     return groupsByArea.get(area) ?? [];
   }, [area, groupsByArea]);
-  const [ageMin, setAgeMin] = useState("");
-  const [ageMax, setAgeMax] = useState("");
-  const [experienceMin, setExperienceMin] = useState("");
-  const [experienceMax, setExperienceMax] = useState("");
-  const ageExperienceFilter = useMemo(
-    () =>
-      parseAgeExperienceFilter({
-        minAgeText: ageMin,
-        maxAgeText: ageMax,
-        minExperienceYearsText: experienceMin,
-        maxExperienceYearsText: experienceMax,
-      }),
-    [ageMin, ageMax, experienceMin, experienceMax],
-  );
-
   useEffect(() => {
     writeDailyPeriod("groups", period.month, period.year);
   }, [period]);
@@ -280,14 +264,6 @@ export default function GroupsTab({
         year={period.year}
         onYearChange={handleYearChange}
         yearOptions={yearOptions}
-        ageMin={ageMin}
-        onAgeMinChange={setAgeMin}
-        ageMax={ageMax}
-        onAgeMaxChange={setAgeMax}
-        experienceMin={experienceMin}
-        onExperienceMinChange={setExperienceMin}
-        experienceMax={experienceMax}
-        onExperienceMaxChange={setExperienceMax}
       />
       <div>
         <ClientTable

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -36,7 +36,6 @@ import {
   type PeriodFilter,
 } from "../state/period";
 import { usePersistentTableSettings } from "../utils/tableSettings";
-import { matchesClientAgeExperience, parseAgeExperienceFilter } from "../utils/clientFilters";
 
 const DEFAULT_VISIBLE_COLUMNS = ["name", "area", "group", "mark"];
 const TABLE_SETTINGS_KEY = "performance";
@@ -70,21 +69,6 @@ export default function PerformanceTab({
     if (!area) return [];
     return groupsByArea.get(area) ?? [];
   }, [area, groupsByArea]);
-  const [ageMin, setAgeMin] = useState("");
-  const [ageMax, setAgeMax] = useState("");
-  const [experienceMin, setExperienceMin] = useState("");
-  const [experienceMax, setExperienceMax] = useState("");
-  const ageExperienceFilter = useMemo(
-    () =>
-      parseAgeExperienceFilter({
-        minAgeText: ageMin,
-        maxAgeText: ageMax,
-        minExperienceYearsText: experienceMin,
-        maxExperienceYearsText: experienceMax,
-      }),
-    [ageMin, ageMax, experienceMin, experienceMax],
-  );
-
   useEffect(() => {
     if (area && group && !availableGroups.includes(group)) {
       setGroup(null);
@@ -356,42 +340,6 @@ export default function PerformanceTab({
           options={columns.map(column => ({ id: column.id, label: column.label }))}
           value={visibleColumns}
           onChange={setVisibleColumns}
-        />
-      </div>
-      <div className="flex flex-wrap items-center gap-2">
-        <input
-          type="number"
-          min={0}
-          placeholder="Возраст от"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={ageMin}
-          onChange={event => setAgeMin(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          placeholder="Возраст до"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={ageMax}
-          onChange={event => setAgeMax(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          step="0.1"
-          placeholder="Опыт от (лет)"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={experienceMin}
-          onChange={event => setExperienceMin(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          step="0.1"
-          placeholder="Опыт до (лет)"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={experienceMax}
-          onChange={event => setExperienceMax(event.target.value)}
         />
       </div>
       <div className="text-xs text-slate-500">

--- a/src/components/clients/ClientFilters.tsx
+++ b/src/components/clients/ClientFilters.tsx
@@ -18,14 +18,6 @@ type Props = {
   year: number,
   onYearChange: (value: number) => void,
   yearOptions: number[],
-  ageMin: string,
-  onAgeMinChange: (value: string) => void,
-  ageMax: string,
-  onAgeMaxChange: (value: string) => void,
-  experienceMin: string,
-  onExperienceMinChange: (value: string) => void,
-  experienceMax: string,
-  onExperienceMaxChange: (value: string) => void,
 };
 
 function Chip({ active, onClick, children }: { active?: boolean; onClick?: () => void; children: React.ReactNode }) {
@@ -59,14 +51,6 @@ export default function ClientFilters({
   year,
   onYearChange,
   yearOptions,
-  ageMin,
-  onAgeMinChange,
-  ageMax,
-  onAgeMaxChange,
-  experienceMin,
-  onExperienceMinChange,
-  experienceMax,
-  onExperienceMaxChange,
 }: Props) {
   return (
     <>
@@ -139,42 +123,6 @@ export default function ClientFilters({
         <div className="text-xs text-slate-500">
           {area && group ? `Найдено: ${listLength}` : "Выберите район и группу"}
         </div>
-      </div>
-      <div className="flex flex-wrap gap-2 items-center">
-        <input
-          type="number"
-          min={0}
-          placeholder="Возраст от"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={ageMin}
-          onChange={event => onAgeMinChange(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          placeholder="Возраст до"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={ageMax}
-          onChange={event => onAgeMaxChange(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          step="0.1"
-          placeholder="Опыт от (лет)"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={experienceMin}
-          onChange={event => onExperienceMinChange(event.target.value)}
-        />
-        <input
-          type="number"
-          min={0}
-          step="0.1"
-          placeholder="Опыт до (лет)"
-          className="px-2 py-2 rounded-md border border-slate-300 text-sm bg-white dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
-          value={experienceMax}
-          onChange={event => onExperienceMaxChange(event.target.value)}
-        />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- remove the age and experience filter inputs from the performance, groups, attendance, and clients sections
- simplify the shared client filters component now that age and experience ranges are no longer configurable
- update client list counters to reflect search-only filtering

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68dee53daa58832bb09025352e865a8b