### PR TITLE
Align monthly payment rollover with due dates

### DIFF
--- a/src/components/GroupsTab.tsx
+++ b/src/components/GroupsTab.tsx
@@ -7,6 +7,7 @@ import ClientForm from "./clients/ClientForm";
 import { fmtMoney, todayISO, uid } from "../state/utils";
 import { commitDBUpdate } from "../state/appState";
 import {
+  DEFAULT_SUBSCRIPTION_PLAN,
   applyPaymentStatusRules,
   getDefaultPayAmount,
   shouldAllowCustomPayAmount,
@@ -100,12 +101,19 @@ export default function GroupsTab({
     if (!area || !group) {
       return [];
     }
+    const matchesPeriod = (client: Client) => {
+      if (period.month == null) {
+        return isClientInPeriod(client, period) || isClientActiveInPeriod(client, period);
+      }
+      return isClientInPeriod(client, period);
+    };
+
     return db.clients.filter(c =>
       c.area === area &&
       c.group === group &&
       !isReserveArea(c.area) &&
       (pay === "all" || c.payStatus === pay) &&
-      (isClientInPeriod(c, period) || isClientActiveInPeriod(c, period)) &&
+      matchesPeriod(c) &&
       (!ui.search || `${c.firstName} ${c.lastName ?? ""} ${c.phone ?? ""}`.toLowerCase().includes(search))
     );
   }, [db.clients, area, group, pay, ui.search, search, period]);
@@ -274,15 +282,83 @@ export default function GroupsTab({
   };
 
   const completePaymentTask = async (client: Client, task: TaskItem) => {
+    const completedAt = todayISO();
     const completed: TaskItem = { ...task, status: "done" };
     const nextTasks = db.tasks.filter(t => t.id !== task.id);
     const nextArchive = [completed, ...db.tasksArchive];
     const payActual = client.payAmount ?? client.payActual;
+
+    const updates: Partial<Client> = {
+      payStatus: "действует",
+      payActual: payActual ?? undefined,
+    };
+
+    const toUTCDate = (value?: string | null): Date | null => {
+      if (!value) {
+        return null;
+      }
+      const parsed = new Date(value);
+      if (Number.isNaN(parsed.getTime())) {
+        return null;
+      }
+      return new Date(Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate()));
+    };
+
+    const addMonths = (date: Date, count: number) => {
+      const year = date.getUTCFullYear();
+      const month = date.getUTCMonth();
+      const day = date.getUTCDate();
+      const targetMonthIndex = month + count;
+      const targetYear = year + Math.floor(targetMonthIndex / 12);
+      const targetMonth = ((targetMonthIndex % 12) + 12) % 12;
+      const maxDay = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+      const clampedDay = Math.min(day, maxDay);
+      return new Date(Date.UTC(targetYear, targetMonth, clampedDay));
+    };
+
+    const completionDate = toUTCDate(completedAt);
+    const currentPayDate = toUTCDate(client.payDate ?? null);
+    const startDate = toUTCDate(client.startDate ?? null);
+    const plan = client.subscriptionPlan ?? DEFAULT_SUBSCRIPTION_PLAN;
+
+    let historyAnchor: Date | null = null;
+    let nextPayDate: Date | null = null;
+
+    if (plan === "half-month") {
+      const base = completionDate ?? currentPayDate ?? startDate;
+      if (base) {
+        const candidate = new Date(base.getTime());
+        candidate.setUTCDate(candidate.getUTCDate() + 14);
+        nextPayDate = candidate;
+      }
+    } else if (plan === "monthly" || plan === "discount") {
+      const base = currentPayDate ?? startDate ?? completionDate;
+      if (base) {
+        historyAnchor = base;
+        nextPayDate = addMonths(base, 1);
+      }
+    } else {
+      const base = completionDate ?? currentPayDate ?? startDate;
+      if (base) {
+        historyAnchor = base;
+        nextPayDate = base;
+      }
+    }
+
+    if (nextPayDate) {
+      updates.payDate = nextPayDate.toISOString();
+    }
+
+    if (historyAnchor) {
+      const historyValue = historyAnchor.toISOString();
+      const existingHistory = Array.isArray(client.payHistory) ? client.payHistory : [];
+      if (!existingHistory.includes(historyValue)) {
+        updates.payHistory = [...existingHistory, historyValue];
+      }
+    }
+
     const nextClients = applyPaymentStatusRules(db.clients, nextTasks, nextArchive, {
-      [client.id]: {
-        payStatus: "действует",
-        payActual: payActual ?? undefined,
-      },
+      [client.id]: updates,
     });
     const next = {
       ...db,
@@ -291,7 +367,7 @@ export default function GroupsTab({
       clients: nextClients,
       changelog: [
         ...db.changelog,
-        { id: uid(), who: "UI", what: `Задача по оплате ${client.firstName} выполнена`, when: todayISO() },
+        { id: uid(), who: "UI", what: `Задача по оплате ${client.firstName} выполнена`, when: completedAt },
       ],
     };
     const result = await commitDBUpdate(next, setDB);

--- a/src/components/__tests__/GroupsTab.test.tsx
+++ b/src/components/__tests__/GroupsTab.test.tsx
@@ -228,8 +228,8 @@ test('filters clients by selected month', async () => {
   fireEvent.change(monthInput, { target: { value: '2' } });
 
   await waitFor(() => {
-    expect(screen.getByRole('row', { name: /Январь/ })).toBeInTheDocument();
     expect(screen.getByRole('row', { name: /Февраль/ })).toBeInTheDocument();
+    expect(screen.queryByRole('row', { name: /Январь/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('row', { name: /Март/ })).not.toBeInTheDocument();
   });
 });
@@ -407,10 +407,125 @@ test('completes payment task and updates client payment data', async () => {
     expect(getDB().tasksArchive).toHaveLength(1);
     expect(getDB().clients[0].payStatus).toBe('действует');
     expect(getDB().clients[0].payActual).toBe(55);
+    expect(getDB().clients[0].payDate).toBe('2024-02-10T00:00:00.000Z');
+    expect(getDB().clients[0].payHistory).toEqual(['2024-01-10T00:00:00.000Z']);
   });
 
-  await waitFor(() => expect(within(tableRow!).queryByRole('button', { name: 'Оплатил' })).not.toBeInTheDocument());
-  expect(within(tableRow!).getByText('действует')).toBeInTheDocument();
+  const januaryRow = await screen.findByText('Должник');
+  const januaryTableRow = januaryRow.closest('tr');
+  expect(januaryTableRow).not.toBeNull();
+  await waitFor(() =>
+    expect(within(januaryTableRow!).queryByRole('button', { name: 'Оплатил' })).not.toBeInTheDocument(),
+  );
+
+  const monthInput = screen.getByLabelText('Фильтр по месяцу');
+  fireEvent.change(monthInput, { target: { value: '2' } });
+
+  await waitFor(() => expect(screen.getByText('Должник')).toBeInTheDocument());
+});
+
+test('monthly subscription completed late keeps previous month visible', async () => {
+  todayISO.mockReturnValue('2024-10-01T00:00:00.000Z');
+
+  const db = makeDB();
+  db.clients = [
+    makeClient({
+      id: 'late',
+      firstName: 'Поздний',
+      payStatus: 'задолженность',
+      subscriptionPlan: 'monthly',
+      payDate: '2024-09-05T00:00:00.000Z',
+    }),
+  ];
+  db.tasks = [
+    {
+      id: 'task-late',
+      title: 'Оплата клиента — Поздний',
+      due: '2024-09-05T00:00:00.000Z',
+      status: 'open',
+      topic: 'оплата',
+      assigneeType: 'client',
+      assigneeId: 'late',
+    },
+  ];
+
+  const { getDB } = renderGroups(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
+
+  const monthInput = screen.getByLabelText('Фильтр по месяцу');
+  fireEvent.change(monthInput, { target: { value: '9' } });
+
+  const row = await screen.findByText('Поздний');
+  const tableRow = row.closest('tr');
+  expect(tableRow).not.toBeNull();
+  const payButton = await within(tableRow!).findByRole('button', { name: 'Оплатил' });
+
+  await userEvent.click(payButton);
+
+  await waitFor(() => {
+    expect(getDB().clients[0].payDate).toBe('2024-10-05T00:00:00.000Z');
+    expect(getDB().clients[0].payHistory).toContain('2024-09-05T00:00:00.000Z');
+  });
+
+  await waitFor(() => expect(screen.getByText('Поздний')).toBeInTheDocument());
+
+  fireEvent.change(monthInput, { target: { value: '10' } });
+  await waitFor(() => expect(screen.getByText('Поздний')).toBeInTheDocument());
+
+  fireEvent.change(monthInput, { target: { value: '9' } });
+  await waitFor(() => expect(screen.getByText('Поздний')).toBeInTheDocument());
+});
+
+test('half-month subscription advances payDate by 14 days on payment completion', async () => {
+  const db = makeDB();
+  db.clients = [
+    makeClient({
+      id: 'half',
+      firstName: 'Пол',
+      payStatus: 'задолженность',
+      subscriptionPlan: 'half-month',
+      payDate: '2024-02-01T00:00:00.000Z',
+      payAmount: 27.5,
+    }),
+  ];
+  db.tasks = [
+    {
+      id: 'task-half',
+      title: 'Оплата клиента — Пол',
+      due: '2024-02-01T00:00:00.000Z',
+      status: 'open',
+      topic: 'оплата',
+      assigneeType: 'client',
+      assigneeId: 'half',
+    },
+  ];
+
+  const { getDB } = renderGroups(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
+
+  const monthInput = screen.getByLabelText('Фильтр по месяцу');
+  fireEvent.change(monthInput, { target: { value: '2' } });
+
+  const row = await screen.findByText('Пол');
+  const tableRow = row.closest('tr');
+  expect(tableRow).not.toBeNull();
+  const payButton = await within(tableRow!).findByRole('button', { name: 'Оплатил' });
+
+  await userEvent.click(payButton);
+
+  await waitFor(() => {
+    expect(getDB().tasks).toHaveLength(0);
+    expect(getDB().tasksArchive).toHaveLength(1);
+    expect(getDB().clients[0].payStatus).toBe('действует');
+    expect(getDB().clients[0].payDate).toBe('2024-01-15T00:00:00.000Z');
+  });
+  await waitFor(() => expect(screen.queryByText('Пол')).not.toBeInTheDocument());
+
+  fireEvent.change(monthInput, { target: { value: '1' } });
+  const januaryRow = await screen.findByText('Пол');
+  const januaryTableRow = januaryRow.closest('tr');
+  expect(januaryTableRow).not.toBeNull();
+  await waitFor(() =>
+    expect(within(januaryTableRow!).queryByRole('button', { name: 'Оплатил' })).not.toBeInTheDocument(),
+  );
 });
 
 test('individual group allows custom payment amount', async () => {

--- a/src/state/period.ts
+++ b/src/state/period.ts
@@ -103,7 +103,13 @@ export function matchesPeriod(value: string | null | undefined, period: PeriodFi
 }
 
 export function isClientInPeriod(client: Client, period: PeriodFilter): boolean {
-  return matchesPeriod(client.payDate ?? client.startDate, period);
+  const checkpoints: (string | null | undefined)[] = [
+    client.payDate,
+    ...(Array.isArray(client.payHistory) ? client.payHistory : []),
+    client.startDate,
+  ];
+
+  return checkpoints.some(value => matchesPeriod(value ?? null, period));
 }
 
 export function isClientActiveInPeriod(client: Client, period: PeriodFilter): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export interface Client {
   payAmount?: number;
   payActual?: number;
   remainingLessons?: number;
+  payHistory?: string[];
   // Автополя (рассчитываются на лету)
 }
 


### PR DESCRIPTION
## Summary
- shift monthly and discount payDate rollover to reuse the previous due date rather than the completion timestamp, preserving the original day
- retain a running pay history for clients so earlier months remain visible in filtered views alongside the new period
- extend GroupsTab tests to cover late monthly payments, pay history expectations, and the updated filtering logic

## Testing
- npm test -- GroupsTab

------
https://chatgpt.com/codex/tasks/task_e_68e5769f013c832b937674c44fe450b5