### PR TITLE
Add redo and optimize undo history to track changed top-level DB keys

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,10 @@ export default function App() {
   const {
     db,
     setDB,
+    undoDBChange,
+    canUndoDBChange,
+    redoDBChange,
+    canRedoDBChange,
     ui,
     setUI,
     roles,
@@ -84,6 +88,10 @@ export default function App() {
         ui={ui}
         setUI={setUI}
         onQuickAdd={onQuickAdd}
+        onUndo={undoDBChange}
+        canUndo={canUndoDBChange}
+        onRedo={redoDBChange}
+        canRedo={canRedoDBChange}
         currentUser={currentUser}
         onLogout={logoutUser}
         isLocalOnly={isLocalOnly}
@@ -230,4 +238,3 @@ export default function App() {
     </div>
   );
 }
-

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -5,6 +5,10 @@ type TopbarProps = {
   ui: UIState;
   setUI: React.Dispatch<React.SetStateAction<UIState>>;
   onQuickAdd: () => void;
+  onUndo: () => void;
+  canUndo: boolean;
+  onRedo: () => void;
+  canRedo: boolean;
   currentUser: AuthUser;
   onLogout: () => void;
   tabs?: React.ReactNode;
@@ -18,6 +22,10 @@ export default function Topbar({
   ui,
   setUI,
   onQuickAdd,
+  onUndo,
+  canUndo,
+  onRedo,
+  canRedo,
   currentUser,
   onLogout,
   tabs,
@@ -85,6 +93,26 @@ export default function Topbar({
                 title="Переключить тему"
               >
                 {ui.theme === "light" ? "🌙" : "☀️"}
+              </button>
+              <button
+                type="button"
+                onClick={onUndo}
+                disabled={!canUndo}
+                className={`${CONTROL_CLASS} inline-flex items-center gap-2 ${canUndo ? "" : "cursor-not-allowed opacity-60"}`}
+                title="Отменить последнее изменение"
+              >
+                <span aria-hidden="true">↩️</span>
+                Отменить
+              </button>
+              <button
+                type="button"
+                onClick={onRedo}
+                disabled={!canRedo}
+                className={`${CONTROL_CLASS} inline-flex items-center gap-2 ${canRedo ? "" : "cursor-not-allowed opacity-60"}`}
+                title="Вернуть последнее отмененное изменение"
+              >
+                <span aria-hidden="true">↪️</span>
+                Вернуть
               </button>
               <button
                 type="button"

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -633,6 +633,10 @@ type RegisterPayload = { name: string; login: string; password: string; role: Ro
 export interface AppState {
   db: DB;
   setDB: Dispatch<SetStateAction<DB>>;
+  undoDBChange: () => void;
+  canUndoDBChange: boolean;
+  redoDBChange: () => void;
+  canRedoDBChange: boolean;
   ui: UIState;
   setUI: Dispatch<SetStateAction<UIState>>;
   roles: Role[];
@@ -651,7 +655,74 @@ export interface AppState {
 }
 
 export function useAppState(): AppState {
-  const [db, setDB] = useState<DB>(() => readLocalDB() ?? makeSeedDB());
+  const [db, setDBState] = useState<DB>(() => readLocalDB() ?? makeSeedDB());
+  const undoStackRef = useRef<Array<{ keys: (keyof DB)[]; changes: Partial<DB> }>>([]);
+  const redoStackRef = useRef<Array<{ keys: (keyof DB)[]; changes: Partial<DB> }>>([]);
+  const skipHistoryRef = useRef(false);
+  const [undoCount, setUndoCount] = useState(undoStackRef.current.length);
+  const [redoCount, setRedoCount] = useState(redoStackRef.current.length);
+  const getChangedKeys = useCallback((prev: DB, nextValue: DB) => {
+    return (Object.keys(nextValue) as (keyof DB)[]).filter(key => nextValue[key] !== prev[key]);
+  }, []);
+  const setDB = useCallback<Dispatch<SetStateAction<DB>>>(next => {
+    setDBState(prev => {
+      const nextValue = typeof next === "function" ? (next as (prevState: DB) => DB)(prev) : next;
+      if (skipHistoryRef.current) {
+        skipHistoryRef.current = false;
+        return nextValue;
+      }
+      if (nextValue !== prev) {
+        const keys = getChangedKeys(prev, nextValue);
+        if (keys.length > 0) {
+          const changes: Partial<DB> = {};
+          keys.forEach(key => {
+            changes[key] = prev[key];
+          });
+          undoStackRef.current.push({ keys, changes });
+          redoStackRef.current = [];
+          setUndoCount(undoStackRef.current.length);
+          setRedoCount(0);
+        }
+      }
+      return nextValue;
+    });
+  }, [getChangedKeys]);
+  const undoDBChange = useCallback(() => {
+    const previous = undoStackRef.current.pop();
+    if (!previous) return;
+    skipHistoryRef.current = true;
+    setDBState(prev => {
+      const redoChanges: Partial<DB> = {};
+      previous.keys.forEach(key => {
+        redoChanges[key] = prev[key];
+      });
+      redoStackRef.current.push({ keys: previous.keys, changes: redoChanges });
+      const nextValue = { ...prev, ...previous.changes };
+      writeLocalDB(nextValue);
+      return nextValue;
+    });
+    setUndoCount(undoStackRef.current.length);
+    setRedoCount(redoStackRef.current.length);
+  }, []);
+  const canUndoDBChange = undoCount > 0;
+  const redoDBChange = useCallback(() => {
+    const nextEntry = redoStackRef.current.pop();
+    if (!nextEntry) return;
+    skipHistoryRef.current = true;
+    setDBState(prev => {
+      const undoChanges: Partial<DB> = {};
+      nextEntry.keys.forEach(key => {
+        undoChanges[key] = prev[key];
+      });
+      undoStackRef.current.push({ keys: nextEntry.keys, changes: undoChanges });
+      const nextValue = { ...prev, ...nextEntry.changes };
+      writeLocalDB(nextValue);
+      return nextValue;
+    });
+    setUndoCount(undoStackRef.current.length);
+    setRedoCount(redoStackRef.current.length);
+  }, []);
+  const canRedoDBChange = redoCount > 0;
   const [ui, setUI] = usePersistentState<UIState>(LS_KEYS.ui, defaultUI, 300);
   const [auth, setAuth] = usePersistentState<AuthState>(LS_KEYS.auth, makeDefaultAuthState(), 300);
   const dbRef = useRef(db);
@@ -1226,6 +1297,10 @@ export function useAppState(): AppState {
   return {
     db,
     setDB,
+    undoDBChange,
+    canUndoDBChange,
+    redoDBChange,
+    canRedoDBChange,
     ui,
     setUI,
     roles,
@@ -1243,4 +1318,3 @@ export function useAppState(): AppState {
     addQuickTask,
   };
 }
-


### PR DESCRIPTION
### Motivation
- Improve responsiveness of the in-session undo stack by avoiding full-DB snapshot copies and add an Excel-like “redo” (вернуть) action so users can undo and then redo changes within the session.
- Provide UI controls for both actions in the top bar so the undo/redo workflow is discoverable and usable.

### Description
- Reworked history storage in `src/state/appState.ts` to record only changed top-level `DB` keys and their previous values (`undoStackRef` now stores `{ keys, changes }`) to speed up pushes and reduce memory churn.
- Added a `redoStackRef` and implemented `redoDBChange` and `canRedoDBChange`, cleared the redo stack on new changes, and persisted state changes to local storage with `writeLocalDB` during undo/redo operations.
- Updated `setDB` to compute changed top-level keys via `getChangedKeys` and push a compact history entry, and used `skipHistoryRef` to avoid recording history when applying undo/redo programmatically.
- Wired the new actions into the UI by adding `onRedo`/`canRedo` props to `Topbar` and passing `redoDBChange`/`canRedoDBChange` from `App` so a “Вернуть” button appears next to “Отменить”.

### Testing
- Attempted to run the development server with `npm start`, but it failed with `react-scripts: not found`, so runtime verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885bb97824832ba8459036dd58df31)