### PR TITLE
Preserve manual payment status when no payment tasks exist

### DIFF
--- a/src/state/__tests__/payments.test.ts
+++ b/src/state/__tests__/payments.test.ts
@@ -1,0 +1,48 @@
+import { derivePaymentStatus } from "../payments";
+import type { Client, TaskItem } from "../../types";
+
+describe("derivePaymentStatus", () => {
+  const baseClient: Client = {
+    id: "client-1",
+    firstName: "Ivan",
+    channel: "Telegram",
+    birthDate: "2020-01-01",
+    gender: "м",
+    area: "area-1",
+    group: "group-1",
+    startDate: "2020-01-01",
+    payMethod: "наличные",
+    payStatus: "ожидание",
+    status: "новый",
+  };
+
+  const baseTask: TaskItem = {
+    id: "task-1",
+    title: "Оплата",
+    due: "2024-01-01",
+    assigneeType: "client",
+    assigneeId: baseClient.id,
+    status: "open",
+    topic: "оплата",
+  };
+
+  it("returns the current client pay status when there are no related tasks", () => {
+    const client: Client = { ...baseClient, payStatus: "действует" };
+
+    expect(derivePaymentStatus(client, [], [])).toBe("действует");
+  });
+
+  it("returns debt status when there is an open related task", () => {
+    const client: Client = { ...baseClient, payStatus: "ожидание" };
+    const tasks: TaskItem[] = [{ ...baseTask, status: "open" }];
+
+    expect(derivePaymentStatus(client, tasks, [])).toBe("задолженность");
+  });
+
+  it("returns active status when all related tasks are done", () => {
+    const client: Client = { ...baseClient, payStatus: "ожидание" };
+    const tasks: TaskItem[] = [{ ...baseTask, status: "done" }];
+
+    expect(derivePaymentStatus(client, tasks, [])).toBe("действует");
+  });
+});

--- a/src/state/payments.ts
+++ b/src/state/payments.ts
@@ -71,7 +71,7 @@ export function derivePaymentStatus(
   );
 
   if (!relatedTasks.length) {
-    return "ожидание";
+    return client.payStatus;
   }
 
   if (relatedTasks.some(task => task.status !== "done")) {


### PR DESCRIPTION
## Summary
- return the client's existing payment status when no related payment tasks are present
- add unit tests covering manual status preservation and existing open/done task scenarios

## Testing
- CI=true npm test -- payments

------
https://chatgpt.com/codex/tasks/task_e_68e5604677e4832b9b9856eccded7b0b