### PR TITLE
Fix delete button crash in groups table

### DIFF
--- a/src/components/clients/ClientTable.tsx
+++ b/src/components/clients/ClientTable.tsx
@@ -303,24 +303,26 @@ export default function ClientTable({
                 Оплатил
               </button>
             )}
-          <button
-            onClick={event => {
-              event.stopPropagation();
-              onCreateTask(client);
-            }}
-            className="px-2 py-1 text-xs rounded-md border border-sky-200 text-sky-600 hover:bg-sky-50 dark:border-sky-700 dark:bg-slate-800 dark:hover:bg-slate-700"
-          >
-            Создать задачу
-          </button>
-          <button
-            onClick={event => {
-              event.stopPropagation();
-              onRemove(client.id);
-            }}
-            className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30"
-          >
-            Удалить
-          </button>
+            <button
+              onClick={event => {
+                event.stopPropagation();
+                onCreateTask(client);
+              }}
+              className="px-2 py-1 text-xs rounded-md border border-sky-200 text-sky-600 hover:bg-sky-50 dark:border-sky-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+            >
+              Создать задачу
+            </button>
+            {onRemove && (
+              <button
+                onClick={event => {
+                  event.stopPropagation();
+                  onRemove(client.id);
+                }}
+                className="px-2 py-1 text-xs rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-700 dark:bg-rose-900/20 dark:hover:bg-rose-900/30"
+              >
+                Удалить
+              </button>
+            )}
           </>
         );
       },


### PR DESCRIPTION
## Summary
- only render the delete button in the client table when a delete handler is provided to prevent runtime errors in the groups view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e64030ad80832bb6f8d73abc75eeb6