### PR TITLE
Add reserve action and update payment task deletion in groups tab

### DIFF
--- a/src/components/GroupsTab.tsx
+++ b/src/components/GroupsTab.tsx
@@ -25,7 +25,7 @@ import {
   type PeriodFilter,
 } from "../state/period";
 
-import { isReserveArea } from "../state/areas";
+import { RESERVE_AREA_NAME, isReserveArea } from "../state/areas";
 
 export default function GroupsTab({
   db,
@@ -385,16 +385,50 @@ export default function GroupsTab({
     }
   };
 
-  const removeClient = async (id: string) => {
-    if (!window.confirm("Удалить клиента?")) return;
+  const removePaymentTask = async (client: Client, task: TaskItem) => {
+    if (!window.confirm("Удалить задачу об оплате?")) return;
+
+    const nextTasks = db.tasks.filter(t => t.id !== task.id);
+    const nextArchive = [task, ...db.tasksArchive];
+    const nextClients = applyPaymentStatusRules(db.clients, nextTasks, nextArchive);
+
     const next = {
       ...db,
-      clients: db.clients.filter(c => c.id !== id),
-      changelog: [...db.changelog, { id: uid(), who: "UI", what: `Удалён клиент ${id}`, when: todayISO() }],
+      tasks: nextTasks,
+      tasksArchive: nextArchive,
+      clients: nextClients,
+      changelog: [
+        ...db.changelog,
+        { id: uid(), who: "UI", what: `Удалена задача по оплате ${client.firstName}`, when: todayISO() },
+      ],
     };
+
     const result = await commitDBUpdate(next, setDB);
     if (!result.ok && result.reason === "error") {
-      window.alert("Не удалось удалить клиента. Проверьте доступ к базе данных.");
+      window.alert("Не удалось удалить задачу. Проверьте доступ к базе данных.");
+    }
+  };
+
+  const reserveClient = async (client: Client) => {
+    if (!window.confirm("Переместить клиента в резерв?")) return;
+
+    const reserveGroup = db.settings.groups.includes(RESERVE_AREA_NAME) ? RESERVE_AREA_NAME : client.group;
+    const nextClients = db.clients.map(c =>
+      c.id === client.id ? { ...c, area: RESERVE_AREA_NAME, group: reserveGroup } : c,
+    );
+
+    const next = {
+      ...db,
+      clients: nextClients,
+      changelog: [
+        ...db.changelog,
+        { id: uid(), who: "UI", what: `Клиент ${client.firstName} перемещён в резерв`, when: todayISO() },
+      ],
+    };
+
+    const result = await commitDBUpdate(next, setDB);
+    if (!result.ok && result.reason === "error") {
+      window.alert("Не удалось переместить клиента в резерв. Проверьте доступ к базе данных.");
     }
   };
 
@@ -424,10 +458,11 @@ export default function GroupsTab({
           currency={ui.currency}
           currencyRates={db.settings.currencyRates}
           onEdit={startEdit}
-          onRemove={removeClient}
+          onRemovePaymentTask={removePaymentTask}
           onCreateTask={createPaymentTask}
           openPaymentTasks={openPaymentTasks}
           onCompletePaymentTask={completePaymentTask}
+          onReserve={reserveClient}
           schedule={db.schedule}
           attendance={db.attendance}
           performance={db.performance}

--- a/src/components/__tests__/GroupsTab.test.tsx
+++ b/src/components/__tests__/GroupsTab.test.tsx
@@ -319,16 +319,47 @@ test('update: moving client between groups clears manual-only fields', async () 
   expect(updated?.payAmount).toBe(55);
 });
 
-test('delete: removes client after confirmation', async () => {
+test('delete: removes payment task after confirmation', async () => {
+  const task = {
+    id: 'task-1',
+    title: 'Оплата',
+    due: '2024-02-01T00:00:00.000Z',
+    status: 'open',
+    assigneeType: 'client',
+    assigneeId: 'c1',
+    topic: 'оплата',
+  };
+
   const db = makeDB();
-  db.clients = [makeClient({ id: 'c1', firstName: 'Del' })];
+  db.tasks = [task];
+  db.clients = [makeClient({ id: 'c1', firstName: 'Del', payStatus: 'задолженность' })];
+
   const { getDB } = renderGroups(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
-  await waitFor(() => expect(screen.getByText('Del')).toBeInTheDocument());
-  await userEvent.click(screen.getByText('Удалить'));
+  const row = await screen.findByText('Del');
+  const deleteBtn = within(row.closest('tr')).getByRole('button', { name: 'Удалить задачу' });
+
+  await userEvent.click(deleteBtn);
 
   expect(global.confirm).toHaveBeenCalled();
-  await waitFor(() => expect(screen.queryByText('Del')).not.toBeInTheDocument());
-  expect(getDB().clients.find(c => c.id === 'c1')).toBeUndefined();
+  await waitFor(() => expect(getDB().tasks).toHaveLength(0));
+  expect(getDB().tasksArchive[0]).toMatchObject({ id: 'task-1' });
+  await waitFor(() => expect(within(row.closest('tr')).queryByRole('button', { name: 'Удалить задачу' })).not.toBeInTheDocument());
+});
+
+test('reserve: moves client to reserve area', async () => {
+  const db = makeDB();
+  db.clients = [makeClient({ id: 'c1', firstName: 'Reserve' })];
+
+  const { getDB } = renderGroups(db, makeUI(), { initialArea: 'Area1', initialGroup: 'Group1' });
+  const row = await screen.findByText('Reserve');
+  const reserveBtn = within(row.closest('tr')).getByRole('button', { name: 'Резерв' });
+
+  await userEvent.click(reserveBtn);
+
+  expect(global.confirm).toHaveBeenCalled();
+  await waitFor(() => expect(screen.queryByText('Reserve')).not.toBeInTheDocument());
+  const updated = getDB().clients.find(c => c.id === 'c1');
+  expect(updated?.area).toBe('резерв');
 });
 
 test('creates payment task with client info', async () => {

--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -23,10 +23,12 @@ type Props = {
   currency: Currency;
   currencyRates: Settings["currencyRates"];
   onEdit: (c: Client) => void;
-  onRemove: (id: string) => void;
+  onRemove?: (id: string) => void;
   onCreateTask: (client: Client) => void;
   openPaymentTasks?: Record<string, TaskItem | undefined>;
   onCompletePaymentTask?: (client: Client, task: TaskItem) => void;
+  onRemovePaymentTask?: (client: Client, task: TaskItem) => void;
+  onReserve?: (client: Client) => void;
   schedule: ScheduleSlot[];
   attendance: AttendanceEntry[];
   performance: PerformanceEntry[];
@@ -73,6 +75,8 @@ export default function ClientTable({
   onCreateTask,
   openPaymentTasks,
   onCompletePaymentTask,
+  onRemovePaymentTask,
+  onReserve,
   schedule,
   attendance,
   performance,
@@ -249,49 +253,80 @@ export default function ClientTable({
       headerClassName: "text-right",
       headerAlign: "right",
       cellClassName: "flex justify-end gap-1",
-      renderCell: client => (
-        <>
-          {client.payStatus === "задолженность" &&
-            openPaymentTasks?.[client.id] &&
-            onCompletePaymentTask && (
+      renderCell: client => {
+        const paymentTask = openPaymentTasks?.[client.id];
+        const canCompletePaymentTask =
+          client.payStatus === "задолженность" && paymentTask && onCompletePaymentTask;
+        const canRemovePaymentTask = paymentTask && onRemovePaymentTask;
+
+        return (
+          <>
+            {canCompletePaymentTask && (
               <button
                 onClick={event => {
                   event.stopPropagation();
-                  onCompletePaymentTask(client, openPaymentTasks[client.id]!);
+                  onCompletePaymentTask!(client, paymentTask);
                 }}
                 className="px-2 py-1 text-xs rounded-md border border-emerald-200 text-emerald-600 hover:bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-900/20 dark:hover:bg-emerald-900/30"
               >
                 Оплатил
               </button>
             )}
-          <button
-            onClick={event => {
-              event.stopPropagation();
-              onCreateTask(client);
-            }}
-            className="px-2 py-1 text-xs rounded-md border border-sky-200 text-sky-600 hover:bg-sky-50 dark:border-sky-700 dark:bg-slate-800 dark:hover:bg-slate-700"
-          >
-            Создать задачу
-          </button>
-          <button
-            onClick={event => {
-              event.stopPropagation();
-              onRemove(client.id);
-            }}
-            className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30"
-          >
-            Удалить
-          </button>
-        </>
-      ),
+            <button
+              onClick={event => {
+                event.stopPropagation();
+                onCreateTask(client);
+              }}
+              className="px-2 py-1 text-xs rounded-md border border-sky-200 text-sky-600 hover:bg-sky-50 dark:border-sky-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+            >
+              Создать задачу
+            </button>
+            {canRemovePaymentTask && (
+              <button
+                onClick={event => {
+                  event.stopPropagation();
+                  onRemovePaymentTask(client, paymentTask);
+                }}
+                className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30"
+              >
+                Удалить задачу
+              </button>
+            )}
+            {onReserve && (
+              <button
+                onClick={event => {
+                  event.stopPropagation();
+                  onReserve(client);
+                }}
+                className="px-2 py-1 text-xs rounded-md border border-amber-200 text-amber-600 hover:bg-amber-50 dark:border-amber-700 dark:bg-amber-900/20 dark:hover:bg-amber-900/30"
+              >
+                Резерв
+              </button>
+            )}
+            {onRemove && (
+              <button
+                onClick={event => {
+                  event.stopPropagation();
+                  onRemove(client.id);
+                }}
+                className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30"
+              >
+                Удалить
+              </button>
+            )}
+          </>
+        );
+      },
     },
   ], [
     billingPeriod,
     currency,
     currencyRates,
     onCompletePaymentTask,
+    onRemovePaymentTask,
     onCreateTask,
     onRemove,
+    onReserve,
     openPaymentTasks,
     remainingMap,
   ]);


### PR DESCRIPTION
## Summary
- repurpose the delete action in group client rows to cancel open payment tasks and refresh payment states
- expose a reserve control that moves the client into the reserve area while logging the change
- update the client table API and group tab tests to cover the new actions

## Testing
- npm test -- --runTestsByPath src/components/__tests__/GroupsTab.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e62f7b4a68832ba25b3291e6c466ee