### PR TITLE
Open quick-add client for immediate editing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -132,7 +132,7 @@ export default function App() {
               path="/clients"
               element={
                 can(ui.role, "manage_clients") ? (
-                  <ClientsTab db={db} setDB={setDB} ui={ui} />
+                  <ClientsTab db={db} setDB={setDB} ui={ui} setUI={setUI} />
                 ) : (
                   <Navigate to="/dashboard" replace />
                 )

--- a/src/components/ClientsTab.tsx
+++ b/src/components/ClientsTab.tsx
@@ -27,6 +27,7 @@ type ClientsTabProps = {
   db: DB;
   setDB: Dispatch<SetStateAction<DB>>;
   ui: UIState;
+  setUI: Dispatch<SetStateAction<UIState>>;
 };
 
 type DuplicatePromptState = {
@@ -61,7 +62,7 @@ type DuplicatePair = {
   matches: DuplicateMatchDetail[];
 };
 
-export default function ClientsTab({ db, setDB, ui }: ClientsTabProps) {
+export default function ClientsTab({ db, setDB, ui, setUI }: ClientsTabProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<Client | null>(null);
   const [duplicatePrompt, setDuplicatePrompt] = useState<DuplicatePromptState | null>(null);
@@ -72,6 +73,21 @@ export default function ClientsTab({ db, setDB, ui }: ClientsTabProps) {
   useEffect(() => {
     setQuery(ui.search);
   }, [ui.search]);
+
+  useEffect(() => {
+    const pendingId = ui.pendingClientId;
+    if (!pendingId) {
+      return;
+    }
+
+    const nextEditing =
+      pendingId === "new" ? null : db.clients.find(entry => entry.id === pendingId) ?? null;
+
+    setEditing(nextEditing);
+    setModalOpen(true);
+
+    setUI(prev => (prev.pendingClientId === pendingId ? { ...prev, pendingClientId: null } : prev));
+  }, [db.clients, setUI, ui.pendingClientId]);
 
   const search = query.trim().toLowerCase();
   const list = useMemo(() => {

--- a/src/components/__tests__/ClientsTab.test.tsx
+++ b/src/components/__tests__/ClientsTab.test.tsx
@@ -93,6 +93,7 @@ const makeUI = (overrides = {}) => ({
   currency: 'EUR',
   search: '',
   theme: 'light',
+  pendingClientId: null,
   ...overrides,
 });
 
@@ -128,7 +129,7 @@ test('search filters clients by full name', async () => {
     makeClient({ id: 'c2', firstName: 'Пётр', lastName: 'Сидоров' }),
   ];
 
-  render(<ClientsTab db={db} setDB={() => {}} ui={makeUI()} />);
+  render(<ClientsTab db={db} setDB={() => {}} ui={makeUI()} setUI={() => {}} />);
   expect(screen.getByText('Всего клиентов: 2')).toBeInTheDocument();
   expect(screen.getByText('Иван Иванов')).toBeInTheDocument();
   expect(screen.getByText('Пётр Сидоров')).toBeInTheDocument();
@@ -143,7 +144,7 @@ test('search filters clients by full name', async () => {
 test('create: adds client through modal', async () => {
   const Wrapper = () => {
     const [state, setState] = React.useState(makeDB());
-    return <ClientsTab db={state} setDB={setState} ui={makeUI()} />;
+    return <ClientsTab db={state} setDB={setState} ui={makeUI()} setUI={() => {}} />;
   };
 
   render(<Wrapper />);
@@ -174,7 +175,7 @@ test('create: warns about duplicates and allows opening existing client', async 
 
   const Wrapper = () => {
     const [state, setState] = React.useState({ ...makeDB(), clients: [existing] });
-    return <ClientsTab db={state} setDB={setState} ui={makeUI()} />;
+    return <ClientsTab db={state} setDB={setState} ui={makeUI()} setUI={() => {}} />;
   };
 
   render(<Wrapper />);
@@ -216,7 +217,7 @@ test('create: can proceed after duplicate warning', async () => {
 
   const Wrapper = () => {
     const [state, setState] = React.useState({ ...makeDB(), clients: [existing] });
-    return <ClientsTab db={state} setDB={setState} ui={makeUI()} />;
+    return <ClientsTab db={state} setDB={setState} ui={makeUI()} setUI={() => {}} />;
   };
 
   render(<Wrapper />);

--- a/src/components/__tests__/GroupsTab.test.tsx
+++ b/src/components/__tests__/GroupsTab.test.tsx
@@ -111,6 +111,7 @@ const makeUI = () => ({
   currency: 'EUR',
   search: '',
   theme: 'light',
+  pendingClientId: null,
 });
 
 const renderGroups = (db = makeDB(), ui = makeUI(), initialFilters = {}) => {

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { TAB_TITLES } from "../components/Tabs";
 import { useToasts } from "../components/Toasts";
 import { doc, onSnapshot, setDoc } from "firebase/firestore";
@@ -228,6 +228,7 @@ const defaultUI: UIState = {
   currency: "EUR",
   search: "",
   theme: "light",
+  pendingClientId: null,
 };
 
 export function can(
@@ -339,6 +340,7 @@ export function useAppState(): AppState {
   const [quickOpen, setQuickOpen] = useState(false);
   const [isLocalOnly, setIsLocalOnly] = useState<boolean>(() => !firestore);
   const location = useLocation();
+  const navigate = useNavigate();
   const localOnlyToastShownRef = useRef(false);
 
   const loginUser = useCallback<Required<AppState>["loginUser"]>(
@@ -592,6 +594,8 @@ export function useAppState(): AppState {
     const next = { ...db, clients: [c, ...db.clients] };
     if (await commitDBUpdate(next, setDB)) {
       setQuickOpen(false);
+      setUI(prev => ({ ...prev, pendingClientId: c.id }));
+      navigate("/clients");
       push("Клиент создан", "success");
     } else {
       push("Не удалось сохранить клиента", "error");

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,7 @@ export interface UIState {
   currency: Currency;
   search: string;
   theme: "light" | "dark";
+  pendingClientId: string | null;
 }
 
 export type TabKey =


### PR DESCRIPTION
## Summary
- add UI state to track a client that should open in the editor
- navigate to the Clients tab and auto-open the edit modal after using quick add
- adjust related components and tests for the new workflow

## Testing
- npm test -- --runTestsByPath src/components/__tests__/ClientsTab.test.tsx src/components/__tests__/GroupsTab.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e025875968832b8115ea7ba6fcb0d3