### PR TITLE
Add undo button to top bar with session-local DB undo stack

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,8 @@ export default function App() {
   const {
     db,
     setDB,
+    undoDBChange,
+    canUndoDBChange,
     ui,
     setUI,
     roles,
@@ -84,6 +86,8 @@ export default function App() {
         ui={ui}
         setUI={setUI}
         onQuickAdd={onQuickAdd}
+        onUndo={undoDBChange}
+        canUndo={canUndoDBChange}
         currentUser={currentUser}
         onLogout={logoutUser}
         isLocalOnly={isLocalOnly}
@@ -230,4 +234,3 @@ export default function App() {
     </div>
   );
 }
-

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -5,6 +5,8 @@ type TopbarProps = {
   ui: UIState;
   setUI: React.Dispatch<React.SetStateAction<UIState>>;
   onQuickAdd: () => void;
+  onUndo: () => void;
+  canUndo: boolean;
   currentUser: AuthUser;
   onLogout: () => void;
   tabs?: React.ReactNode;
@@ -18,6 +20,8 @@ export default function Topbar({
   ui,
   setUI,
   onQuickAdd,
+  onUndo,
+  canUndo,
   currentUser,
   onLogout,
   tabs,
@@ -85,6 +89,16 @@ export default function Topbar({
                 title="Переключить тему"
               >
                 {ui.theme === "light" ? "🌙" : "☀️"}
+              </button>
+              <button
+                type="button"
+                onClick={onUndo}
+                disabled={!canUndo}
+                className={`${CONTROL_CLASS} inline-flex items-center gap-2 ${canUndo ? "" : "cursor-not-allowed opacity-60"}`}
+                title="Отменить последнее изменение"
+              >
+                <span aria-hidden="true">↩️</span>
+                Отменить
               </button>
               <button
                 type="button"


### PR DESCRIPTION
### Motivation

- Provide a UI control to undo the last in-app data change, with the undo history limited to changes made during the current session (since the page was opened).

### Description

- Added a session undo stack to the app state by wrapping `setDB` in `src/state/appState.ts`, tracking previous `DB` snapshots in `undoStackRef`, and preventing the undo operation from being recorded using `skipHistoryRef`.
- Exposed `undoDBChange` and `canUndoDBChange` from `useAppState` and persist the reverted state to local storage with `writeLocalDB` when undoing.
- Wired the undo action into the UI by adding `onUndo` and `canUndo` props to `Topbar` and rendering an `Отменить` button that is disabled when no undo history exists (`src/components/Topbar.tsx` and `src/App.tsx`).

### Testing

- Ran `npm install` successfully to refresh dependencies.
- Launched the dev server with `npm start`, which started and compiled the app (webpack compiled with ESLint warnings but no blocking errors).
- Attempted an automated Playwright screenshot to validate the top bar, but the Playwright run failed with a Chromium crash (SIGSEGV) so a screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885bb97824832ba8459036dd58df31)