### PR TITLE
Fix lead card opening and stabilize payment details

### DIFF
--- a/src/components/LeadsTab.tsx
+++ b/src/components/LeadsTab.tsx
@@ -168,17 +168,44 @@ export default function LeadsTab({
                 {({ index, style }: ListChildComponentProps) => {
                   const l = leads[index];
                   return (
-                    <div key={l.id} style={style} className="p-2 rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800">
-                      <button
-                        onClick={() => setOpen(l)}
-                        className="w-full text-left text-sm font-medium transition-colors duration-150 hover:text-sky-600 hover:underline dark:hover:text-sky-300"
-                      >
+                    <div
+                      key={l.id}
+                      style={style}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => setOpen(l)}
+                      onKeyDown={event => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          setOpen(l);
+                        }
+                      }}
+                      aria-label={l.name}
+                      className="group p-2 rounded-xl border border-slate-200 bg-slate-50 transition hover:border-sky-200 hover:bg-sky-50 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-sky-700 dark:hover:bg-slate-700 cursor-pointer"
+                    >
+                      <div className="text-sm font-medium text-slate-800 transition-colors duration-150 group-hover:text-sky-600 dark:text-slate-100 dark:group-hover:text-sky-300">
                         {l.name}
-                      </button>
+                      </div>
                       <div className="text-xs text-slate-500">{l.source}{formatLeadContactSummary(l)}</div>
                       <div className="flex gap-1 mt-2">
-                        <button onClick={() => move(l.id, -1)} className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">◀</button>
-                        <button onClick={() => move(l.id, +1)} className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800">▶</button>
+                        <button
+                          onClick={event => {
+                            event.stopPropagation();
+                            void move(l.id, -1);
+                          }}
+                          className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
+                        >
+                          ◀
+                        </button>
+                        <button
+                          onClick={event => {
+                            event.stopPropagation();
+                            void move(l.id, +1);
+                          }}
+                          className="px-2 py-1 text-xs rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
+                        >
+                          ▶
+                        </button>
                       </div>
                     </div>
                   );

--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -214,6 +214,13 @@ export default function ClientTable({
       sortValue: client => client.payAmount ?? 0,
     },
     {
+      id: "payActual",
+      label: "Факт оплаты",
+      width: "minmax(130px, max-content)",
+      renderCell: client => (client.payActual != null ? fmtMoney(client.payActual, currency, currencyRates) : "—"),
+      sortValue: client => client.payActual ?? 0,
+    },
+    {
       id: "payDate",
       label: "Дата оплаты",
       width: "minmax(140px, max-content)",


### PR DESCRIPTION
## Summary
- make lead cards clickable with proper keyboard support and ensure stage controls don’t trigger the modal
- prevent client payment amounts from being overwritten when opening the edit form by only syncing on relevant changes
- expose the “Факт оплаты” column in client table column settings for groups and clients

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e104115684832ba4c53f92048435fa