### PR TITLE
Add payment completion action in Groups tab

### DIFF
--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -14,6 +14,7 @@ import type {
   PerformanceEntry,
   ScheduleSlot,
   Settings,
+  TaskItem,
 } from "../../types";
 import { usePersistentTableSettings } from "../../utils/tableSettings";
 
@@ -24,6 +25,8 @@ type Props = {
   onEdit: (c: Client) => void;
   onRemove: (id: string) => void;
   onCreateTask: (client: Client) => void;
+  openPaymentTasks?: Record<string, TaskItem | undefined>;
+  onCompletePaymentTask?: (client: Client, task: TaskItem) => void;
   schedule: ScheduleSlot[];
   attendance: AttendanceEntry[];
   performance: PerformanceEntry[];
@@ -68,6 +71,8 @@ export default function ClientTable({
   onEdit,
   onRemove,
   onCreateTask,
+  openPaymentTasks,
+  onCompletePaymentTask,
   schedule,
   attendance,
   performance,
@@ -240,12 +245,25 @@ export default function ClientTable({
     {
       id: "actions",
       label: "Действия",
-      width: "minmax(220px, 1fr)",
+      width: "minmax(260px, 1fr)",
       headerClassName: "text-right",
       headerAlign: "right",
       cellClassName: "flex justify-end gap-1",
       renderCell: client => (
         <>
+          {client.payStatus === "задолженность" &&
+            openPaymentTasks?.[client.id] &&
+            onCompletePaymentTask && (
+              <button
+                onClick={event => {
+                  event.stopPropagation();
+                  onCompletePaymentTask(client, openPaymentTasks[client.id]!);
+                }}
+                className="px-2 py-1 text-xs rounded-md border border-emerald-200 text-emerald-600 hover:bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-900/20 dark:hover:bg-emerald-900/30"
+              >
+                Оплатил
+              </button>
+            )}
           <button
             onClick={event => {
               event.stopPropagation();
@@ -267,7 +285,16 @@ export default function ClientTable({
         </>
       ),
     },
-  ], [billingPeriod, currency, currencyRates, onCreateTask, onRemove, remainingMap]);
+  ], [
+    billingPeriod,
+    currency,
+    currencyRates,
+    onCompletePaymentTask,
+    onCreateTask,
+    onRemove,
+    openPaymentTasks,
+    remainingMap,
+  ]);
 
   const columnIds = useMemo(() => columns.map(column => column.id), [columns]);
   const { visibleColumns, setVisibleColumns, sort, setSort } = usePersistentTableSettings(

--- a/src/state/payments.ts
+++ b/src/state/payments.ts
@@ -85,11 +85,14 @@ export function applyPaymentStatusRules(
   clients: Client[],
   tasks: TaskItem[],
   archivedTasks: TaskItem[] = [],
+  updates: Partial<Record<string, Partial<Client>>> = {},
 ): Client[] {
   return clients.map(client => {
-    const nextStatus = derivePaymentStatus(client, tasks, archivedTasks);
+    const patch = updates[client.id];
+    const base = patch ? { ...client, ...patch } : client;
+    const nextStatus = derivePaymentStatus(base, tasks, archivedTasks);
     const withPayStatus =
-      client.payStatus === nextStatus ? client : { ...client, payStatus: nextStatus };
+      base.payStatus === nextStatus ? base : { ...base, payStatus: nextStatus };
     return applyClientStatusAutoTransition(withPayStatus);
   });
 }


### PR DESCRIPTION
## Summary
- show an "Оплатил" action in the client table whenever a client has an open payment task
- add a Groups tab handler that completes the payment task, updates the client payment fields, and persists the changes
- allow payment status recomputation to accept client overrides and add a component test for the payment completion flow

## Testing
- CI=true npm test -- --runTestsByPath src/components/__tests__/GroupsTab.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e563ca2f04832bb1fc52e68d950cba