### PR TITLE
feat: add actual payment tracking for clients

### DIFF
--- a/src/components/ClientsTab.tsx
+++ b/src/components/ClientsTab.tsx
@@ -198,6 +198,9 @@ export default function ClientsTab({ db, setDB, ui, setUI }: ClientsTabProps) {
       if (!Object.prototype.hasOwnProperty.call(prepared, "payAmount")) {
         delete updated.payAmount;
       }
+      if (!Object.prototype.hasOwnProperty.call(prepared, "payActual")) {
+        delete updated.payActual;
+      }
       if (!Object.prototype.hasOwnProperty.call(prepared, "remainingLessons")) {
         delete updated.remainingLessons;
       }

--- a/src/components/GroupsTab.tsx
+++ b/src/components/GroupsTab.tsx
@@ -162,6 +162,9 @@ export default function GroupsTab({
       if (!Object.prototype.hasOwnProperty.call(prepared, "payAmount")) {
         delete updated.payAmount;
       }
+      if (!Object.prototype.hasOwnProperty.call(prepared, "payActual")) {
+        delete updated.payActual;
+      }
       if (!Object.prototype.hasOwnProperty.call(prepared, "remainingLessons")) {
         delete updated.remainingLessons;
       }

--- a/src/components/clients/ClientDetailsModal.tsx
+++ b/src/components/clients/ClientDetailsModal.tsx
@@ -113,6 +113,10 @@ export default function ClientDetailsModal({
               label="Сумма оплаты"
               value={client.payAmount != null ? fmtMoney(client.payAmount, currency, currencyRates) : "—"}
             />
+            <InfoRow
+              label="Факт оплаты"
+              value={client.payActual != null ? fmtMoney(client.payActual, currency, currencyRates) : "—"}
+            />
             <InfoRow label="Остаток занятий" value={remaining != null ? String(remaining) : "—"} />
           </div>
         )}

--- a/src/components/clients/ClientForm.tsx
+++ b/src/components/clients/ClientForm.tsx
@@ -69,6 +69,7 @@ export default function ClientForm({ db, editing, onSave, onClose }: Props) {
     payDate: todayISO().slice(0, 10),
     parentName: "",
     payAmount: String(getDefaultPayAmount(db.settings.groups[0]) ?? ""),
+    payActual: "",
     remainingLessons: "",
     subscriptionPlan: DEFAULT_SUBSCRIPTION_PLAN,
   }), [db.settings.areas, db.settings.groups, firstAreaWithSchedule, firstGroupForArea]);
@@ -125,6 +126,7 @@ export default function ClientForm({ db, editing, onSave, onClose }: Props) {
         payDate: editing.payDate?.slice(0, 10) ?? "",
         parentName: editing.parentName ?? "",
         payAmount: editing.payAmount != null ? String(editing.payAmount) : String(getDefaultPayAmount(editing.group) ?? ""),
+        payActual: editing.payActual != null ? String(editing.payActual) : "",
         remainingLessons: editing.remainingLessons != null ? String(editing.remainingLessons) : "",
         subscriptionPlan: editing.subscriptionPlan ?? DEFAULT_SUBSCRIPTION_PLAN,
       };
@@ -361,6 +363,16 @@ export default function ClientForm({ db, editing, onSave, onClose }: Props) {
                 {payAmountLockedByPlan ? "Сумма выбрана формой абонемента" : "Сумма фиксирована для этой группы"}
               </span>
             )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Факт оплаты, €</label>
+            <input
+              type="number"
+              inputMode="decimal"
+              className={fieldClass}
+              {...register("payActual")}
+              placeholder="Укажите сумму"
+            />
           </div>
           <div className="flex flex-col gap-1">
             <label className={labelClass}>Остаток занятий</label>

--- a/src/components/clients/__tests__/clientCsv.test.ts
+++ b/src/components/clients/__tests__/clientCsv.test.ts
@@ -56,6 +56,7 @@ const baseCandidate = (): Omit<Client, 'id'> => ({
   subscriptionPlan: 'monthly',
   payDate: '2024-01-10T00:00:00.000Z',
   payAmount: 100,
+  payActual: 100,
   remainingLessons: 5,
 });
 
@@ -90,6 +91,7 @@ describe('appendImportedClients', () => {
       subscriptionPlan: 'monthly',
       payDate: '2024-01-10T00:00:00.000Z',
       payAmount: 120,
+      payActual: 120,
       remainingLessons: 8,
     };
 
@@ -108,6 +110,7 @@ describe('appendImportedClients', () => {
         lastName: 'Сидоров',
         telegram: '@petr',
         payAmount: 150,
+        payActual: 150,
       },
       {
         ...baseCandidate(),
@@ -116,6 +119,7 @@ describe('appendImportedClients', () => {
         telegram: 'https://t.me/petr',
         instagram: 'https://instagram.com/petr',
         payAmount: 160,
+        payActual: 160,
       },
     ];
 

--- a/src/components/clients/clientCsv.ts
+++ b/src/components/clients/clientCsv.ts
@@ -39,6 +39,7 @@ export const CLIENT_CSV_HEADERS = [
   "subscriptionPlan",
   "payDate",
   "payAmount",
+  "payActual",
   "remainingLessons",
   "statusUpdatedAt",
 ] as const;
@@ -92,6 +93,9 @@ const HEADER_ALIASES: HeaderAliasMap = {
   "дата_оплаты": "payDate",
   payamount: "payAmount",
   "сумма": "payAmount",
+  payactual: "payActual",
+  "факт": "payActual",
+  "факт_оплаты": "payActual",
   remaininglessons: "remainingLessons",
   "оставшиеся_занятия": "remainingLessons",
   statusupdatedat: "statusUpdatedAt",
@@ -307,6 +311,7 @@ function clientToRow(client: Client): (string | number | null | undefined)[] {
     client.subscriptionPlan ?? DEFAULT_SUBSCRIPTION_PLAN,
     client.payDate ? client.payDate.slice(0, 10) : "",
     client.payAmount != null ? client.payAmount : "",
+    client.payActual != null ? client.payActual : "",
     client.remainingLessons != null ? client.remainingLessons : "",
     client.statusUpdatedAt ? client.statusUpdatedAt.slice(0, 10) : "",
   ];
@@ -342,6 +347,7 @@ export function buildClientCsvTemplate(): string {
     "monthly",
     "2024-09-10",
     "12000",
+    "",
     "",
     "2024-10-10",
   ];
@@ -516,6 +522,15 @@ export function parseClientsCsv(text: string, db: DB): ClientCsvImportResult {
       }
     }
 
+    const payActualRaw = normalizeNumberString(record.payActual);
+    if (payActualRaw) {
+      const parsedActual = Number.parseFloat(payActualRaw);
+      if (Number.isNaN(parsedActual) || !Number.isFinite(parsedActual)) {
+        errors.push(`Строка ${lineNumber}: неверное значение payActual "${record.payActual}"`);
+        hasError = true;
+      }
+    }
+
     const remainingRaw = normalizeIntString(record.remainingLessons);
     if (remainingRaw) {
       const parsedRemaining = Number.parseInt(remainingRaw, 10);
@@ -559,6 +574,7 @@ export function parseClientsCsv(text: string, db: DB): ClientCsvImportResult {
       subscriptionPlan,
       payDate: payDate ?? "",
       payAmount: payAmountRaw,
+      payActual: payActualRaw,
       remainingLessons: remainingRaw,
     };
 

--- a/src/components/clients/clientMutations.test.ts
+++ b/src/components/clients/clientMutations.test.ts
@@ -23,14 +23,16 @@ describe("transformClientFormValues", () => {
     subscriptionPlan: "monthly",
     payDate: "2024-01-10",
     payAmount: "",
+    payActual: "",
     remainingLessons: "",
   };
 
-  it("omits payAmount and remainingLessons when not provided", () => {
+  it("omits payAmount, payActual and remainingLessons when not provided", () => {
     const data: ClientFormValues = {
       ...baseFormValues,
       group: "взрослые",
       payAmount: "",
+      payActual: "",
       remainingLessons: "",
       whatsApp: "",
     };
@@ -38,6 +40,7 @@ describe("transformClientFormValues", () => {
     const result = transformClientFormValues(data);
 
     expect(result).not.toHaveProperty("payAmount");
+    expect(result).not.toHaveProperty("payActual");
     expect(result).not.toHaveProperty("remainingLessons");
   });
 
@@ -46,6 +49,7 @@ describe("transformClientFormValues", () => {
       ...baseFormValues,
       group: "индивидуальные",
       payAmount: "150",
+      payActual: "120",
       remainingLessons: "8",
       telegram: "@client",
     };
@@ -54,6 +58,7 @@ describe("transformClientFormValues", () => {
 
     expect(result).toMatchObject({
       payAmount: 150,
+      payActual: 120,
       remainingLessons: 8,
       telegram: "@client",
     });
@@ -77,6 +82,7 @@ describe("transformClientFormValues", () => {
       ...baseFormValues,
       group: "взрослые",
       payAmount: "",
+      payActual: "",
     };
 
     const editing: Client = {
@@ -87,5 +93,22 @@ describe("transformClientFormValues", () => {
     const result = transformClientFormValues(data, editing);
 
     expect(result).toHaveProperty("payAmount", 100);
+  });
+
+  it("allows clearing payActual when editing", () => {
+    const data: ClientFormValues = {
+      ...baseFormValues,
+      group: "индивидуальные",
+      payActual: "",
+    };
+
+    const editing: Client = {
+      id: "client-2",
+      ...transformClientFormValues({ ...baseFormValues, payActual: "200", group: "индивидуальные" }),
+    };
+
+    const result = transformClientFormValues(data, editing);
+
+    expect(result).not.toHaveProperty("payActual");
   });
 });

--- a/src/components/clients/clientMutations.ts
+++ b/src/components/clients/clientMutations.ts
@@ -46,6 +46,7 @@ export function transformClientFormValues(
 ): Omit<Client, "id"> {
   const {
     payAmount: payAmountRaw,
+    payActual: payActualRaw,
     remainingLessons: remainingLessonsRaw,
     subscriptionPlan,
     lastName,
@@ -57,6 +58,17 @@ export function transformClientFormValues(
     ...base
   } = data;
   const resolvedPayAmount = resolvePayAmount(payAmountRaw, base.group, subscriptionPlan, editing?.payAmount);
+  const resolvedPayActual = (() => {
+    const normalized = payActualRaw.trim();
+    if (!normalized.length) {
+      return undefined;
+    }
+    const parsed = Number.parseFloat(normalized);
+    if (Number.isNaN(parsed) || !Number.isFinite(parsed)) {
+      return undefined;
+    }
+    return parsed;
+  })();
   let resolvedRemaining: number | undefined;
   if (
     requiresManualRemainingLessons(base.group) ||
@@ -81,6 +93,7 @@ export function transformClientFormValues(
     ...(telegram.trim() ? { telegram: telegram.trim() } : {}),
     ...(instagram.trim() ? { instagram: instagram.trim() } : {}),
     ...(resolvedPayAmount != null ? { payAmount: resolvedPayAmount } : {}),
+    ...(resolvedPayActual != null ? { payActual: resolvedPayActual } : {}),
     ...(resolvedRemaining != null ? { remainingLessons: resolvedRemaining } : {}),
     ...(statusUpdatedAt ? { statusUpdatedAt } : {}),
     birthDate: parseDateInput(data.birthDate),

--- a/src/state/__tests__/analytics.period.test.ts
+++ b/src/state/__tests__/analytics.period.test.ts
@@ -21,6 +21,7 @@ describe("computeAnalyticsSnapshot with period", () => {
         status: "действующий",
         payDate: "2024-01-10T00:00:00.000Z",
         payAmount: 60,
+        payActual: 60,
         remainingLessons: 0,
       },
       {
@@ -39,6 +40,7 @@ describe("computeAnalyticsSnapshot with period", () => {
         status: "действующий",
         payDate: "2023-12-05T00:00:00.000Z",
         payAmount: 70,
+        payActual: 70,
         remainingLessons: 0,
       },
     ],
@@ -100,6 +102,7 @@ describe("computeAnalyticsSnapshot with period", () => {
       status: "новый",
       payDate: "2024-03-05T00:00:00.000Z",
       payAmount: 80,
+      payActual: 0,
       remainingLessons: 0,
     });
 

--- a/src/state/analytics.ts
+++ b/src/state/analytics.ts
@@ -242,8 +242,12 @@ function deriveGroupPrice(db: DB, group: string): number {
   return total / relevant.length;
 }
 
-function getClientAmount(client: Client): number {
+function getClientForecastAmount(client: Client): number {
   return ensureNumber(client.payAmount ?? getDefaultPayAmount(client.group) ?? 0);
+}
+
+function getClientActualAmount(client: Client): number {
+  return ensureNumber(client.payActual ?? 0);
 }
 
 function capacityForArea(db: DB, area: Area): number {
@@ -301,8 +305,8 @@ export function computeAnalyticsSnapshot(db: DB, area: AreaScope, period?: Perio
   const rent = rentForAreas(db, relevantAreas);
   const coachSalary = coachSalaryForAreas(db, relevantAreas);
 
-  const actualRevenue = actualClients.reduce((sum, client) => sum + getClientAmount(client), 0);
-  const forecastRevenue = rosterClients.reduce((sum, client) => sum + getClientAmount(client), 0);
+  const actualRevenue = actualClients.reduce((sum, client) => sum + getClientActualAmount(client), 0);
+  const forecastRevenue = rosterClients.reduce((sum, client) => sum + getClientForecastAmount(client), 0);
   const maxRevenue = relevantAreas.reduce((sum, item) => sum + maxRevenueForArea(db, item), 0);
 
   const totalExpenses = rent + coachSalary;

--- a/src/state/seed.ts
+++ b/src/state/seed.ts
@@ -125,6 +125,7 @@ export function makeSeedDB(): DB {
       subscriptionPlan,
       payDate: start.toISOString(),
       payAmount: planMeta?.amount ?? rnd(50, 100),
+      payActual: planMeta?.amount ?? rnd(40, 100),
       remainingLessons: manual ? rnd(4, 12) : undefined,
     } as Client;
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export interface Client {
   subscriptionPlan?: SubscriptionPlan;
   payDate?: string; // ISO
   payAmount?: number;
+  payActual?: number;
   remainingLessons?: number;
   // Автополя (рассчитываются на лету)
 }
@@ -80,6 +81,7 @@ export interface ClientFormValues {
   subscriptionPlan: SubscriptionPlan;
   payDate: string;
   payAmount: string;
+  payActual: string;
   remainingLessons: string;
 }
 


### PR DESCRIPTION
## Summary
- add the `payActual` field to client types, forms, CSV import/export, and seed data
- show the new "Факт оплаты" value in the client details modal and make it editable in the client form
- use the actual payment amounts for analytics actual revenue while keeping planned revenue based on the forecast amount

## Testing
- npm test -- --watch=false *(fails: useNavigate is not a function in react-router-dom mock)*

------
https://chatgpt.com/codex/tasks/task_e_68e02debe7d4832b9f6c0b4706bbfd0e