### PR TITLE
Restore task area filtering when using grouped view

### DIFF
--- a/src/components/TasksTab.tsx
+++ b/src/components/TasksTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import Modal from "./Modal";
@@ -9,6 +9,69 @@ import { applyPaymentStatusRules } from "../state/payments";
 import { buildGroupsByArea } from "../state/lessons";
 import { readDailySelection, writeDailySelection, clearDailySelection } from "../state/filterPersistence";
 import type { Area, Client, Currency, DB, Group, TaskItem } from "../types";
+
+type TaskSection = { key: string; label: string | null; tasks: TaskItem[] };
+const UNGROUPED_KEY = "__ungrouped__";
+
+const canonicalize = (value?: string | null) => (value ?? "").trim();
+const normalizeKey = (value?: string | null) => {
+  const canonical = canonicalize(value);
+  return canonical ? canonical.toLocaleLowerCase() : "";
+};
+
+function buildTaskSections(tasks: TaskItem[], availableGroups: Group[]): TaskSection[] {
+  const buckets = new Map<string, TaskItem[]>();
+  const labels = new Map<string, string>();
+  const order: string[] = [];
+
+  const normalizedAvailableLabels = new Map<string, string>();
+  availableGroups.forEach(groupName => {
+    const key = normalizeKey(groupName) || UNGROUPED_KEY;
+    const label = canonicalize(groupName) || "Без группы";
+    normalizedAvailableLabels.set(key, label);
+  });
+
+  tasks.forEach(task => {
+    const normalizedGroup = normalizeKey(task.group);
+    const key = normalizedGroup || UNGROUPED_KEY;
+    const canonicalGroup = canonicalize(task.group);
+    if (!buckets.has(key)) {
+      buckets.set(key, []);
+      const label =
+        normalizedAvailableLabels.get(key) ?? (canonicalGroup ? canonicalGroup : "Без группы");
+      labels.set(key, label);
+      order.push(key);
+    }
+    buckets.get(key)!.push(task);
+  });
+
+  const sections: TaskSection[] = [];
+
+  availableGroups.forEach(groupName => {
+    const canonicalGroup = canonicalize(groupName);
+    const key = normalizeKey(groupName) || UNGROUPED_KEY;
+    const tasksInBucket = buckets.get(key);
+    if (!tasksInBucket) return;
+
+    sections.push({ key, label: canonicalGroup || "Без группы", tasks: tasksInBucket });
+    buckets.delete(key);
+    labels.delete(key);
+
+    const idx = order.indexOf(key);
+    if (idx !== -1) {
+      order.splice(idx, 1);
+    }
+  });
+
+  order.forEach(key => {
+    const tasksInBucket = buckets.get(key);
+    if (!tasksInBucket) return;
+    const label = labels.get(key) ?? (key === UNGROUPED_KEY ? "Без группы" : key);
+    sections.push({ key, label, tasks: tasksInBucket });
+  });
+
+  return sections;
+}
 
 export function resolveClientsAfterTaskCompletion(
   clients: Client[],
@@ -49,7 +112,7 @@ export default function TasksTab({
   const [showArchive, setShowArchive] = useState(false);
   const [viewClientId, setViewClientId] = useState<string | null>(null);
 
-  const schedule = db.schedule ?? [];
+  const schedule = useMemo(() => db.schedule ?? [], [db.schedule]);
   const groupsByArea = useMemo(() => buildGroupsByArea(schedule), [schedule]);
   const areaOptions = useMemo(() => Array.from(groupsByArea.keys()), [groupsByArea]);
   const availableGroups = useMemo(() => {
@@ -57,15 +120,37 @@ export default function TasksTab({
     return groupsByArea.get(area) ?? [];
   }, [area, groupsByArea]);
 
+  const normalizedGroupAreas = useMemo(() => {
+    const map = new Map<string, string>();
+    groupsByArea.forEach((groups, areaName) => {
+      const normalizedAreaName = normalizeKey(areaName);
+      if (!normalizedAreaName) return;
+
+      groups.forEach(groupName => {
+        const normalizedGroupName = normalizeKey(groupName);
+        if (!normalizedGroupName) return;
+        if (!map.has(normalizedGroupName)) {
+          map.set(normalizedGroupName, normalizedAreaName);
+        }
+      });
+    });
+    return map;
+  }, [groupsByArea]);
+
+  const normalizedAvailableGroups = useMemo(
+    () => new Set(availableGroups.map(normalizeKey)),
+    [availableGroups],
+  );
+
   useEffect(() => {
     if (!area && group !== null) {
       setGroup(null);
       return;
     }
-    if (area && group && !availableGroups.includes(group)) {
+    if (area && group && !normalizedAvailableGroups.has(normalizeKey(group))) {
       setGroup(null);
     }
-  }, [area, availableGroups, group]);
+  }, [area, group, normalizedAvailableGroups]);
 
   useEffect(() => {
     if (area || group) {
@@ -75,15 +160,29 @@ export default function TasksTab({
     }
   }, [area, group]);
 
-  const matchesFilter = (task: TaskItem) => {
-    if (area && task.area !== area) return false;
-    if (group && task.group !== group) return false;
-    return true;
-  };
+  const normalizedArea = useMemo(() => normalizeKey(area), [area]);
+  const normalizedGroup = useMemo(() => normalizeKey(group), [group]);
+
+  const matchesFilter = useCallback(
+    (task: TaskItem) => {
+      if (normalizedArea) {
+        const taskArea = normalizeKey(task.area);
+        if (taskArea !== normalizedArea) {
+          const inferredArea = normalizedGroupAreas.get(normalizeKey(task.group));
+          if (inferredArea !== normalizedArea) {
+            return false;
+          }
+        }
+      }
+      if (normalizedGroup && normalizeKey(task.group) !== normalizedGroup) return false;
+      return true;
+    },
+    [normalizedArea, normalizedGroup, normalizedGroupAreas],
+  );
 
   const activeTasks = useMemo(() => db.tasks.filter(task => task.status !== "done"), [db.tasks]);
-  const visibleActiveTasks = useMemo(() => activeTasks.filter(matchesFilter), [activeTasks, area, group]);
-  const filteredArchive = useMemo(() => db.tasksArchive.filter(matchesFilter), [db.tasksArchive, area, group]);
+  const visibleActiveTasks = useMemo(() => activeTasks.filter(matchesFilter), [activeTasks, matchesFilter]);
+  const filteredArchive = useMemo(() => db.tasksArchive.filter(matchesFilter), [db.tasksArchive, matchesFilter]);
   const sortedArchive = useMemo(
     () =>
       filteredArchive
@@ -92,6 +191,22 @@ export default function TasksTab({
     [filteredArchive],
   );
   const archiveCount = sortedArchive.length;
+
+  const groupedActiveTasks = useMemo(() => {
+    if (area && !group) {
+      return buildTaskSections(visibleActiveTasks, availableGroups);
+    }
+
+    return [{ key: "all", label: null, tasks: visibleActiveTasks }];
+  }, [visibleActiveTasks, area, group, availableGroups]);
+
+  const groupedArchiveTasks = useMemo(() => {
+    if (area && !group) {
+      return buildTaskSections(sortedArchive, availableGroups);
+    }
+
+    return [{ key: "all", label: null, tasks: sortedArchive }];
+  }, [sortedArchive, area, group, availableGroups]);
   const recalcClients = (
     tasks: TaskItem[],
     archive: TaskItem[],
@@ -227,60 +342,71 @@ export default function TasksTab({
           </select>
         </div>
         <button onClick={add} className="px-3 py-2 rounded-lg bg-sky-600 text-white text-sm hover:bg-sky-700">+ Задача</button>
-        <ul className="space-y-2">
-          {visibleActiveTasks.map(t => (
-            <li
-              key={t.id}
-              role="button"
-              tabIndex={0}
-              onClick={() => openTask(t)}
-              onKeyDown={event => {
-                if (event.key === "Enter" || event.key === " ") {
-                  event.preventDefault();
-                  openTask(t);
-                }
-              }}
-              className="p-3 rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 flex items-center justify-between gap-2 cursor-pointer transition hover:border-sky-200 hover:bg-sky-50 focus:outline-none focus:ring-2 focus:ring-sky-500 dark:hover:border-sky-400/60 dark:hover:bg-slate-800/60"
-            >
-              <div className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={t.status === "done"}
-                  onClick={event => event.stopPropagation()}
-                  onChange={() => complete(t.id)}
-                />
-                <span
-                  className={`text-sm ${
-                    t.status === "done" ? "line-through text-slate-500" : "text-slate-800 dark:text-slate-100"
-                  }`}
-                >
-                  {t.title}
-                </span>
-              </div>
-              <div className="flex items-center gap-2 text-xs">
-                <span className="text-slate-500">{fmtDate(t.due)}</span>
-                <button
-                  onClick={event => {
-                    event.stopPropagation();
-                    openTask(t);
-                  }}
-                  className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
-                >
-                  ✎
-                </button>
-                <button
-                  onClick={event => {
-                    event.stopPropagation();
-                    remove(t.id);
-                  }}
-                  className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
-                >
-                  ✕
-                </button>
-              </div>
-            </li>
+        <div className="space-y-4">
+          {groupedActiveTasks.map(section => (
+            <div key={section.key} className="space-y-2">
+              {section.label ? (
+                <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500 border border-slate-200 rounded-md bg-slate-50 dark:text-slate-300 dark:border-slate-700 dark:bg-slate-800/60">
+                  {section.label}
+                </div>
+              ) : null}
+              <ul className="space-y-2">
+                {section.tasks.map(t => (
+                  <li
+                    key={t.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => openTask(t)}
+                    onKeyDown={event => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        openTask(t);
+                      }
+                    }}
+                    className="p-3 rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 flex items-center justify-between gap-2 cursor-pointer transition hover:border-sky-200 hover:bg-sky-50 focus:outline-none focus:ring-2 focus:ring-sky-500 dark:hover:border-sky-400/60 dark:hover:bg-slate-800/60"
+                  >
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={t.status === "done"}
+                        onClick={event => event.stopPropagation()}
+                        onChange={() => complete(t.id)}
+                      />
+                      <span
+                        className={`text-sm ${
+                          t.status === "done" ? "line-through text-slate-500" : "text-slate-800 dark:text-slate-100"
+                        }`}
+                      >
+                        {t.title}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-xs">
+                      <span className="text-slate-500">{fmtDate(t.due)}</span>
+                      <button
+                        onClick={event => {
+                          event.stopPropagation();
+                          openTask(t);
+                        }}
+                        className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
+                      >
+                        ✎
+                      </button>
+                      <button
+                        onClick={event => {
+                          event.stopPropagation();
+                          remove(t.id);
+                        }}
+                        className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-700 dark:bg-slate-800"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
           ))}
-        </ul>
+        </div>
         <div className="pt-4 border-t border-slate-200 dark:border-slate-700 space-y-2">
           <button
             type="button"
@@ -291,33 +417,44 @@ export default function TasksTab({
             <span className="text-xs text-slate-500">{archiveCount}</span>
           </button>
           {showArchive && (
-            <ul className="space-y-2">
+            <div className="space-y-4">
               {sortedArchive.length ? (
-                sortedArchive.map(task => (
-                  <li
-                    key={task.id}
-                    className="p-3 rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 text-sm flex flex-col gap-1"
-                  >
-                    <div className="flex items-start justify-between gap-2">
-                      <span className="font-medium text-slate-700 dark:text-slate-200">{task.title}</span>
-                      <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">{fmtDate(task.due)}</span>
-                    </div>
-                    <div className="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
-                      <span>{task.topic ?? ""}</span>
-                      <button
-                        type="button"
-                        onClick={() => restore(task.id)}
-                        className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800"
-                      >
-                        Вернуть
-                      </button>
-                    </div>
-                  </li>
+                groupedArchiveTasks.map(section => (
+                  <div key={`archive-${section.key}`} className="space-y-2">
+                    {section.label ? (
+                      <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500 border border-slate-200 rounded-md bg-slate-100 dark:text-slate-300 dark:border-slate-700 dark:bg-slate-900/60">
+                        {section.label}
+                      </div>
+                    ) : null}
+                    <ul className="space-y-2">
+                      {section.tasks.map(task => (
+                        <li
+                          key={task.id}
+                          className="p-3 rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 text-sm flex flex-col gap-1"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <span className="font-medium text-slate-700 dark:text-slate-200">{task.title}</span>
+                            <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">{fmtDate(task.due)}</span>
+                          </div>
+                          <div className="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+                            <span>{task.topic ?? ""}</span>
+                            <button
+                              type="button"
+                              onClick={() => restore(task.id)}
+                              className="px-2 py-1 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800"
+                            >
+                              Вернуть
+                            </button>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 ))
               ) : (
-                <li className="text-sm text-slate-500 dark:text-slate-400 px-3">Архив пуст</li>
+                <div className="text-sm text-slate-500 dark:text-slate-400 px-3">Архив пуст</div>
               )}
-            </ul>
+            </div>
           )}
         </div>
         {edit && (


### PR DESCRIPTION
## Summary
- infer task areas from their group assignments so district filtering keeps showing tasks even when labels differ
- memoize the schedule array to avoid unnecessary regrouping churn and satisfy hook dependency linting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e573785b4c832bb475ec3e5072ff50