### PR TITLE
Normalize task grouping filters

### DIFF
--- a/src/components/TasksTab.tsx
+++ b/src/components/TasksTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import Modal from "./Modal";
@@ -9,6 +9,55 @@ import { applyPaymentStatusRules } from "../state/payments";
 import { buildGroupsByArea } from "../state/lessons";
 import { readDailySelection, writeDailySelection, clearDailySelection } from "../state/filterPersistence";
 import type { Area, Client, Currency, DB, Group, TaskItem } from "../types";
+
+type TaskSection = { key: string; label: string | null; tasks: TaskItem[] };
+const UNGROUPED_KEY = "__ungrouped__";
+
+const normalize = (value?: string | null) => value?.trim() ?? "";
+
+function buildTaskSections(tasks: TaskItem[], availableGroups: Group[]): TaskSection[] {
+  const buckets = new Map<string, TaskItem[]>();
+  const labels = new Map<string, string>();
+  const order: string[] = [];
+
+  tasks.forEach(task => {
+    const normalizedGroup = normalize(task.group);
+    const key = normalizedGroup || UNGROUPED_KEY;
+    if (!buckets.has(key)) {
+      buckets.set(key, []);
+      labels.set(key, normalizedGroup || "Без группы");
+      order.push(key);
+    }
+    buckets.get(key)!.push(task);
+  });
+
+  const sections: TaskSection[] = [];
+
+  availableGroups.forEach(groupName => {
+    const normalizedGroup = normalize(groupName);
+    const key = normalizedGroup || UNGROUPED_KEY;
+    const tasksInBucket = buckets.get(key);
+    if (!tasksInBucket) return;
+
+    sections.push({ key, label: normalizedGroup || "Без группы", tasks: tasksInBucket });
+    buckets.delete(key);
+    labels.delete(key);
+
+    const idx = order.indexOf(key);
+    if (idx !== -1) {
+      order.splice(idx, 1);
+    }
+  });
+
+  order.forEach(key => {
+    const tasksInBucket = buckets.get(key);
+    if (!tasksInBucket) return;
+    const label = labels.get(key) ?? (key === UNGROUPED_KEY ? "Без группы" : key);
+    sections.push({ key, label, tasks: tasksInBucket });
+  });
+
+  return sections;
+}
 
 export function resolveClientsAfterTaskCompletion(
   clients: Client[],
@@ -57,15 +106,20 @@ export default function TasksTab({
     return groupsByArea.get(area) ?? [];
   }, [area, groupsByArea]);
 
+  const normalizedAvailableGroups = useMemo(
+    () => new Set(availableGroups.map(normalize)),
+    [availableGroups],
+  );
+
   useEffect(() => {
     if (!area && group !== null) {
       setGroup(null);
       return;
     }
-    if (area && group && !availableGroups.includes(group)) {
+    if (area && group && !normalizedAvailableGroups.has(normalize(group))) {
       setGroup(null);
     }
-  }, [area, availableGroups, group]);
+  }, [area, group, normalizedAvailableGroups]);
 
   useEffect(() => {
     if (area || group) {
@@ -75,15 +129,21 @@ export default function TasksTab({
     }
   }, [area, group]);
 
-  const matchesFilter = (task: TaskItem) => {
-    if (area && task.area !== area) return false;
-    if (group && task.group !== group) return false;
-    return true;
-  };
+  const normalizedArea = useMemo(() => normalize(area), [area]);
+  const normalizedGroup = useMemo(() => normalize(group), [group]);
+
+  const matchesFilter = useCallback(
+    (task: TaskItem) => {
+      if (normalizedArea && normalize(task.area) !== normalizedArea) return false;
+      if (normalizedGroup && normalize(task.group) !== normalizedGroup) return false;
+      return true;
+    },
+    [normalizedArea, normalizedGroup],
+  );
 
   const activeTasks = useMemo(() => db.tasks.filter(task => task.status !== "done"), [db.tasks]);
-  const visibleActiveTasks = useMemo(() => activeTasks.filter(matchesFilter), [activeTasks, area, group]);
-  const filteredArchive = useMemo(() => db.tasksArchive.filter(matchesFilter), [db.tasksArchive, area, group]);
+  const visibleActiveTasks = useMemo(() => activeTasks.filter(matchesFilter), [activeTasks, matchesFilter]);
+  const filteredArchive = useMemo(() => db.tasksArchive.filter(matchesFilter), [db.tasksArchive, matchesFilter]);
   const sortedArchive = useMemo(
     () =>
       filteredArchive
@@ -92,6 +152,22 @@ export default function TasksTab({
     [filteredArchive],
   );
   const archiveCount = sortedArchive.length;
+
+  const groupedActiveTasks = useMemo(() => {
+    if (area && !group) {
+      return buildTaskSections(visibleActiveTasks, availableGroups);
+    }
+
+    return [{ key: "all", label: null, tasks: visibleActiveTasks }];
+  }, [visibleActiveTasks, area, group, availableGroups]);
+
+  const groupedArchiveTasks = useMemo(() => {
+    if (area && !group) {
+      return buildTaskSections(sortedArchive, availableGroups);
+    }
+
+    return [{ key: "all", label: null, tasks: sortedArchive }];
+  }, [sortedArchive, area, group, availableGroups]);
   const recalcClients = (
     tasks: TaskItem[],
     archive: TaskItem[],
@@ -227,60 +303,71 @@ export default function TasksTab({
           </select>
         </div>
         <button onClick={add} className="px-3 py-2 rounded-lg bg-sky-600 text-white text-sm hover:bg-sky-700">+ Задача</button>
-        <ul className="space-y-2">
-          {visibleActiveTasks.map(t => (
-            <li
-              key={t.id}
-              role="button"
-              tabIndex={0}
-              onClick={() => openTask(t)}
-              onKeyDown={event => {
-                if (event.key === "Enter" || event.key === " ") {
-                  event.preventDefault();
-                  openTask(t);
-                }
-              }}
-              className="p-3 rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 flex items-center justify-between gap-2 cursor-pointer transition hover:border-sky-200 hover:bg-sky-50 focus:outline-none focus:ring-2 focus:ring-sky-500 dark:hover:border-sky-400/60 dark:hover:bg-slate-800/60"
-            >
-              <div className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={t.status === "done"}
-                  onClick={event => event.stopPropagation()}
-                  onChange={() => complete(t.id)}
-                />
-                <span
-                  className={`text-sm ${
-                    t.status === "done" ? "line-through text-slate-500" : "text-slate-800 dark:text-slate-100"
-                  }`}
-                >
-                  {t.title}
-                </span>
-              </div>
-              <div className="flex items-center gap-2 text-xs">
-                <span className="text-slate-500">{fmtDate(t.due)}</span>
-                <button
-                  onClick={event => {
-                    event.stopPropagation();
-                    openTask(t);
-                  }}
-                  className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
-                >
-                  ✎
-                </button>
-                <button
-                  onClick={event => {
-                    event.stopPropagation();
-                    remove(t.id);
-                  }}
-                  className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
-                >
-                  ✕
-                </button>
-              </div>
-            </li>
+        <div className="space-y-4">
+          {groupedActiveTasks.map(section => (
+            <div key={section.key} className="space-y-2">
+              {section.label ? (
+                <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500 border border-slate-200 rounded-md bg-slate-50 dark:text-slate-300 dark:border-slate-700 dark:bg-slate-800/60">
+                  {section.label}
+                </div>
+              ) : null}
+              <ul className="space-y-2">
+                {section.tasks.map(t => (
+                  <li
+                    key={t.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => openTask(t)}
+                    onKeyDown={event => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        openTask(t);
+                      }
+                    }}
+                    className="p-3 rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 flex items-center justify-between gap-2 cursor-pointer transition hover:border-sky-200 hover:bg-sky-50 focus:outline-none focus:ring-2 focus:ring-sky-500 dark:hover:border-sky-400/60 dark:hover:bg-slate-800/60"
+                  >
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={t.status === "done"}
+                        onClick={event => event.stopPropagation()}
+                        onChange={() => complete(t.id)}
+                      />
+                      <span
+                        className={`text-sm ${
+                          t.status === "done" ? "line-through text-slate-500" : "text-slate-800 dark:text-slate-100"
+                        }`}
+                      >
+                        {t.title}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-xs">
+                      <span className="text-slate-500">{fmtDate(t.due)}</span>
+                      <button
+                        onClick={event => {
+                          event.stopPropagation();
+                          openTask(t);
+                        }}
+                        className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
+                      >
+                        ✎
+                      </button>
+                      <button
+                        onClick={event => {
+                          event.stopPropagation();
+                          remove(t.id);
+                        }}
+                        className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
           ))}
-        </ul>
+        </div>
         <div className="pt-4 border-t border-slate-200 dark:border-slate-700 space-y-2">
           <button
             type="button"
@@ -291,33 +378,44 @@ export default function TasksTab({
             <span className="text-xs text-slate-500">{archiveCount}</span>
           </button>
           {showArchive && (
-            <ul className="space-y-2">
+            <div className="space-y-4">
               {sortedArchive.length ? (
-                sortedArchive.map(task => (
-                  <li
-                    key={task.id}
-                    className="p-3 rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 text-sm flex flex-col gap-1"
-                  >
-                    <div className="flex items-start justify-between gap-2">
-                      <span className="font-medium text-slate-700 dark:text-slate-200">{task.title}</span>
-                      <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">{fmtDate(task.due)}</span>
-                    </div>
-                    <div className="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
-                      <span>{task.topic ?? ""}</span>
-                      <button
-                        type="button"
-                        onClick={() => restore(task.id)}
-                        className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800"
-                      >
-                        Вернуть
-                      </button>
-                    </div>
-                  </li>
+                groupedArchiveTasks.map(section => (
+                  <div key={`archive-${section.key}`} className="space-y-2">
+                    {section.label ? (
+                      <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500 border border-slate-200 rounded-md bg-slate-100 dark:text-slate-300 dark:border-slate-700 dark:bg-slate-900/60">
+                        {section.label}
+                      </div>
+                    ) : null}
+                    <ul className="space-y-2">
+                      {section.tasks.map(task => (
+                        <li
+                          key={task.id}
+                          className="p-3 rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 text-sm flex flex-col gap-1"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <span className="font-medium text-slate-700 dark:text-slate-200">{task.title}</span>
+                            <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">{fmtDate(task.due)}</span>
+                          </div>
+                          <div className="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+                            <span>{task.topic ?? ""}</span>
+                            <button
+                              type="button"
+                              onClick={() => restore(task.id)}
+                              className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800"
+                            >
+                              Вернуть
+                            </button>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 ))
               ) : (
-                <li className="text-sm text-slate-500 dark:text-slate-400 px-3">Архив пуст</li>
+                <div className="text-sm text-slate-500 dark:text-slate-400 px-3">Архив пуст</div>
               )}
-            </ul>
+            </div>
           )}
         </div>
         {edit && (


### PR DESCRIPTION
## Summary
- normalize area and group names before filtering or grouping tasks so the area filter continues to show matching tasks
- ensure grouped task sections preserve "Без группы" buckets while keeping configured group order

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e573785b4c832bb475ec3e5072ff50