### PR TITLE
Automate payment task sweep on daily schedule

### DIFF
--- a/src/state/__tests__/useAppState.test.tsx
+++ b/src/state/__tests__/useAppState.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import { act, renderHook, waitFor } from '@testing-library/react';
 
 const mockPush = jest.fn();
+const FIXED_TODAY = '2024-05-10T00:00:00.000Z';
 
 jest.mock(
   'react-router-dom',
@@ -26,8 +27,9 @@ jest.mock('../../firebase', () => ({
 }));
 
 import { commitDBUpdate, DB_CONFLICT_EVENT, LS_KEYS, LOCAL_ONLY_MESSAGE, useAppState } from '../appState';
+import type { TaskItem } from '../../types';
 import { RESERVE_AREA_NAME } from '../reserve';
-import { makeSeedDB } from '../seed';
+import * as seedModule from '../seed';
 
 describe('useAppState with local persistence', () => {
   beforeEach(() => {
@@ -87,7 +89,7 @@ describe('useAppState with local persistence', () => {
   });
 
   it('ensures the reserve area is available even if missing from stored settings', async () => {
-    const legacy = makeSeedDB();
+    const legacy = seedModule.makeSeedDB();
     legacy.settings.areas = legacy.settings.areas.filter(area => area !== RESERVE_AREA_NAME);
     localStorage.setItem(LS_KEYS.db, JSON.stringify(legacy));
 
@@ -124,5 +126,97 @@ describe('useAppState with local persistence', () => {
     });
 
     expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('Обновляем локальную копию'), 'warning');
+  });
+
+  it('creates payment tasks for clients whose pay date is today and lack open tasks', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(FIXED_TODAY));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const template = seedModule.makeSeedDB();
+    const base = {
+      revision: template.revision,
+      clients: [] as any[],
+      attendance: [] as any[],
+      performance: [] as any[],
+      schedule: [] as any[],
+      leads: [] as any[],
+      leadsArchive: [] as any[],
+      leadHistory: [] as any[],
+      tasks: [
+        {
+          id: 'existing-task',
+          title: 'Оплата клиента — Existing',
+          due: FIXED_TODAY,
+          status: 'open',
+          topic: 'оплата',
+          assigneeType: 'client',
+          assigneeId: 'client-with-task',
+        },
+      ],
+      tasksArchive: [] as any[],
+      staff: [] as any[],
+      settings: template.settings,
+      changelog: [] as any[],
+    };
+
+    const shared = {
+      channel: 'Telegram',
+      birthDate: '2015-01-01T00:00:00.000Z',
+      gender: 'м',
+      area: template.settings.areas[0],
+      group: template.settings.groups[0],
+      startDate: FIXED_TODAY,
+      payMethod: 'перевод',
+      payStatus: 'ожидание',
+      status: 'действующий',
+      subscriptionPlan: 'monthly',
+    };
+
+    base.clients = [
+      { ...shared, id: 'client-a', firstName: 'Анна', parentName: 'Мария', payDate: FIXED_TODAY, payAmount: 100 },
+      { ...shared, id: 'client-b', firstName: 'Борис', payDate: FIXED_TODAY, payAmount: 120 },
+      { ...shared, id: 'client-with-task', firstName: 'Виктор', payDate: FIXED_TODAY, payAmount: 55 },
+      { ...shared, id: 'client-other', firstName: 'Глеб', payDate: '2024-05-09T00:00:00.000Z' },
+    ];
+
+    localStorage.setItem(LS_KEYS.db, JSON.stringify(base));
+    const seedSpy = jest.spyOn(seedModule, 'makeSeedDB').mockReturnValue(
+      JSON.parse(JSON.stringify(base)),
+    );
+
+    try {
+      const { result } = renderHook(() => useAppState());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        const openPaymentTasks = result.current.db.tasks.filter(
+          task => task.status === 'open' && task.topic === 'оплата' && task.assigneeType === 'client',
+        );
+
+        expect(openPaymentTasks.filter(task => task.assigneeId === 'client-a')).toHaveLength(1);
+        expect(openPaymentTasks.filter(task => task.assigneeId === 'client-b')).toHaveLength(1);
+        expect(openPaymentTasks.filter(task => task.assigneeId === 'client-with-task')).toHaveLength(1);
+        expect(openPaymentTasks.filter(task => task.assigneeId === 'client-other')).toHaveLength(0);
+      });
+
+      const stored = localStorage.getItem(LS_KEYS.db);
+      expect(stored).not.toBeNull();
+      const parsed = JSON.parse(stored as string);
+      const persistedPaymentTasks = parsed.tasks.filter(
+        (task: TaskItem) => task.status === 'open' && task.topic === 'оплата' && task.assigneeType === 'client',
+      );
+
+      expect(persistedPaymentTasks.filter((task: TaskItem) => task.assigneeId === 'client-a')).toHaveLength(1);
+      expect(persistedPaymentTasks.filter((task: TaskItem) => task.assigneeId === 'client-b')).toHaveLength(1);
+      expect(persistedPaymentTasks.filter((task: TaskItem) => task.assigneeId === 'client-with-task')).toHaveLength(1);
+      expect(persistedPaymentTasks.filter((task: TaskItem) => task.assigneeId === 'client-other')).toHaveLength(0);
+    } finally {
+      seedSpy.mockRestore();
+      warnSpy.mockRestore();
+      jest.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add an app-state effect that ensures payment tasks exist for clients whose pay date matches the current day
- reuse manual task formatting while preventing duplicate assignments and updating changelog entries
- cover the automatic sweep with a Jest test that freezes the current date and verifies one task per eligible client

## Testing
- npm test -- --runTestsByPath src/state/__tests__/useAppState.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e563c1df38832bbcfa64516b518f8f