### PR TITLE
Adjust analytics targets to maximum values

### DIFF
--- a/src/state/__tests__/analytics.period.test.ts
+++ b/src/state/__tests__/analytics.period.test.ts
@@ -109,4 +109,15 @@ describe("computeAnalyticsSnapshot with period", () => {
     expect(snapshot.metrics.athletes.values.forecast).toBe(2);
     expect(snapshot.metrics.athletes.values.actual).toBe(2);
   });
+
+  it("uses maximum values for target projections", () => {
+    const db = buildDB();
+    const period: PeriodFilter = { year: 2024, month: 1 };
+    const snapshot = computeAnalyticsSnapshot(db, "all", period);
+
+    expect(snapshot.metrics.revenue.values.target).toBe(550);
+    expect(snapshot.metrics.profit.values.target).toBe(400);
+    expect(snapshot.metrics.fill.values.target).toBe(100);
+    expect(snapshot.metrics.athletes.values.target).toBe(10);
+  });
 });

--- a/src/state/analytics.ts
+++ b/src/state/analytics.ts
@@ -31,7 +31,7 @@ export const PROJECTION_LABELS: Record<ProjectionKey, string> = {
   actual: "Фактические",
   forecast: "Прогноз",
   remaining: "Остаток",
-  target: "До цели",
+  target: "Цель",
 };
 
 const METRIC_UNITS: Record<MetricKey, Unit> = {
@@ -321,7 +321,7 @@ export function computeAnalyticsSnapshot(db: DB, area: AreaScope, period?: Perio
         actual: ensureNumber(actualRevenue),
         forecast: ensureNumber(forecastRevenue),
         remaining: Math.max(0, ensureNumber(forecastRevenue - actualRevenue)),
-        target: Math.max(0, ensureNumber(maxRevenue - actualRevenue)),
+        target: ensureNumber(maxRevenue),
       },
     },
     profit: {
@@ -330,7 +330,7 @@ export function computeAnalyticsSnapshot(db: DB, area: AreaScope, period?: Perio
         actual: ensureNumber(actualProfit),
         forecast: ensureNumber(forecastProfit),
         remaining: Math.max(0, ensureNumber(forecastProfit - actualProfit)),
-        target: Math.max(0, ensureNumber(maxProfit - actualProfit)),
+        target: ensureNumber(maxProfit),
       },
     },
     fill: {
@@ -339,7 +339,7 @@ export function computeAnalyticsSnapshot(db: DB, area: AreaScope, period?: Perio
         actual: ensureNumber(actualFill),
         forecast: ensureNumber(forecastFill),
         remaining: Math.max(0, ensureNumber(forecastFill - actualFill)),
-        target: capacity ? Math.max(0, 100 - ensureNumber(actualFill)) : 0,
+        target: capacity ? 100 : 0,
       },
     },
     athletes: {
@@ -348,7 +348,7 @@ export function computeAnalyticsSnapshot(db: DB, area: AreaScope, period?: Perio
         actual: actualClients.length,
         forecast: rosterClients.length,
         remaining: Math.max(0, rosterClients.length - actualClients.length),
-        target: Math.max(0, capacity - actualClients.length),
+        target: capacity,
       },
     },
   };


### PR DESCRIPTION
## Summary
- rename the analytics target projection label to «Цель»
- set snapshot target values to use maximum revenue, profit, fill, and athlete counts
- add a regression test to cover the new target calculations

## Testing
- CI=1 npm test -- --runTestsByPath src/state/__tests__/analytics.period.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e02547fa30832b84df183ebb00629c