### PR TITLE
Add revision tracking and conflict handling for DB persistence

### DIFF
--- a/src/components/AnalyticsTab.tsx
+++ b/src/components/AnalyticsTab.tsx
@@ -146,12 +146,14 @@ export default function AnalyticsTab({ db, setDB, currency }: Props) {
         [field]: { ...(currentMap ?? {}), [area]: value },
       } as DB["settings"];
       const next = { ...db, settings: nextSettings };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
-        window.alert(
-          "Не удалось сохранить значение. Изменение сохранено локально, проверьте подключение к базе данных.",
-        );
-        setDB(next);
+      const result = await commitDBUpdate(next, setDB);
+      if (!result.ok) {
+        if (result.reason === "error") {
+          window.alert(
+            "Не удалось сохранить значение. Изменение сохранено локально, проверьте подключение к базе данных.",
+          );
+        }
+        return;
       }
     },
     [area, db, setDB],
@@ -196,12 +198,14 @@ export default function AnalyticsTab({ db, setDB, currency }: Props) {
         nextFavorites = [...favorites, id];
       }
       const next = { ...db, settings: { ...db.settings, analyticsFavorites: nextFavorites } };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
-        window.alert(
-          "Не удалось обновить избранные показатели. Изменение сохранено локально, проверьте доступ к базе данных.",
-        );
-        setDB(next);
+      const result = await commitDBUpdate(next, setDB);
+      if (!result.ok) {
+        if (result.reason === "error") {
+          window.alert(
+            "Не удалось обновить избранные показатели. Изменение сохранено локально, проверьте доступ к базе данных.",
+          );
+        }
+        return;
       }
     },
     [db, favorites, setDB],

--- a/src/components/AttendanceTab.tsx
+++ b/src/components/AttendanceTab.tsx
@@ -225,12 +225,14 @@ export default function AttendanceTab({
         attendance: db.attendance.filter(entry => entry.id !== mark.id),
         clients: db.clients,
       };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
-        window.alert(
-          "Не удалось обновить отметку посещаемости. Изменение сохранено локально, проверьте доступ к базе данных.",
-        );
-        setDB(next);
+      const result = await commitDBUpdate(next, setDB);
+      if (!result.ok) {
+        if (result.reason === "error") {
+          window.alert(
+            "Не удалось обновить отметку посещаемости. Изменение сохранено локально, проверьте доступ к базе данных.",
+          );
+        }
+        return;
       }
     } else if (mark) {
       const updated = { ...mark, came: false };
@@ -250,12 +252,14 @@ export default function AttendanceTab({
         attendance: db.attendance.map(entry => (entry.id === mark.id ? updated : entry)),
         clients: nextClients,
       };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
-        window.alert(
-          "Не удалось обновить отметку посещаемости. Изменение сохранено локально, проверьте доступ к базе данных.",
-        );
-        setDB(next);
+      const result = await commitDBUpdate(next, setDB);
+      if (!result.ok) {
+        if (result.reason === "error") {
+          window.alert(
+            "Не удалось обновить отметку посещаемости. Изменение сохранено локально, проверьте доступ к базе данных.",
+          );
+        }
+        return;
       }
     } else {
       const desiredDate = toMiddayISO(selectedDate) ?? new Date().toISOString();
@@ -272,12 +276,13 @@ export default function AttendanceTab({
             return { ...c, remainingLessons: nextRemaining };
           });
       const next = { ...db, attendance: [entry, ...db.attendance], clients: nextClients };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
-        window.alert(
-          "Не удалось сохранить отметку посещаемости. Изменение сохранено локально, проверьте доступ к базе данных.",
-        );
-        setDB(next);
+      const result = await commitDBUpdate(next, setDB);
+      if (!result.ok) {
+        if (result.reason === "error") {
+          window.alert(
+            "Не удалось сохранить отметку посещаемости. Изменение сохранено локально, проверьте доступ к базе данных.",
+          );
+        }
       }
     }
   }, [db, marksForSelectedDate, selectedDate, setDB]);
@@ -382,9 +387,11 @@ export default function AttendanceTab({
       ...db,
       clients: db.clients.map(client => (client.id === editing.id ? updated : client)),
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert("Не удалось сохранить изменения клиента. Проверьте доступ к базе данных.");
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok) {
+      if (result.reason === "error") {
+        window.alert("Не удалось сохранить изменения клиента. Проверьте доступ к базе данных.");
+      }
       return;
     }
     setEditing(null);

--- a/src/components/ClientsTab.tsx
+++ b/src/components/ClientsTab.tsx
@@ -179,12 +179,14 @@ export default function ClientsTab({ db, setDB, ui, setUI }: ClientsTabProps) {
         { id: uid(), who: "UI", what: `Создан клиент ${client.firstName}`, when: todayISO() },
       ],
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert(
-        "Не удалось синхронизировать нового клиента. Запись сохранена локально, проверьте доступ к базе данных.",
-      );
-      setDB(next);
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok) {
+      if (result.reason === "error") {
+        window.alert(
+          "Не удалось синхронизировать нового клиента. Запись сохранена локально, проверьте доступ к базе данных.",
+        );
+      }
+      return;
     }
     setModalOpen(false);
     setEditing(null);
@@ -213,10 +215,14 @@ export default function ClientsTab({ db, setDB, ui, setUI }: ClientsTabProps) {
           { id: uid(), who: "UI", what: `Обновлён клиент ${finalClient.firstName}`, when: todayISO() },
         ],
       };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
-        window.alert("Не удалось синхронизировать изменения клиента. Они сохранены локально, проверьте доступ к базе данных.");
-        setDB(next);
+      const result = await commitDBUpdate(next, setDB);
+      if (!result.ok) {
+        if (result.reason === "error") {
+          window.alert(
+            "Не удалось синхронизировать изменения клиента. Они сохранены локально, проверьте доступ к базе данных.",
+          );
+        }
+        return;
       }
       setModalOpen(false);
       setEditing(null);
@@ -281,8 +287,8 @@ export default function ClientsTab({ db, setDB, ui, setUI }: ClientsTabProps) {
         { id: uid(), who: "UI", what: `Создана задача по оплате ${client.firstName}`, when: todayISO() },
       ],
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось создать задачу. Проверьте доступ к базе данных.");
     }
   };
@@ -294,8 +300,8 @@ export default function ClientsTab({ db, setDB, ui, setUI }: ClientsTabProps) {
       clients: db.clients.filter(client => client.id !== id),
       changelog: [...db.changelog, { id: uid(), who: "UI", what: `Удалён клиент ${id}`, when: todayISO() }],
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось удалить клиента. Проверьте доступ к базе данных.");
     }
   };
@@ -334,12 +340,14 @@ export default function ClientsTab({ db, setDB, ui, setUI }: ClientsTabProps) {
 
         if (shouldReplace) {
           const { next, summary } = replaceImportedClients(db, result.clients);
-          const ok = await commitDBUpdate(next, setDB);
-          if (!ok) {
-            window.alert(
-              "Не удалось синхронизировать импорт. Данные сохранены локально, проверьте доступ к базе данных.",
-            );
-            setDB(next);
+          const resultCommit = await commitDBUpdate(next, setDB);
+          if (!resultCommit.ok) {
+            if (resultCommit.reason === "error") {
+              window.alert(
+                "Не удалось синхронизировать импорт. Данные сохранены локально, проверьте доступ к базе данных.",
+              );
+            }
+            return;
           }
           messages.push(`Заменено клиентов: ${summary.replaced}`);
           const removedClients = summary.previous - summary.replaced;
@@ -360,12 +368,14 @@ export default function ClientsTab({ db, setDB, ui, setUI }: ClientsTabProps) {
           }
         } else {
           const { next, summary } = appendImportedClients(db, result.clients);
-          const ok = await commitDBUpdate(next, setDB);
-          if (!ok) {
-            window.alert(
-              "Не удалось синхронизировать импорт. Данные сохранены локально, проверьте доступ к базе данных.",
-            );
-            setDB(next);
+          const resultCommit = await commitDBUpdate(next, setDB);
+          if (!resultCommit.ok) {
+            if (resultCommit.reason === "error") {
+              window.alert(
+                "Не удалось синхронизировать импорт. Данные сохранены локально, проверьте доступ к базе данных.",
+              );
+            }
+            return;
           }
           messages.push(`Импортировано клиентов: ${summary.added}`);
           if (summary.merged) {

--- a/src/components/GroupsTab.tsx
+++ b/src/components/GroupsTab.tsx
@@ -173,10 +173,12 @@ export default function GroupsTab({
         clients: db.clients.map(cl => (cl.id === editing.id ? updated : cl)),
         changelog: [...db.changelog, { id: uid(), who: "UI", what: `Обновлён клиент ${updated.firstName}`, when: todayISO() }],
       };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
-        window.alert("Не удалось синхронизировать изменения клиента. Они сохранены локально, проверьте доступ к базе данных.");
-        setDB(next);
+      const result = await commitDBUpdate(next, setDB);
+      if (!result.ok) {
+        if (result.reason === "error") {
+          window.alert("Не удалось синхронизировать изменения клиента. Они сохранены локально, проверьте доступ к базе данных.");
+        }
+        return;
       }
     } else {
       const c: Client = {
@@ -189,10 +191,14 @@ export default function GroupsTab({
         clients: [c, ...db.clients],
         changelog: [...db.changelog, { id: uid(), who: "UI", what: `Создан клиент ${c.firstName}`, when: todayISO() }],
       };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
-        window.alert("Не удалось синхронизировать нового клиента. Запись сохранена локально, проверьте доступ к базе данных.");
-        setDB(next);
+      const result = await commitDBUpdate(next, setDB);
+      if (!result.ok) {
+        if (result.reason === "error") {
+          window.alert(
+            "Не удалось синхронизировать нового клиента. Запись сохранена локально, проверьте доступ к базе данных.",
+          );
+        }
+        return;
       }
     }
     setModalOpen(false);
@@ -231,8 +237,8 @@ export default function GroupsTab({
         { id: uid(), who: "UI", what: `Создана задача по оплате ${client.firstName}`, when: todayISO() },
       ],
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось создать задачу. Проверьте доступ к базе данных.");
     }
   };
@@ -244,8 +250,8 @@ export default function GroupsTab({
       clients: db.clients.filter(c => c.id !== id),
       changelog: [...db.changelog, { id: uid(), who: "UI", what: `Удалён клиент ${id}`, when: todayISO() }],
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось удалить клиента. Проверьте доступ к базе данных.");
     }
   };

--- a/src/components/LeadsTab.tsx
+++ b/src/components/LeadsTab.tsx
@@ -49,10 +49,12 @@ export default function LeadsTab({
     const updatedLead: Lead = { ...current, stage: nextStage, updatedAt: todayISO() };
 
     const next = { ...db, leads: db.leads.map(x => (x.id === id ? updatedLead : x)) };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert("Не удалось обновить статус лида. Изменение сохранено локально, проверьте доступ к базе данных.");
-      setDB(next);
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok) {
+      if (result.reason === "error") {
+        window.alert("Не удалось обновить статус лида. Изменение сохранено локально, проверьте доступ к базе данных.");
+      }
+      return;
     }
   };
 
@@ -92,10 +94,12 @@ export default function LeadsTab({
       changelog: [...db.changelog, { id: uid(), who: "UI", what: `Обновлён лид ${nextLead.name}`, when: todayISO() }],
     };
 
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert("Не удалось синхронизировать изменения лида. Они сохранены локально, проверьте доступ к базе данных.");
-      setDB(next);
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok) {
+      if (result.reason === "error") {
+        window.alert("Не удалось синхронизировать изменения лида. Они сохранены локально, проверьте доступ к базе данных.");
+      }
+      return;
     }
   };
 
@@ -112,10 +116,12 @@ export default function LeadsTab({
         { id: uid(), who: "UI", what: `Лид ${lead.name} конвертирован в клиента ${newClient.firstName}`, when: todayISO() },
       ],
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert("Не удалось обновить лида. Изменение сохранено локально, проверьте доступ к базе данных.");
-      setDB(next);
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok) {
+      if (result.reason === "error") {
+        window.alert("Не удалось обновить лида. Изменение сохранено локально, проверьте доступ к базе данных.");
+      }
+      return;
     }
   };
 
@@ -129,10 +135,12 @@ export default function LeadsTab({
       leadHistory: [resolution, ...db.leadHistory.filter(entry => entry.leadId !== lead.id)],
       changelog: [...db.changelog, { id: uid(), who: "UI", what: `Лид ${lead.name} перенесён в архив`, when: todayISO() }],
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert("Не удалось переместить лида в архив. Изменение сохранено локально, проверьте доступ к базе данных.");
-      setDB(next);
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok) {
+      if (result.reason === "error") {
+        window.alert("Не удалось переместить лида в архив. Изменение сохранено локально, проверьте доступ к базе данных.");
+      }
+      return;
     }
   };
 
@@ -143,8 +151,8 @@ export default function LeadsTab({
       leads: db.leads.filter(l => l.id !== lead.id),
       changelog: [...db.changelog, { id: uid(), who: "UI", what: `Удалён лид ${lead.id}`, when: todayISO() }],
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось удалить лида. Проверьте доступ к базе данных.");
     }
   };

--- a/src/components/PerformanceTab.tsx
+++ b/src/components/PerformanceTab.tsx
@@ -155,8 +155,8 @@ export default function PerformanceTab({
         ...db,
         performance: db.performance.map(entry => (entry.id === mark.id ? updated : entry)),
       };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
+      const result = await commitDBUpdate(next, setDB);
+      if (!result.ok && result.reason === "error") {
         window.alert("Не удалось обновить отметку успеваемости. Проверьте доступ к базе данных.");
       }
     } else {
@@ -167,8 +167,8 @@ export default function PerformanceTab({
         successful: true,
       };
       const next = { ...db, performance: [entry, ...db.performance] };
-      const ok = await commitDBUpdate(next, setDB);
-      if (!ok) {
+      const result = await commitDBUpdate(next, setDB);
+      if (!result.ok && result.reason === "error") {
         window.alert("Не удалось сохранить отметку успеваемости. Проверьте доступ к базе данных.");
       }
     }
@@ -273,9 +273,11 @@ export default function PerformanceTab({
       ...db,
       clients: db.clients.map(client => (client.id === editing.id ? updated : client)),
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert("Не удалось сохранить изменения клиента. Проверьте доступ к базе данных.");
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok) {
+      if (result.reason === "error") {
+        window.alert("Не удалось сохранить изменения клиента. Проверьте доступ к базе данных.");
+      }
       return;
     }
     setEditing(null);

--- a/src/components/ScheduleTab.tsx
+++ b/src/components/ScheduleTab.tsx
@@ -33,8 +33,8 @@ export default function ScheduleTab({
       if (!(key in nextLimits)) nextLimits[key] = 0;
     }
     const next = { ...db, settings: { ...db.settings, areas: nextAreas, limits: nextLimits } };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось добавить район. Проверьте доступ к базе данных.");
     }
   };
@@ -63,8 +63,8 @@ export default function ScheduleTab({
       settings: { ...db.settings, areas: renamedAreas, limits: renamedLimits },
       schedule: db.schedule.map(s => s.area === oldName ? { ...s, area: name } : s),
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось переименовать район. Проверьте доступ к базе данных.");
     }
   };
@@ -81,8 +81,8 @@ export default function ScheduleTab({
       settings: { ...db.settings, areas: db.settings.areas.filter(a => a !== name), limits: filteredLimits },
       schedule: db.schedule.filter(s => s.area !== name),
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось удалить район. Проверьте доступ к базе данных.");
     }
   };
@@ -108,8 +108,8 @@ export default function ScheduleTab({
         ? db.settings
         : { ...db.settings, groups: [...db.settings.groups, group] },
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось добавить слот расписания. Проверьте доступ к базе данных.");
     }
   };
@@ -127,16 +127,16 @@ export default function ScheduleTab({
         ? db.settings
         : { ...db.settings, groups: [...db.settings.groups, group] },
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось обновить слот расписания. Проверьте доступ к базе данных.");
     }
   };
   const deleteSlot = async (id: string) => {
     if (!window.confirm("Удалить группу?")) return;
     const next = { ...db, schedule: db.schedule.filter(x => x.id !== id) };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось удалить слот расписания. Проверьте доступ к базе данных.");
     }
   };

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -137,9 +137,11 @@ export default function SettingsTab({
       },
     };
 
-    const ok = await commitDBUpdate(updated, setDB);
-    if (!ok) {
-      window.alert("Не удалось сохранить курсы валют. Проверьте доступ к базе данных.");
+    const result = await commitDBUpdate(updated, setDB);
+    if (!result.ok) {
+      if (result.reason === "error") {
+        window.alert("Не удалось сохранить курсы валют. Проверьте доступ к базе данных.");
+      }
       return;
     }
 
@@ -241,9 +243,11 @@ export default function SettingsTab({
               currencyRates: { EUR: 1, TRY: nextRates.eurTry, RUB: nextRates.eurRub },
             },
           };
-          const ok = await commitDBUpdate(updated, setDB);
-          if (!ok) {
-            console.error("Failed to update currency rates in Firestore");
+          const result = await commitDBUpdate(updated, setDB);
+          if (!result.ok) {
+            if (result.reason === "error") {
+              console.error("Failed to update currency rates in Firestore");
+            }
           } else {
             lastSavedRatesRef.current = { eurTry: nextRates.eurTry, eurRub: nextRates.eurRub };
           }
@@ -348,8 +352,8 @@ export default function SettingsTab({
                                 limits: { ...db.settings.limits, [key]: Number(e.target.value) },
                               },
                             };
-                            const ok = await commitDBUpdate(next, setDB);
-                            if (!ok) {
+                            const result = await commitDBUpdate(next, setDB);
+                            if (!result.ok && result.reason === "error") {
                               window.alert("Не удалось сохранить лимит. Проверьте доступ к базе данных.");
                             }
                           }}

--- a/src/components/TasksTab.tsx
+++ b/src/components/TasksTab.tsx
@@ -46,10 +46,12 @@ export default function TasksTab({
       tasksArchive: nextArchive,
       clients: recalcClients(nextTasks, nextArchive),
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert("Не удалось обновить задачу. Изменение сохранено локально, проверьте доступ к базе данных.");
-      setDB(next);
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok) {
+      if (result.reason === "error") {
+        window.alert("Не удалось обновить задачу. Изменение сохранено локально, проверьте доступ к базе данных.");
+      }
+      return;
     }
   };
   const save = async () => {
@@ -61,10 +63,11 @@ export default function TasksTab({
       tasksArchive: db.tasksArchive,
       clients: recalcClients(nextTasks, db.tasksArchive),
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
-      window.alert("Не удалось сохранить задачу. Изменение сохранено локально, проверьте доступ к базе данных.");
-      setDB(next);
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok) {
+      if (result.reason === "error") {
+        window.alert("Не удалось сохранить задачу. Изменение сохранено локально, проверьте доступ к базе данных.");
+      }
       return;
     }
     setEdit(null);
@@ -78,10 +81,9 @@ export default function TasksTab({
       tasksArchive: db.tasksArchive,
       clients: recalcClients(nextTasks, db.tasksArchive),
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось добавить задачу. Изменение сохранено локально, проверьте доступ к базе данных.");
-      setDB(next);
     }
   };
   const remove = async (id: string) => {
@@ -95,10 +97,9 @@ export default function TasksTab({
       tasksArchive: nextArchive,
       clients: recalcClients(nextTasks, nextArchive),
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось удалить задачу. Изменение сохранено локально, проверьте доступ к базе данных.");
-      setDB(next);
     }
   };
 
@@ -114,10 +115,9 @@ export default function TasksTab({
       tasksArchive: nextArchive,
       clients: recalcClients(nextTasks, nextArchive),
     };
-    const ok = await commitDBUpdate(next, setDB);
-    if (!ok) {
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
       window.alert("Не удалось восстановить задачу. Изменение сохранено локально, проверьте доступ к базе данных.");
-      setDB(next);
     }
   };
 

--- a/src/components/__tests__/ClientsTab.test.tsx
+++ b/src/components/__tests__/ClientsTab.test.tsx
@@ -12,7 +12,7 @@ jest.mock('react-window', () => ({
 
 jest.mock('../../state/appState', () => ({
   __esModule: true,
-  commitDBUpdate: jest.fn().mockResolvedValue(true),
+  commitDBUpdate: jest.fn(),
 }));
 
 jest.mock('../../state/utils', () => ({
@@ -47,7 +47,7 @@ beforeEach(() => {
   window.localStorage.clear();
   commitDBUpdate.mockImplementation(async (next, setDB) => {
     setDB(next);
-    return true;
+    return { ok: true, db: next };
   });
   uid.mockReturnValue('uid-123');
   todayISO.mockReturnValue('2024-01-01T00:00:00.000Z');
@@ -62,6 +62,7 @@ beforeEach(() => {
 });
 
 const makeDB = () => ({
+  revision: 0,
   clients: [],
   attendance: [],
   performance: [],

--- a/src/components/__tests__/GroupsTab.test.tsx
+++ b/src/components/__tests__/GroupsTab.test.tsx
@@ -20,7 +20,7 @@ jest.mock('react-window', () => {
 
 jest.mock('../../state/appState', () => ({
   __esModule: true,
-  commitDBUpdate: jest.fn().mockResolvedValue(true),
+  commitDBUpdate: jest.fn(),
 }));
 
 jest.mock('../../state/utils', () => ({
@@ -63,7 +63,7 @@ beforeEach(() => {
   window.localStorage.clear();
   commitDBUpdate.mockImplementation(async (next, setDB) => {
     setDB(next);
-    return true;
+    return { ok: true, db: next };
   });
   uid.mockReturnValue('uid-123');
   todayISO.mockReturnValue('2024-01-01T00:00:00.000Z');
@@ -78,6 +78,7 @@ beforeEach(() => {
 });
 
 const makeDB = () => ({
+  revision: 0,
   clients: [],
   attendance: [],
   performance: [],

--- a/src/components/__tests__/LeadsTab.test.tsx
+++ b/src/components/__tests__/LeadsTab.test.tsx
@@ -12,7 +12,7 @@ jest.mock('react-window', () => ({
 
 jest.mock('../../state/appState', () => ({
   __esModule: true,
-  commitDBUpdate: jest.fn().mockResolvedValue(true),
+  commitDBUpdate: jest.fn(),
 }));
 
 jest.mock('../../state/utils', () => ({
@@ -41,7 +41,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   commitDBUpdate.mockImplementation(async (next, setDB) => {
     setDB(next);
-    return true;
+    return { ok: true, db: next };
   });
   global.confirm = jest.fn(() => true);
   global.prompt = jest.fn();
@@ -49,6 +49,7 @@ beforeEach(() => {
 });
 
 const makeDB = () => ({
+  revision: 0,
   clients: [],
   attendance: [],
   schedule: [],
@@ -146,8 +147,8 @@ test('create: adds new lead via modal', async () => {
         updatedAt: todayISO(),
       };
       const next = { ...state, leads: [l, ...state.leads] };
-      const ok = await commitDBUpdate(next, setDB);
-      if (ok) {
+      const result = await commitDBUpdate(next, setDB);
+      if (result.ok) {
         setOpen(false);
       }
     };

--- a/src/components/__tests__/ScheduleTab.groups.test.tsx
+++ b/src/components/__tests__/ScheduleTab.groups.test.tsx
@@ -6,7 +6,7 @@ import "@testing-library/jest-dom";
 
 jest.mock("../../state/appState", () => ({
   __esModule: true,
-  commitDBUpdate: jest.fn().mockResolvedValue(true),
+  commitDBUpdate: jest.fn(),
 }));
 
 jest.mock("../../state/utils", () => ({
@@ -29,7 +29,7 @@ import { commitDBUpdate } from "../../state/appState";
 beforeEach(() => {
   commitDBUpdate.mockImplementation(async (next, setDB) => {
     setDB(next);
-    return true;
+    return { ok: true, db: next };
   });
   window.alert = jest.fn();
 });
@@ -37,11 +37,12 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   jest.restoreAllMocks();
-  commitDBUpdate.mockResolvedValue(true);
+  commitDBUpdate.mockReset();
 });
 
 function makeDb() {
   return {
+    revision: 0,
     clients: [],
     attendance: [],
     schedule: [],
@@ -59,6 +60,7 @@ function makeDb() {
       coachSalaryByAreaEUR: {},
       currencyRates: { EUR: 1, TRY: 1, RUB: 1 },
       coachPayFormula: "",
+      analyticsFavorites: [],
     },
     changelog: [],
   };

--- a/src/components/__tests__/ScheduleTab.test.tsx
+++ b/src/components/__tests__/ScheduleTab.test.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom';
 
 jest.mock('../../state/appState', () => ({
   __esModule: true,
-  commitDBUpdate: jest.fn().mockResolvedValue(true),
+  commitDBUpdate: jest.fn(),
 }));
 
 jest.mock('../../state/utils', () => ({
@@ -37,7 +37,7 @@ import { commitDBUpdate } from '../../state/appState';
 beforeEach(() => {
   commitDBUpdate.mockImplementation(async (next, setDB) => {
     setDB(next);
-    return true;
+    return { ok: true, db: next };
   });
   window.alert = jest.fn();
 });
@@ -45,14 +45,15 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   jest.restoreAllMocks();
-  commitDBUpdate.mockResolvedValue(true);
+  commitDBUpdate.mockReset();
 });
 
 function makeDb() {
   return {
+    revision: 0,
     clients: [],
     attendance: [],
-  schedule: [],
+    schedule: [],
   leads: [],
   leadsArchive: [],
   leadHistory: [],
@@ -67,6 +68,7 @@ function makeDb() {
       coachSalaryByAreaEUR: {},
       currencyRates: { EUR: 1, TRY: 1, RUB: 1 },
       coachPayFormula: '',
+      analyticsFavorites: [],
     },
     changelog: [],
   };

--- a/src/components/__tests__/SettingsTab.test.tsx
+++ b/src/components/__tests__/SettingsTab.test.tsx
@@ -11,6 +11,7 @@ jest.mock("../../state/appState", () => ({
 }));
 
 const createDB = (): DB => ({
+  revision: 0,
   clients: [],
   attendance: [],
   performance: [],
@@ -42,7 +43,7 @@ describe("SettingsTab", () => {
   beforeEach(() => {
     fetchMock = jest.fn() as FetchMock;
     globalWithFetch.fetch = fetchMock as unknown as typeof fetch;
-    (commitDBUpdate as jest.Mock).mockResolvedValue(true);
+    (commitDBUpdate as jest.Mock).mockImplementation(async (next: DB) => ({ ok: true, db: next }));
   });
 
   afterEach(() => {

--- a/src/components/__tests__/TasksTab.test.tsx
+++ b/src/components/__tests__/TasksTab.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 jest.mock('../../state/appState', () => ({
   __esModule: true,
-  commitDBUpdate: jest.fn().mockResolvedValue(true),
+  commitDBUpdate: jest.fn(),
 }));
 
 jest.mock('../../state/utils', () => ({
@@ -27,12 +27,28 @@ import { commitDBUpdate } from '../../state/appState';
 function setup(initialTasks, overrides = {}) {
   const Wrapper = () => {
     const [db, setDB] = React.useState({
+      revision: 0,
       tasks: initialTasks,
       tasksArchive: overrides.tasksArchive ?? [],
       clients: overrides.clients ?? [],
       attendance: overrides.attendance ?? [],
       performance: overrides.performance ?? [],
       schedule: overrides.schedule ?? [],
+      leads: [],
+      leadsArchive: [],
+      leadHistory: [],
+      staff: [],
+      settings: {
+        areas: [],
+        groups: [],
+        limits: {},
+        rentByAreaEUR: {},
+        coachSalaryByAreaEUR: {},
+        currencyRates: { EUR: 1, TRY: 1, RUB: 1 },
+        coachPayFormula: '',
+        analyticsFavorites: [],
+      },
+      changelog: [],
     });
     return <TasksTab db={db} setDB={setDB} currency="RUB" />;
   };
@@ -48,7 +64,7 @@ describe('TasksTab CRUD operations', () => {
   beforeEach(() => {
     commitDBUpdate.mockImplementation(async (next, setDB) => {
       setDB(next);
-      return true;
+      return { ok: true, db: next };
     });
     window.confirm = jest.fn(() => true);
     window.alert = jest.fn();

--- a/src/state/__tests__/useAppState.firebase.test.tsx
+++ b/src/state/__tests__/useAppState.firebase.test.tsx
@@ -17,6 +17,7 @@ jest.mock(
   "react-router-dom",
   () => ({
     useLocation: () => ({ pathname: "/" }),
+    useNavigate: () => jest.fn(),
   }),
   { virtual: true },
 );

--- a/src/state/seed.ts
+++ b/src/state/seed.ts
@@ -190,6 +190,7 @@ export function makeSeedDB(): DB {
   };
 
   return {
+    revision: 0,
     clients,
     attendance,
     performance,

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,6 +199,7 @@ export interface Settings {
 }
 
 export interface DB {
+  revision: number;
   clients: Client[];
   attendance: AttendanceEntry[];
   performance: PerformanceEntry[];


### PR DESCRIPTION
## Summary
- add a revision field to the DB schema and seed so local state tracks document versions
- wrap Firestore writes in a transaction that checks revisions, increments on success, and dispatches a conflict event for UI reloads
- update UI commit callers and tests to handle conflict errors and cover the new toast + reload flow

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e516ffe158832b968252594c69f3a7