### PR TITLE
Fix GroupsTab filtering and half-month payment rollover

### DIFF
--- a/src/components/__tests__/GroupsTab.test.tsx
+++ b/src/components/__tests__/GroupsTab.test.tsx
@@ -228,8 +228,8 @@ test('filters clients by selected month', async () => {
   fireEvent.change(monthInput, { target: { value: '2' } });
 
   await waitFor(() => {
-    expect(screen.getByRole('row', { name: /Январь/ })).toBeInTheDocument();
     expect(screen.getByRole('row', { name: /Февраль/ })).toBeInTheDocument();
+    expect(screen.queryByRole('row', { name: /Январь/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('row', { name: /Март/ })).not.toBeInTheDocument();
   });
 });
@@ -411,6 +411,50 @@ test('completes payment task and updates client payment data', async () => {
 
   await waitFor(() => expect(within(tableRow!).queryByRole('button', { name: 'Оплатил' })).not.toBeInTheDocument());
   expect(within(tableRow!).getByText('действует')).toBeInTheDocument();
+});
+
+test('half-month subscription advances payDate by 14 days on payment completion', async () => {
+  const db = makeDB();
+  db.clients = [
+    makeClient({
+      id: 'half',
+      firstName: 'Пол',
+      payStatus: 'задолженность',
+      subscriptionPlan: 'half-month',
+      payDate: '2024-02-01T00:00:00.000Z',
+      payAmount: 27.5,
+    }),
+  ];
+  db.tasks = [
+    {
+      id: 'task-half',
+      title: 'Оплата клиента — Пол',
+      due: '2024-02-01T00:00:00.000Z',
+      status: 'open',
+      topic: 'оплата',
+      assigneeType: 'client',
+      assigneeId: 'half',
+    },
+  ];
+
+  const { getDB } = renderGroups(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
+
+  const monthInput = screen.getByLabelText('Фильтр по месяцу');
+  fireEvent.change(monthInput, { target: { value: '2' } });
+
+  const row = await screen.findByText('Пол');
+  const tableRow = row.closest('tr');
+  expect(tableRow).not.toBeNull();
+  const payButton = await within(tableRow!).findByRole('button', { name: 'Оплатил' });
+
+  await userEvent.click(payButton);
+
+  await waitFor(() => {
+    expect(getDB().tasks).toHaveLength(0);
+    expect(getDB().tasksArchive).toHaveLength(1);
+    expect(getDB().clients[0].payStatus).toBe('действует');
+    expect(getDB().clients[0].payDate).toBe('2024-02-15T00:00:00.000Z');
+  });
 });
 
 test('individual group allows custom payment amount', async () => {


### PR DESCRIPTION
## Summary
- tighten the GroupsTab monthly filter so chosen months only show matching payments
- advance half-month subscription pay dates by 14 days when closing payment tasks
- adjust GroupsTab tests for the refined filtering and add coverage for the half-month rollover

## Testing
- npm test -- GroupsTab

------
https://chatgpt.com/codex/tasks/task_e_68e5769f013c832b937674c44fe450b5